### PR TITLE
Lock the docker image to 22.19.0

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for production optimization
-FROM node:22-alpine AS base
+FROM node:22.19.0-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps


### PR DESCRIPTION
## Background

This PR is still a continuation to address https://github.com/alexanderwanyoike/the0/issues/4 Still getting some issues to to node:22-alpine updating to node:22.20 as the default image instead we will lock the docker base image to 22.19.0 so as to be consistent. 


## Checklist
- [x] Lock base `the0-docs` docker image to `22.19.0`