### PR TITLE
Fix docs docker image to not use standalone build output

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -56,16 +56,8 @@ ENV NODE_ENV=production
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
-COPY --from=builder /app/public ./public
-
-# Set the correct permission for prerender cache
-RUN mkdir .next
-RUN chown nextjs:nodejs .next
-
-# Automatically leverage output traces to reduce image size
-# https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+# Copy the entire built application
+COPY --from=builder --chown=nextjs:nodejs /app ./
 
 USER nextjs
 
@@ -73,8 +65,7 @@ EXPOSE 3000
 
 ENV PORT=3000
 # set hostname to localhost
-ENV HOSTNAME=0.0.0.0
+ENV HOSTNAME="0.0.0.0"
 
-# server.js is created by next build from the standalone output
-# https://nextjs.org/docs/pages/api-reference/next-config-js/output
-CMD ["node", "server.js"]
+# Start the Next.js application
+CMD ["npm", "start"]


### PR DESCRIPTION
## Background

This PR aims to address another issue with https://github.com/alexanderwanyoike/the0/issues/4 

```
Dockerfile:67
--------------------
  65 |     # Automatically leverage output traces to reduce image size
  66 |     # https://nextjs.org/docs/advanced-features/output-file-tracing
  67 | >>> COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
  68 |     COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
  69 |     
--------------------
```

This issue is was due to the `Dockerfile` being configured to use standalone nextjs as opposed to the minimal build output this was because the site deployment to netlify used the minimal output. Thus the fix is updating the `Dockerfile` to use the `minimal` output

### Changes

- [x] Update `Dockerfile` to support `minimal` nextjs build output (default output)