### PR TITLE
Fix NATs and format code

### DIFF
--- a/api/src/api-key/__tests__/api-key-e2e.spec.ts
+++ b/api/src/api-key/__tests__/api-key-e2e.spec.ts
@@ -1,25 +1,26 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
-import request from 'supertest';
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication, ValidationPipe } from "@nestjs/common";
+import request from "supertest";
 
-import { AuthGuard } from '@nestjs/passport';
-import { Ok, Failure } from '@/common/result';
-import { ApiKeyRepository } from '@/api-key/api-key.repository';
-import { ApiKeyModule } from '@/api-key/api-key.module';
-import { PassportModule } from '@nestjs/passport';
-import { ConfigModule } from '@nestjs/config';
+import { AuthGuard } from "@nestjs/passport";
+import { Ok, Failure } from "@/common/result";
+import { ApiKeyRepository } from "@/api-key/api-key.repository";
+import { ApiKeyModule } from "@/api-key/api-key.module";
+import { PassportModule } from "@nestjs/passport";
+import { ConfigModule } from "@nestjs/config";
 
-describe('ApiKeyController (e2e)', () => {
+describe("ApiKeyController (e2e)", () => {
   let app: INestApplication;
   let mockGuard: any;
   let mockRepository: jest.Mocked<ApiKeyRepository>;
 
   const mockApiKey = {
-    id: 'test-key-id',
-    userId: 'test-user-123',
-    name: 'Test API Key',
-    keyValue: 'the0_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
-    key: 'the0_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    id: "test-key-id",
+    userId: "test-user-123",
+    name: "Test API Key",
+    keyValue:
+      "the0_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+    key: "the0_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
     isActive: true,
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -44,7 +45,7 @@ describe('ApiKeyController (e2e)', () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [
         ConfigModule.forRoot({ isGlobal: true }),
-        PassportModule.register({ defaultStrategy: 'jwt' }),
+        PassportModule.register({ defaultStrategy: "jwt" }),
         ApiKeyModule,
       ],
     })
@@ -70,10 +71,10 @@ describe('ApiKeyController (e2e)', () => {
     jest.clearAllMocks();
 
     // Mock request user for all tests
-    jest.spyOn(mockGuard, 'canActivate').mockImplementation((context: any) => {
+    jest.spyOn(mockGuard, "canActivate").mockImplementation((context: any) => {
       const httpContext = context.switchToHttp();
       const request = httpContext.getRequest();
-      request.user = { uid: 'test-user-123' }; // Updated to match your structure
+      request.user = { uid: "test-user-123" }; // Updated to match your structure
       return true;
     });
 
@@ -82,64 +83,64 @@ describe('ApiKeyController (e2e)', () => {
     mockRepository.createApiKey.mockResolvedValue(Ok(mockApiKey));
   });
 
-  it('/api-keys (POST) should create API key', async () => {
+  it("/api-keys (POST) should create API key", async () => {
     return request(app.getHttpServer())
-      .post('/api-keys')
-      .send({ name: 'Test API Key' })
+      .post("/api-keys")
+      .send({ name: "Test API Key" })
       .expect(201)
       .expect((res) => {
-        expect(res.body.name).toBe('Test API Key');
+        expect(res.body.name).toBe("Test API Key");
         expect(res.body.key).toMatch(/^the0_[a-f0-9]{64}$/);
         expect(res.body.isActive).toBe(true);
         expect(mockRepository.createApiKey).toHaveBeenCalledWith(
-          'test-user-123',
-          'Test API Key',
+          "test-user-123",
+          "Test API Key",
         );
       });
   });
 
-  it('/api-keys (POST) should fail with duplicate name', async () => {
+  it("/api-keys (POST) should fail with duplicate name", async () => {
     // Mock existing API key with same name
     mockRepository.findAll.mockResolvedValue(Ok([mockApiKey]));
 
     return request(app.getHttpServer())
-      .post('/api-keys')
-      .send({ name: 'Test API Key' })
+      .post("/api-keys")
+      .send({ name: "Test API Key" })
       .expect(400)
       .expect((res) => {
         expect(res.body.message).toBe(
-          'An API key with this name already exists',
+          "An API key with this name already exists",
         );
       });
   });
 
-  it('/api-keys (POST) should validate input', async () => {
+  it("/api-keys (POST) should validate input", async () => {
     return request(app.getHttpServer())
-      .post('/api-keys')
-      .send({ name: '' }) // Invalid empty name
+      .post("/api-keys")
+      .send({ name: "" }) // Invalid empty name
       .expect(400);
   });
 
-  it('/api-keys (GET) should return user API keys', async () => {
+  it("/api-keys (GET) should return user API keys", async () => {
     mockRepository.findAll.mockResolvedValue(Ok([mockApiKey]));
 
     return request(app.getHttpServer())
-      .get('/api-keys')
+      .get("/api-keys")
       .expect(200)
       .expect((res) => {
         expect(Array.isArray(res.body)).toBe(true);
         expect(res.body).toHaveLength(1);
-        expect(res.body[0]).toHaveProperty('key');
+        expect(res.body[0]).toHaveProperty("key");
         expect(res.body[0].key).toMatch(/^the0_[a-f0-9]{64}$/);
-        expect(mockRepository.findAll).toHaveBeenCalledWith('test-user-123');
+        expect(mockRepository.findAll).toHaveBeenCalledWith("test-user-123");
       });
   });
 
-  it('/api-keys (GET) should handle empty result', async () => {
+  it("/api-keys (GET) should handle empty result", async () => {
     mockRepository.findAll.mockResolvedValue(Ok([]));
 
     return request(app.getHttpServer())
-      .get('/api-keys')
+      .get("/api-keys")
       .expect(200)
       .expect((res) => {
         expect(Array.isArray(res.body)).toBe(true);
@@ -147,89 +148,87 @@ describe('ApiKeyController (e2e)', () => {
       });
   });
 
-  it('/api-keys/:id (GET) should return specific API key', async () => {
+  it("/api-keys/:id (GET) should return specific API key", async () => {
     mockRepository.findOne.mockResolvedValue(Ok(mockApiKey));
 
     return request(app.getHttpServer())
-      .get('/api-keys/test-key-id')
+      .get("/api-keys/test-key-id")
       .expect(200)
       .expect((res) => {
-        expect(res.body.id).toBe('test-key-id');
-        expect(res.body).toHaveProperty('key');
+        expect(res.body.id).toBe("test-key-id");
+        expect(res.body).toHaveProperty("key");
         expect(res.body.key).toMatch(/^the0_[a-f0-9]{64}$/);
         expect(mockRepository.findOne).toHaveBeenCalledWith(
-          'test-user-123',
-          'test-key-id',
+          "test-user-123",
+          "test-key-id",
         );
       });
   });
 
-  it('/api-keys/:id (GET) should return 404 for non-existent key', async () => {
-    mockRepository.findOne.mockResolvedValue(Failure('Not found'));
+  it("/api-keys/:id (GET) should return 404 for non-existent key", async () => {
+    mockRepository.findOne.mockResolvedValue(Failure("Not found"));
 
     return request(app.getHttpServer())
-      .get('/api-keys/non-existent-id')
+      .get("/api-keys/non-existent-id")
       .expect(404)
       .expect((res) => {
-        expect(res.body.message).toBe('Not found');
+        expect(res.body.message).toBe("Not found");
       });
   });
 
-  it('/api-keys/:id (DELETE) should delete API key', async () => {
+  it("/api-keys/:id (DELETE) should delete API key", async () => {
     mockRepository.deleteApiKey.mockResolvedValue(Ok(null));
 
     return request(app.getHttpServer())
-      .delete('/api-keys/test-key-id')
+      .delete("/api-keys/test-key-id")
       .expect(200)
       .expect((res) => {
-        expect(res.body.message).toBe('API key deleted successfully');
+        expect(res.body.message).toBe("API key deleted successfully");
         expect(mockRepository.deleteApiKey).toHaveBeenCalledWith(
-          'test-user-123',
-          'test-key-id',
+          "test-user-123",
+          "test-key-id",
         );
       });
   });
 
-  it('/api-keys/:id (DELETE) should return 404 for non-existent key', async () => {
-    mockRepository.deleteApiKey.mockResolvedValue(
-      Failure('API key not found'),
-    );
+  it("/api-keys/:id (DELETE) should return 404 for non-existent key", async () => {
+    mockRepository.deleteApiKey.mockResolvedValue(Failure("API key not found"));
 
     return request(app.getHttpServer())
-      .delete('/api-keys/non-existent-id')
+      .delete("/api-keys/non-existent-id")
       .expect(404)
       .expect((res) => {
-        expect(res.body.message).toBe('API key not found');
+        expect(res.body.message).toBe("API key not found");
       });
   });
 
-  it('/api-keys/stats/summary (GET) should return statistics', async () => {
-    const apiKeys = [mockApiKey, { ...mockApiKey, id: 'test-key-id-2' }];
+  it("/api-keys/stats/summary (GET) should return statistics", async () => {
+    const apiKeys = [mockApiKey, { ...mockApiKey, id: "test-key-id-2" }];
     mockRepository.findAll.mockResolvedValue(Ok(apiKeys));
 
     return request(app.getHttpServer())
-      .get('/api-keys/stats/summary')
+      .get("/api-keys/stats/summary")
       .expect(200)
       .expect((res) => {
-        expect(res.body).toHaveProperty('total');
-        expect(res.body).toHaveProperty('active');
-        expect(typeof res.body.total).toBe('number');
-        expect(typeof res.body.active).toBe('number');
+        expect(res.body).toHaveProperty("total");
+        expect(res.body).toHaveProperty("active");
+        expect(typeof res.body.total).toBe("number");
+        expect(typeof res.body.active).toBe("number");
         expect(res.body.total).toBe(2);
         expect(res.body.active).toBe(2);
       });
   });
 
-  it('should handle repository errors gracefully', async () => {
+  it("should handle repository errors gracefully", async () => {
     mockRepository.findAll.mockResolvedValue(
-      Failure('Database connection error'),
+      Failure("Database connection error"),
     );
 
     return request(app.getHttpServer())
-      .get('/api-keys')
+      .get("/api-keys")
       .expect(500)
       .expect((res) => {
-        expect(res.body.message).toBe('Database connection error');
+        expect(res.body.message).toBe("Database connection error");
       });
   });
 
@@ -237,45 +236,45 @@ describe('ApiKeyController (e2e)', () => {
     await app.close();
   });
 
-  it('/api-keys (POST) should validate input', async () => {
+  it("/api-keys (POST) should validate input", async () => {
     // Test empty name
     await request(app.getHttpServer())
-      .post('/api-keys')
-      .send({ name: '' })
+      .post("/api-keys")
+      .send({ name: "" })
       .expect(400)
       .expect((res) => {
         expect(res.body.message).toContain(
-          'name must be longer than or equal to 3 characters',
+          "name must be longer than or equal to 3 characters",
         );
       });
 
     // Test missing name
     await request(app.getHttpServer())
-      .post('/api-keys')
+      .post("/api-keys")
       .send({})
       .expect(400)
       .expect((res) => {
-        expect(res.body.message).toContain('name should not be empty');
+        expect(res.body.message).toContain("name should not be empty");
       });
 
     // Test name too long
     await request(app.getHttpServer())
-      .post('/api-keys')
-      .send({ name: 'a'.repeat(51) }) // 51 characters (max is 50)
+      .post("/api-keys")
+      .send({ name: "a".repeat(51) }) // 51 characters (max is 50)
       .expect(400)
       .expect((res) => {
         expect(res.body.message).toContain(
-          'name must be shorter than or equal to 50 characters',
+          "name must be shorter than or equal to 50 characters",
         );
       });
 
     // Test non-string name
     await request(app.getHttpServer())
-      .post('/api-keys')
+      .post("/api-keys")
       .send({ name: 123 })
       .expect(400)
       .expect((res) => {
-        expect(res.body.message).toContain('name must be a string');
+        expect(res.body.message).toContain("name must be a string");
       });
   });
 });

--- a/api/src/api-key/__tests__/api-key.controller.spec.ts
+++ b/api/src/api-key/__tests__/api-key.controller.spec.ts
@@ -1,24 +1,24 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { HttpException, HttpStatus } from '@nestjs/common';
-import { ApiKeyController } from '@/api-key/api-key.controller';
-import { ApiKeyService } from '@/api-key/api-key.service';
-import { CreateApiKeyDto } from '@/api-key/dto/create-api-key.dto';
-import { Ok, Failure } from '@/common/result';
+import { Test, TestingModule } from "@nestjs/testing";
+import { HttpException, HttpStatus } from "@nestjs/common";
+import { ApiKeyController } from "@/api-key/api-key.controller";
+import { ApiKeyService } from "@/api-key/api-key.service";
+import { CreateApiKeyDto } from "@/api-key/dto/create-api-key.dto";
+import { Ok, Failure } from "@/common/result";
 
-describe('ApiKeyController', () => {
+describe("ApiKeyController", () => {
   let controller: ApiKeyController;
   let service: jest.Mocked<ApiKeyService>;
 
   const mockRequest = {
-    user: { uid: 'user-123' },
+    user: { uid: "user-123" },
     headers: {},
   };
 
   const mockApiKeyResponse = {
-    id: 'test-id',
-    userId: 'user-123',
-    name: 'Test API Key',
-    key: 'the0_abcdef123456789abcdef123456789abcdef123456789abcdef123456789',
+    id: "test-id",
+    userId: "user-123",
+    name: "Test API Key",
+    key: "the0_abcdef123456789abcdef123456789abcdef123456789abcdef123456789",
     isActive: true,
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -47,12 +47,12 @@ describe('ApiKeyController', () => {
     service = module.get(ApiKeyService);
   });
 
-  describe('createApiKey', () => {
-    it('should create API key successfully', async () => {
-      const createDto: CreateApiKeyDto = { name: 'Test API Key' };
+  describe("createApiKey", () => {
+    it("should create API key successfully", async () => {
+      const createDto: CreateApiKeyDto = { name: "Test API Key" };
       const createdResponse = {
         ...mockApiKeyResponse,
-        key: 'the0_abcdef123456789',
+        key: "the0_abcdef123456789",
       };
 
       service.createApiKey.mockResolvedValue(Ok(createdResponse));
@@ -60,13 +60,13 @@ describe('ApiKeyController', () => {
       const result = await controller.createApiKey(mockRequest, createDto);
 
       expect(result).toEqual(createdResponse);
-      expect(service.createApiKey).toHaveBeenCalledWith('user-123', createDto);
+      expect(service.createApiKey).toHaveBeenCalledWith("user-123", createDto);
     });
 
-    it('should throw BadRequestException on service failure', async () => {
-      const createDto: CreateApiKeyDto = { name: 'Test API Key' };
+    it("should throw BadRequestException on service failure", async () => {
+      const createDto: CreateApiKeyDto = { name: "Test API Key" };
       service.createApiKey.mockResolvedValue(
-        Failure('API key name already exists'),
+        Failure("API key name already exists"),
       );
 
       await expect(
@@ -75,8 +75,8 @@ describe('ApiKeyController', () => {
         new HttpException(
           {
             statusCode: HttpStatus.BAD_REQUEST,
-            message: 'API key name already exists',
-            error: 'Bad Request',
+            message: "API key name already exists",
+            error: "Bad Request",
           },
           HttpStatus.BAD_REQUEST,
         ),
@@ -84,25 +84,25 @@ describe('ApiKeyController', () => {
     });
   });
 
-  describe('getApiKeys', () => {
-    it('should return user API keys', async () => {
+  describe("getApiKeys", () => {
+    it("should return user API keys", async () => {
       service.getUserApiKeys.mockResolvedValue(Ok([mockApiKeyResponse]));
 
       const result = await controller.getApiKeys(mockRequest);
 
       expect(result).toEqual([mockApiKeyResponse]);
-      expect(service.getUserApiKeys).toHaveBeenCalledWith('user-123');
+      expect(service.getUserApiKeys).toHaveBeenCalledWith("user-123");
     });
 
-    it('should throw InternalServerErrorException on service failure', async () => {
-      service.getUserApiKeys.mockResolvedValue(Failure('Database error'));
+    it("should throw InternalServerErrorException on service failure", async () => {
+      service.getUserApiKeys.mockResolvedValue(Failure("Database error"));
 
       await expect(controller.getApiKeys(mockRequest)).rejects.toThrow(
         new HttpException(
           {
             statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-            message: 'Database error',
-            error: 'Internal Server Error',
+            message: "Database error",
+            error: "Internal Server Error",
           },
           HttpStatus.INTERNAL_SERVER_ERROR,
         ),
@@ -110,27 +110,27 @@ describe('ApiKeyController', () => {
     });
   });
 
-  describe('getApiKeyById', () => {
-    it('should return specific API key', async () => {
+  describe("getApiKeyById", () => {
+    it("should return specific API key", async () => {
       service.getApiKeyById.mockResolvedValue(Ok(mockApiKeyResponse));
 
-      const result = await controller.getApiKeyById(mockRequest, 'test-id');
+      const result = await controller.getApiKeyById(mockRequest, "test-id");
 
       expect(result).toEqual(mockApiKeyResponse);
-      expect(service.getApiKeyById).toHaveBeenCalledWith('user-123', 'test-id');
+      expect(service.getApiKeyById).toHaveBeenCalledWith("user-123", "test-id");
     });
 
-    it('should throw NotFoundException when API key not found', async () => {
-      service.getApiKeyById.mockResolvedValue(Failure('Not found'));
+    it("should throw NotFoundException when API key not found", async () => {
+      service.getApiKeyById.mockResolvedValue(Failure("Not found"));
 
       await expect(
-        controller.getApiKeyById(mockRequest, 'test-id'),
+        controller.getApiKeyById(mockRequest, "test-id"),
       ).rejects.toThrow(
         new HttpException(
           {
             statusCode: HttpStatus.NOT_FOUND,
-            message: 'Not found',
-            error: 'Not Found',
+            message: "Not found",
+            error: "Not Found",
           },
           HttpStatus.NOT_FOUND,
         ),
@@ -138,27 +138,27 @@ describe('ApiKeyController', () => {
     });
   });
 
-  describe('deleteApiKey', () => {
-    it('should delete API key successfully', async () => {
+  describe("deleteApiKey", () => {
+    it("should delete API key successfully", async () => {
       service.deleteApiKey.mockResolvedValue(Ok(null));
 
-      const result = await controller.deleteApiKey(mockRequest, 'test-id');
+      const result = await controller.deleteApiKey(mockRequest, "test-id");
 
-      expect(result).toEqual({ message: 'API key deleted successfully' });
-      expect(service.deleteApiKey).toHaveBeenCalledWith('user-123', 'test-id');
+      expect(result).toEqual({ message: "API key deleted successfully" });
+      expect(service.deleteApiKey).toHaveBeenCalledWith("user-123", "test-id");
     });
 
-    it('should throw NotFoundException when API key not found', async () => {
-      service.deleteApiKey.mockResolvedValue(Failure('API key not found'));
+    it("should throw NotFoundException when API key not found", async () => {
+      service.deleteApiKey.mockResolvedValue(Failure("API key not found"));
 
       await expect(
-        controller.deleteApiKey(mockRequest, 'test-id'),
+        controller.deleteApiKey(mockRequest, "test-id"),
       ).rejects.toThrow(
         new HttpException(
           {
             statusCode: HttpStatus.NOT_FOUND,
-            message: 'API key not found',
-            error: 'Not Found',
+            message: "API key not found",
+            error: "Not Found",
           },
           HttpStatus.NOT_FOUND,
         ),
@@ -166,26 +166,26 @@ describe('ApiKeyController', () => {
     });
   });
 
-  describe('getApiKeyStats', () => {
-    it('should return API key statistics', async () => {
+  describe("getApiKeyStats", () => {
+    it("should return API key statistics", async () => {
       const stats = { total: 2, active: 2 };
       service.getApiKeyStats.mockResolvedValue(Ok(stats));
 
       const result = await controller.getApiKeyStats(mockRequest);
 
       expect(result).toEqual(stats);
-      expect(service.getApiKeyStats).toHaveBeenCalledWith('user-123');
+      expect(service.getApiKeyStats).toHaveBeenCalledWith("user-123");
     });
 
-    it('should throw InternalServerErrorException on service failure', async () => {
-      service.getApiKeyStats.mockResolvedValue(Failure('Database error'));
+    it("should throw InternalServerErrorException on service failure", async () => {
+      service.getApiKeyStats.mockResolvedValue(Failure("Database error"));
 
       await expect(controller.getApiKeyStats(mockRequest)).rejects.toThrow(
         new HttpException(
           {
             statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-            message: 'Database error',
-            error: 'Internal Server Error',
+            message: "Database error",
+            error: "Internal Server Error",
           },
           HttpStatus.INTERNAL_SERVER_ERROR,
         ),

--- a/api/src/api-key/__tests__/api-key.repository.spec.ts
+++ b/api/src/api-key/__tests__/api-key.repository.spec.ts
@@ -1,32 +1,38 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { ApiKeyRepository } from '../api-key.repository';
-import { Ok, Failure } from '../../common/result';
+import { Test, TestingModule } from "@nestjs/testing";
+import { ApiKeyRepository } from "../api-key.repository";
+import { Ok, Failure } from "../../common/result";
 
-jest.mock('../../database/connection', () => ({
+jest.mock("../../database/connection", () => ({
   getDatabase: jest.fn().mockReturnValue({
     select: jest.fn().mockReturnValue({
       from: jest.fn().mockReturnValue({
-        where: jest.fn().mockReturnValue([{
-          id: 'test-id',
-          userId: 'user-123',
-          name: 'Test Key',
-          keyValue: 'the0_abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234',
-          isActive: true,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        }]),
+        where: jest.fn().mockReturnValue([
+          {
+            id: "test-id",
+            userId: "user-123",
+            name: "Test Key",
+            keyValue:
+              "the0_abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
+            isActive: true,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ]),
       }),
     }),
     insert: jest.fn().mockReturnValue({
       values: jest.fn().mockReturnValue({
-        returning: jest.fn().mockReturnValue([{
-          id: 'test-id',
-          name: 'Test Key',
-          keyValue: 'the0_abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234',
-          isActive: true,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        }]),
+        returning: jest.fn().mockReturnValue([
+          {
+            id: "test-id",
+            name: "Test Key",
+            keyValue:
+              "the0_abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
+            isActive: true,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ]),
       }),
     }),
     update: jest.fn().mockReturnValue({
@@ -40,23 +46,23 @@ jest.mock('../../database/connection', () => ({
   }),
   getTables: jest.fn().mockReturnValue({
     apiKeys: {
-      id: 'id',
-      userId: 'userId',
-      name: 'name',
-      keyValue: 'keyValue',
-      isActive: 'isActive',
-      lastUsedAt: 'lastUsedAt',
-      createdAt: 'createdAt',
-      updatedAt: 'updatedAt',
+      id: "id",
+      userId: "userId",
+      name: "name",
+      keyValue: "keyValue",
+      isActive: "isActive",
+      lastUsedAt: "lastUsedAt",
+      createdAt: "createdAt",
+      updatedAt: "updatedAt",
     },
   }),
 }));
 
-jest.mock('crypto', () => ({
-  randomBytes: jest.fn().mockReturnValue(Buffer.from('abcd1234'.repeat(8))),
+jest.mock("crypto", () => ({
+  randomBytes: jest.fn().mockReturnValue(Buffer.from("abcd1234".repeat(8))),
 }));
 
-describe('ApiKeyRepository', () => {
+describe("ApiKeyRepository", () => {
   let repository: ApiKeyRepository;
 
   beforeEach(async () => {
@@ -71,39 +77,41 @@ describe('ApiKeyRepository', () => {
     jest.clearAllMocks();
   });
 
-  it('should be defined', () => {
+  it("should be defined", () => {
     expect(repository).toBeDefined();
   });
 
-  describe('createApiKey', () => {
-    it('should create API key successfully', async () => {
-      const result = await repository.createApiKey('user-123', 'Test Key');
+  describe("createApiKey", () => {
+    it("should create API key successfully", async () => {
+      const result = await repository.createApiKey("user-123", "Test Key");
 
       expect(result.success).toBe(true);
-      expect(result.data.name).toBe('Test Key');
+      expect(result.data.name).toBe("Test Key");
     });
   });
 
-  describe('findByKey', () => {
-    it('should find API key by key value', async () => {
-      const result = await repository.findByKey('the0_abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234');
+  describe("findByKey", () => {
+    it("should find API key by key value", async () => {
+      const result = await repository.findByKey(
+        "the0_abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
+      );
 
       expect(result.success).toBe(true);
-      expect(result.data.id).toBe('test-id');
+      expect(result.data.id).toBe("test-id");
     });
   });
 
-  describe('updateLastUsed', () => {
-    it('should update last used timestamp', async () => {
-      const result = await repository.updateLastUsed('test-id');
+  describe("updateLastUsed", () => {
+    it("should update last used timestamp", async () => {
+      const result = await repository.updateLastUsed("test-id");
 
       expect(result.success).toBe(true);
     });
   });
 
-  describe('deleteApiKey', () => {
-    it('should delete API key successfully', async () => {
-      const result = await repository.deleteApiKey('user-123', 'test-id');
+  describe("deleteApiKey", () => {
+    it("should delete API key successfully", async () => {
+      const result = await repository.deleteApiKey("user-123", "test-id");
 
       expect(result.success).toBe(true);
     });

--- a/api/src/api-key/__tests__/api-key.service.spec.ts
+++ b/api/src/api-key/__tests__/api-key.service.spec.ts
@@ -1,18 +1,18 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { ApiKeyService } from '@/api-key/api-key.service';
-import { ApiKeyRepository } from '@/api-key/api-key.repository';
-import { CreateApiKeyDto } from '../dto/create-api-key.dto';
-import { Ok, Failure } from '@/common/result';
+import { Test, TestingModule } from "@nestjs/testing";
+import { ApiKeyService } from "@/api-key/api-key.service";
+import { ApiKeyRepository } from "@/api-key/api-key.repository";
+import { CreateApiKeyDto } from "../dto/create-api-key.dto";
+import { Ok, Failure } from "@/common/result";
 
-describe('ApiKeyService', () => {
+describe("ApiKeyService", () => {
   let service: ApiKeyService;
   let repository: jest.Mocked<ApiKeyRepository>;
 
   const mockApiKey = {
-    id: 'test-id',
-    userId: 'user-123',
-    name: 'Test API Key',
-    key: 'the0_abcdef123456789abcdef123456789abcdef123456789abcdef123456789',
+    id: "test-id",
+    userId: "user-123",
+    name: "Test API Key",
+    key: "the0_abcdef123456789abcdef123456789abcdef123456789abcdef123456789",
     isActive: true,
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -42,140 +42,144 @@ describe('ApiKeyService', () => {
     repository = module.get(ApiKeyRepository);
   });
 
-  describe('createApiKey', () => {
-    it('should create an API key successfully', async () => {
-      const createDto: CreateApiKeyDto = { name: 'Test API Key' };
+  describe("createApiKey", () => {
+    it("should create an API key successfully", async () => {
+      const createDto: CreateApiKeyDto = { name: "Test API Key" };
       repository.findAll.mockResolvedValue(Ok([]));
       repository.createApiKey.mockResolvedValue(Ok(mockApiKey));
 
-      const result = await service.createApiKey('user-123', createDto);
+      const result = await service.createApiKey("user-123", createDto);
 
       expect(result.success).toBe(true);
-      expect(result.data.name).toBe('Test API Key');
-      expect(result.data.key).toBe('the0_abcdef123456789abcdef123456789abcdef123456789abcdef123456789');
+      expect(result.data.name).toBe("Test API Key");
+      expect(result.data.key).toBe(
+        "the0_abcdef123456789abcdef123456789abcdef123456789abcdef123456789",
+      );
       expect(repository.createApiKey).toHaveBeenCalledWith(
-        'user-123',
-        'Test API Key',
+        "user-123",
+        "Test API Key",
       );
     });
 
-    it('should fail if API key name already exists', async () => {
-      const createDto: CreateApiKeyDto = { name: 'Test API Key' };
+    it("should fail if API key name already exists", async () => {
+      const createDto: CreateApiKeyDto = { name: "Test API Key" };
       repository.findAll.mockResolvedValue(Ok([mockApiKey]));
 
-      const result = await service.createApiKey('user-123', createDto);
+      const result = await service.createApiKey("user-123", createDto);
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('An API key with this name already exists');
+      expect(result.error).toBe("An API key with this name already exists");
     });
 
-    it('should handle repository errors', async () => {
-      const createDto: CreateApiKeyDto = { name: 'Test API Key' };
-      repository.findAll.mockResolvedValue(Failure('Database error'));
+    it("should handle repository errors", async () => {
+      const createDto: CreateApiKeyDto = { name: "Test API Key" };
+      repository.findAll.mockResolvedValue(Failure("Database error"));
 
-      const result = await service.createApiKey('user-123', createDto);
+      const result = await service.createApiKey("user-123", createDto);
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Database error');
+      expect(result.error).toBe("Database error");
     });
   });
 
-  describe('getUserApiKeys', () => {
-    it('should return user API keys with full key', async () => {
+  describe("getUserApiKeys", () => {
+    it("should return user API keys with full key", async () => {
       repository.findAll.mockResolvedValue(Ok([mockApiKey]));
 
-      const result = await service.getUserApiKeys('user-123');
+      const result = await service.getUserApiKeys("user-123");
 
       expect(result.success).toBe(true);
       expect(result.data).toHaveLength(1);
-      expect(result.data[0].key).toBe('the0_abcdef123456789abcdef123456789abcdef123456789abcdef123456789');
+      expect(result.data[0].key).toBe(
+        "the0_abcdef123456789abcdef123456789abcdef123456789abcdef123456789",
+      );
     });
 
-    it('should handle repository errors', async () => {
-      repository.findAll.mockResolvedValue(Failure('Database error'));
+    it("should handle repository errors", async () => {
+      repository.findAll.mockResolvedValue(Failure("Database error"));
 
-      const result = await service.getUserApiKeys('user-123');
+      const result = await service.getUserApiKeys("user-123");
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Database error');
+      expect(result.error).toBe("Database error");
     });
   });
 
-  describe('getApiKeyById', () => {
-    it('should return specific API key with full key', async () => {
+  describe("getApiKeyById", () => {
+    it("should return specific API key with full key", async () => {
       repository.findOne.mockResolvedValue(Ok(mockApiKey));
 
-      const result = await service.getApiKeyById('user-123', 'test-id');
+      const result = await service.getApiKeyById("user-123", "test-id");
 
       expect(result.success).toBe(true);
-      expect(result.data.key).toBe('the0_abcdef123456789abcdef123456789abcdef123456789abcdef123456789');
+      expect(result.data.key).toBe(
+        "the0_abcdef123456789abcdef123456789abcdef123456789abcdef123456789",
+      );
     });
 
-    it('should handle not found', async () => {
-      repository.findOne.mockResolvedValue(Failure('Not found'));
+    it("should handle not found", async () => {
+      repository.findOne.mockResolvedValue(Failure("Not found"));
 
-      const result = await service.getApiKeyById('user-123', 'test-id');
+      const result = await service.getApiKeyById("user-123", "test-id");
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Not found');
+      expect(result.error).toBe("Not found");
     });
   });
 
-  describe('deleteApiKey', () => {
-    it('should delete API key successfully', async () => {
+  describe("deleteApiKey", () => {
+    it("should delete API key successfully", async () => {
       repository.deleteApiKey.mockResolvedValue(Ok(null));
 
-      const result = await service.deleteApiKey('user-123', 'test-id');
+      const result = await service.deleteApiKey("user-123", "test-id");
 
       expect(result.success).toBe(true);
       expect(repository.deleteApiKey).toHaveBeenCalledWith(
-        'user-123',
-        'test-id',
+        "user-123",
+        "test-id",
       );
     });
 
-    it('should handle repository errors', async () => {
-      repository.deleteApiKey.mockResolvedValue(
-        Failure('API key not found'),
-      );
+    it("should handle repository errors", async () => {
+      repository.deleteApiKey.mockResolvedValue(Failure("API key not found"));
 
-      const result = await service.deleteApiKey('user-123', 'test-id');
+      const result = await service.deleteApiKey("user-123", "test-id");
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('API key not found');
+      expect(result.error).toBe("API key not found");
     });
   });
 
-  describe('validateApiKey', () => {
-    it('should validate API key and update last used', async () => {
+  describe("validateApiKey", () => {
+    it("should validate API key and update last used", async () => {
       repository.findByKey.mockResolvedValue(Ok(mockApiKey));
       repository.updateLastUsed.mockResolvedValue(Ok(null));
 
-      const result = await service.validateApiKey('the0_abcdef123456789');
+      const result = await service.validateApiKey("the0_abcdef123456789");
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual(mockApiKey);
-      expect(repository.updateLastUsed).toHaveBeenCalledWith('test-id');
+      expect(repository.updateLastUsed).toHaveBeenCalledWith("test-id");
     });
 
-    it('should handle invalid API key', async () => {
+    it("should handle invalid API key", async () => {
       repository.findByKey.mockResolvedValue(
-        Failure('API key not found or inactive'),
+        Failure("API key not found or inactive"),
       );
 
-      const result = await service.validateApiKey('invalid-key');
+      const result = await service.validateApiKey("invalid-key");
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('API key not found or inactive');
+      expect(result.error).toBe("API key not found or inactive");
     });
   });
 
-  describe('getApiKeyStats', () => {
-    it('should return API key statistics', async () => {
-      const apiKeys = [mockApiKey, { ...mockApiKey, id: 'test-id-2' }];
+  describe("getApiKeyStats", () => {
+    it("should return API key statistics", async () => {
+      const apiKeys = [mockApiKey, { ...mockApiKey, id: "test-id-2" }];
       repository.findAll.mockResolvedValue(Ok(apiKeys));
 
-      const result = await service.getApiKeyStats('user-123');
+      const result = await service.getApiKeyStats("user-123");
 
       expect(result.success).toBe(true);
       expect(result.data.total).toBe(2);

--- a/api/src/api-key/api-key.controller.ts
+++ b/api/src/api-key/api-key.controller.ts
@@ -9,14 +9,14 @@ import {
   HttpException,
   UseGuards,
   Request,
-} from '@nestjs/common';
-import { ApiKeyService } from '@/api-key/api-key.service';
-import { CreateApiKeyDto } from '@/api-key/dto/create-api-key.dto';
-import { AuthGuard } from '@nestjs/passport';
-import { ApiKeyCreatedResponseDto } from '@/api-key/dto/api-key-created-response.dto';
-import { ApiKeyResponseDto } from '@/api-key/dto/api-key-response.dto'; // Assuming you have JWT auth
+} from "@nestjs/common";
+import { ApiKeyService } from "@/api-key/api-key.service";
+import { CreateApiKeyDto } from "@/api-key/dto/create-api-key.dto";
+import { AuthGuard } from "@nestjs/passport";
+import { ApiKeyCreatedResponseDto } from "@/api-key/dto/api-key-created-response.dto";
+import { ApiKeyResponseDto } from "@/api-key/dto/api-key-response.dto"; // Assuming you have JWT auth
 
-@Controller('api-keys')
+@Controller("api-keys")
 @UseGuards(AuthGuard())
 export class ApiKeyController {
   constructor(private readonly apiKeyService: ApiKeyService) {}
@@ -42,7 +42,7 @@ export class ApiKeyController {
         {
           statusCode: HttpStatus.BAD_REQUEST,
           message: result.error,
-          error: 'Bad Request',
+          error: "Bad Request",
         },
         HttpStatus.BAD_REQUEST,
       );
@@ -57,15 +57,18 @@ export class ApiKeyController {
    */
   @Get()
   async getApiKeys(@Request() req: any): Promise<ApiKeyResponseDto[]> {
-    console.log('🔑 API Key Controller GET /api-keys called');
-    console.log('🔑 Auth header:', req.headers.authorization ? 'Present' : 'Missing');
-    console.log('🔑 req.user:', JSON.stringify(req.user, null, 2));
-    
+    console.log("🔑 API Key Controller GET /api-keys called");
+    console.log(
+      "🔑 Auth header:",
+      req.headers.authorization ? "Present" : "Missing",
+    );
+    console.log("🔑 req.user:", JSON.stringify(req.user, null, 2));
+
     if (!req.user) {
-      console.log('❌ No user found in request - authentication failed');
-      throw new Error('Authentication required');
+      console.log("❌ No user found in request - authentication failed");
+      throw new Error("Authentication required");
     }
-    
+
     const userId = req.user.uid;
 
     const result = await this.apiKeyService.getUserApiKeys(userId);
@@ -75,7 +78,7 @@ export class ApiKeyController {
         {
           statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
           message: result.error,
-          error: 'Internal Server Error',
+          error: "Internal Server Error",
         },
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
@@ -88,10 +91,10 @@ export class ApiKeyController {
    * Get a specific API key by ID
    * GET /api-keys/:id
    */
-  @Get(':id')
+  @Get(":id")
   async getApiKeyById(
     @Request() req: any,
-    @Param('id') keyId: string,
+    @Param("id") keyId: string,
   ): Promise<ApiKeyResponseDto> {
     const userId = req.user.uid;
 
@@ -99,7 +102,7 @@ export class ApiKeyController {
 
     if (!result.success) {
       const status =
-        result.error === 'Not found'
+        result.error === "Not found"
           ? HttpStatus.NOT_FOUND
           : HttpStatus.INTERNAL_SERVER_ERROR;
       throw new HttpException(
@@ -108,8 +111,8 @@ export class ApiKeyController {
           message: result.error,
           error:
             status === HttpStatus.NOT_FOUND
-              ? 'Not Found'
-              : 'Internal Server Error',
+              ? "Not Found"
+              : "Internal Server Error",
         },
         status,
       );
@@ -122,21 +125,21 @@ export class ApiKeyController {
    * Delete (deactivate) an API key
    * DELETE /api-keys/:id
    */
-  @Delete(':id')
+  @Delete(":id")
   async deleteApiKey(
     @Request() req: any,
-    @Param('id') keyId: string,
+    @Param("id") keyId: string,
   ): Promise<{ message: string }> {
-    console.log('🔑 DELETE /api-keys/:id endpoint called with keyId:', keyId);
-    console.log('🔑 User ID from request:', req.user.uid);
-    
+    console.log("🔑 DELETE /api-keys/:id endpoint called with keyId:", keyId);
+    console.log("🔑 User ID from request:", req.user.uid);
+
     const userId = req.user.uid;
 
     const result = await this.apiKeyService.deleteApiKey(userId, keyId);
 
     if (!result.success) {
       const status =
-        result.error === 'API key not found'
+        result.error === "API key not found"
           ? HttpStatus.NOT_FOUND
           : HttpStatus.INTERNAL_SERVER_ERROR;
       throw new HttpException(
@@ -145,21 +148,21 @@ export class ApiKeyController {
           message: result.error,
           error:
             status === HttpStatus.NOT_FOUND
-              ? 'Not Found'
-              : 'Internal Server Error',
+              ? "Not Found"
+              : "Internal Server Error",
         },
         status,
       );
     }
 
-    return { message: 'API key deleted successfully' };
+    return { message: "API key deleted successfully" };
   }
 
   /**
    * Get API key statistics
    * GET /api-keys/stats
    */
-  @Get('stats/summary')
+  @Get("stats/summary")
   async getApiKeyStats(
     @Request() req: any,
   ): Promise<{ total: number; active: number }> {
@@ -172,7 +175,7 @@ export class ApiKeyController {
         {
           statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
           message: result.error,
-          error: 'Internal Server Error',
+          error: "Internal Server Error",
         },
         HttpStatus.INTERNAL_SERVER_ERROR,
       );

--- a/api/src/api-key/api-key.decorator.ts
+++ b/api/src/api-key/api-key.decorator.ts
@@ -1,4 +1,4 @@
-import { SetMetadata } from '@nestjs/common';
+import { SetMetadata } from "@nestjs/common";
 
-export const API_KEY_AUTH_KEY = 'apiKeyAuth';
+export const API_KEY_AUTH_KEY = "apiKeyAuth";
 export const ApiKeyAuth = () => SetMetadata(API_KEY_AUTH_KEY, true);

--- a/api/src/api-key/api-key.guard.ts
+++ b/api/src/api-key/api-key.guard.ts
@@ -3,8 +3,8 @@ import {
   CanActivate,
   ExecutionContext,
   UnauthorizedException,
-} from '@nestjs/common';
-import { ApiKeyService } from '@/api-key/api-key.service';
+} from "@nestjs/common";
+import { ApiKeyService } from "@/api-key/api-key.service";
 
 @Injectable()
 export class ApiKeyGuard implements CanActivate {
@@ -15,13 +15,13 @@ export class ApiKeyGuard implements CanActivate {
     const apiKey = this.extractApiKeyFromHeader(request);
 
     if (!apiKey) {
-      throw new UnauthorizedException('API key is required');
+      throw new UnauthorizedException("API key is required");
     }
 
     const result = await this.apiKeyService.validateApiKey(apiKey);
 
     if (!result.success) {
-      throw new UnauthorizedException('Invalid API key');
+      throw new UnauthorizedException("Invalid API key");
     }
 
     // Attach the user to the request for downstream use
@@ -41,15 +41,15 @@ export class ApiKeyGuard implements CanActivate {
     // X-API-Key: the0_xxx
 
     const authHeader = request.headers.authorization;
-    const apiKeyHeader = request.headers['x-api-key'];
+    const apiKeyHeader = request.headers["x-api-key"];
 
     if (apiKeyHeader) {
       return apiKeyHeader;
     }
 
     if (authHeader) {
-      const [type, key] = authHeader.split(' ');
-      if ((type === 'Bearer' || type === 'ApiKey') && key) {
+      const [type, key] = authHeader.split(" ");
+      if ((type === "Bearer" || type === "ApiKey") && key) {
         return key;
       }
     }

--- a/api/src/api-key/api-key.module.ts
+++ b/api/src/api-key/api-key.module.ts
@@ -1,7 +1,7 @@
-import { Module } from '@nestjs/common';
-import { ApiKeyController } from './api-key.controller';
-import { ApiKeyService } from './api-key.service';
-import { ApiKeyRepository } from './api-key.repository';
+import { Module } from "@nestjs/common";
+import { ApiKeyController } from "./api-key.controller";
+import { ApiKeyService } from "./api-key.service";
+import { ApiKeyRepository } from "./api-key.repository";
 
 @Module({
   controllers: [ApiKeyController],

--- a/api/src/api-key/api-key.repository.ts
+++ b/api/src/api-key/api-key.repository.ts
@@ -1,16 +1,19 @@
-import { Injectable } from '@nestjs/common';
-import { RoleRepository } from '@/common/role.repository';
-import { ApiKey } from './models/api-key.model';
-import { Result, Ok, Failure } from '@/common/result';
-import { eq, and } from 'drizzle-orm';
-import { createId } from '@paralleldrive/cuid2';
-import * as crypto from 'crypto';
+import { Injectable } from "@nestjs/common";
+import { RoleRepository } from "@/common/role.repository";
+import { ApiKey } from "./models/api-key.model";
+import { Result, Ok, Failure } from "@/common/result";
+import { eq, and } from "drizzle-orm";
+import { createId } from "@paralleldrive/cuid2";
+import * as crypto from "crypto";
 
 @Injectable()
 export class ApiKeyRepository extends RoleRepository<ApiKey> {
-  protected readonly tableName = 'apiKeys' as const;
+  protected readonly tableName = "apiKeys" as const;
 
-  async createApiKey(userId: string, name: string): Promise<Result<ApiKey, string>> {
+  async createApiKey(
+    userId: string,
+    name: string,
+  ): Promise<Result<ApiKey, string>> {
     try {
       // Generate a secure API key
       const apiKey = this.generateApiKey();
@@ -23,7 +26,7 @@ export class ApiKeyRepository extends RoleRepository<ApiKey> {
       };
 
       const result = await this.create(data);
-      
+
       if (!result.success) {
         return Failure(result.error);
       }
@@ -40,18 +43,19 @@ export class ApiKeyRepository extends RoleRepository<ApiKey> {
 
   async findByKey(key: string): Promise<Result<ApiKey, string>> {
     try {
-      const records = await this.db.select().from(this.table)
-        .where(and(
-          eq(this.table.keyValue, key),
-          eq(this.table.isActive, true)
-        ));
+      const records = await this.db
+        .select()
+        .from(this.table)
+        .where(
+          and(eq(this.table.keyValue, key), eq(this.table.isActive, true)),
+        );
 
       if (records.length === 0) {
-        return Failure('API key not found or inactive');
+        return Failure("API key not found or inactive");
       }
 
       const apiKey = records[0];
-      
+
       return Ok({
         id: apiKey.id,
         userId: apiKey.userId,
@@ -69,7 +73,8 @@ export class ApiKeyRepository extends RoleRepository<ApiKey> {
 
   async updateLastUsed(keyId: string): Promise<Result<void, string>> {
     try {
-      await this.db.update(this.table)
+      await this.db
+        .update(this.table)
         .set({ lastUsedAt: new Date() })
         .where(eq(this.table.id, keyId));
 
@@ -79,29 +84,30 @@ export class ApiKeyRepository extends RoleRepository<ApiKey> {
     }
   }
 
-  async deleteApiKey(userId: string, id: string): Promise<Result<void, string>> {
+  async deleteApiKey(
+    userId: string,
+    id: string,
+  ): Promise<Result<void, string>> {
     try {
-      console.log('🔑 Deleting API key:', { userId, id });
-      
+      console.log("🔑 Deleting API key:", { userId, id });
+
       // First check if the API key exists and belongs to the user
       const existingKey = await this.findOne(userId, id);
       if (!existingKey.success) {
-        console.log('❌ API key not found:', existingKey.error);
-        return Failure('API key not found');
+        console.log("❌ API key not found:", existingKey.error);
+        return Failure("API key not found");
       }
-      
-      console.log('✅ Found API key to delete:', existingKey.data.name);
-      
-      await this.db.delete(this.table)
-        .where(and(
-          eq(this.table.id, id),
-          eq(this.table.userId, userId)
-        ));
 
-      console.log('✅ API key deleted successfully');
+      console.log("✅ Found API key to delete:", existingKey.data.name);
+
+      await this.db
+        .delete(this.table)
+        .where(and(eq(this.table.id, id), eq(this.table.userId, userId)));
+
+      console.log("✅ API key deleted successfully");
       return Ok(null);
     } catch (error: any) {
-      console.log('❌ Error deleting API key:', error);
+      console.log("❌ Error deleting API key:", error);
       return Failure(error.message);
     }
   }
@@ -121,8 +127,8 @@ export class ApiKeyRepository extends RoleRepository<ApiKey> {
   }
 
   private generateApiKey(): string {
-    const prefix = 'the0_';
-    const randomBytes = crypto.randomBytes(32).toString('hex');
+    const prefix = "the0_";
+    const randomBytes = crypto.randomBytes(32).toString("hex");
     return `${prefix}${randomBytes}`;
   }
 }

--- a/api/src/api-key/api-key.service.ts
+++ b/api/src/api-key/api-key.service.ts
@@ -1,11 +1,11 @@
 // src/api-keys/services/api-key.service.ts
-import { Injectable } from '@nestjs/common';
-import { ApiKeyRepository } from './api-key.repository';
-import { Result, Ok, Failure } from '../common/result';
-import { ApiKey } from './models/api-key.model';
-import { CreateApiKeyDto } from './dto/create-api-key.dto';
-import { ApiKeyCreatedResponseDto } from './dto/api-key-created-response.dto';
-import { ApiKeyResponseDto } from './dto/api-key-response.dto';
+import { Injectable } from "@nestjs/common";
+import { ApiKeyRepository } from "./api-key.repository";
+import { Result, Ok, Failure } from "../common/result";
+import { ApiKey } from "./models/api-key.model";
+import { CreateApiKeyDto } from "./dto/create-api-key.dto";
+import { ApiKeyCreatedResponseDto } from "./dto/api-key-created-response.dto";
+import { ApiKeyResponseDto } from "./dto/api-key-response.dto";
 
 @Injectable()
 export class ApiKeyService {
@@ -28,7 +28,7 @@ export class ApiKeyService {
       (key) => key.name === createApiKeyDto.name,
     );
     if (nameExists) {
-      return Failure('An API key with this name already exists');
+      return Failure("An API key with this name already exists");
     }
 
     // Create the API key

--- a/api/src/api-key/dto/api-key-created-response.dto.ts
+++ b/api/src/api-key/dto/api-key-created-response.dto.ts
@@ -1,4 +1,4 @@
-import { ApiKeyResponseDto } from '@/api-key/dto/api-key-response.dto';
+import { ApiKeyResponseDto } from "@/api-key/dto/api-key-response.dto";
 
 export class ApiKeyCreatedResponseDto extends ApiKeyResponseDto {
   key: string; // Full key only returned on creation

--- a/api/src/api-key/dto/create-api-key.dto.ts
+++ b/api/src/api-key/dto/create-api-key.dto.ts
@@ -1,13 +1,13 @@
-import { IsString, IsNotEmpty, MaxLength, MinLength } from 'class-validator';
+import { IsString, IsNotEmpty, MaxLength, MinLength } from "class-validator";
 
 export class CreateApiKeyDto {
-  @IsString({ message: 'name must be a string' })
-  @IsNotEmpty({ message: 'name should not be empty' })
+  @IsString({ message: "name must be a string" })
+  @IsNotEmpty({ message: "name should not be empty" })
   @MinLength(3, {
-    message: 'name must be longer than or equal to 3 characters',
+    message: "name must be longer than or equal to 3 characters",
   })
   @MaxLength(50, {
-    message: 'name must be shorter than or equal to 50 characters',
+    message: "name must be shorter than or equal to 50 characters",
   })
   name: string;
 }

--- a/api/src/app.controller.spec.ts
+++ b/api/src/app.controller.spec.ts
@@ -1,8 +1,8 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
+import { Test, TestingModule } from "@nestjs/testing";
+import { AppController } from "./app.controller";
+import { AppService } from "./app.service";
 
-describe('AppController', () => {
+describe("AppController", () => {
   let appController: AppController;
 
   beforeEach(async () => {
@@ -14,9 +14,9 @@ describe('AppController', () => {
     appController = app.get<AppController>(AppController);
   });
 
-  describe('root', () => {
+  describe("root", () => {
     it('should return "Hello World!"', () => {
-      expect(appController.getHello()).toBe('Hello World!');
+      expect(appController.getHello()).toBe("Hello World!");
     });
   });
 });

--- a/api/src/app.controller.ts
+++ b/api/src/app.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Get } from '@nestjs/common';
-import { AppService } from './app.service';
+import { Controller, Get } from "@nestjs/common";
+import { AppService } from "./app.service";
 
 @Controller()
 export class AppController {

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -1,16 +1,16 @@
-import { Module } from '@nestjs/common';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
-import { BotModule } from './bot/bot.module';
-import { AuthModule } from './auth/auth.module';
-import { BacktestModule } from './backtest/backtest.module';
-import { ConfigModule } from '@nestjs/config';
-import { CustomBotModule } from './custom-bot/custom-bot.module';
-import { ApiKeyModule } from './api-key/api-key.module';
-import { LogsModule } from './logs/logs.module';
-import { NatsModule } from './nats/nats.module';
-import { UploadModule } from './upload/upload.module';
-import configuration from './config/configuration';
+import { Module } from "@nestjs/common";
+import { AppController } from "./app.controller";
+import { AppService } from "./app.service";
+import { BotModule } from "./bot/bot.module";
+import { AuthModule } from "./auth/auth.module";
+import { BacktestModule } from "./backtest/backtest.module";
+import { ConfigModule } from "@nestjs/config";
+import { CustomBotModule } from "./custom-bot/custom-bot.module";
+import { ApiKeyModule } from "./api-key/api-key.module";
+import { LogsModule } from "./logs/logs.module";
+import { NatsModule } from "./nats/nats.module";
+import { UploadModule } from "./upload/upload.module";
+import configuration from "./config/configuration";
 // Removed OSS-incompatible modules: StripeConnect, Transactions, Subscriptions, FeatureGates, Usage
 
 @Module({

--- a/api/src/app.service.ts
+++ b/api/src/app.service.ts
@@ -1,8 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable } from "@nestjs/common";
 
 @Injectable()
 export class AppService {
   getHello(): string {
-    return 'Hello World!';
+    return "Hello World!";
   }
 }

--- a/api/src/auth/__tests__/auth-combined.guard.spec.ts
+++ b/api/src/auth/__tests__/auth-combined.guard.spec.ts
@@ -1,11 +1,11 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { ExecutionContext } from '@nestjs/common';
-import { AuthCombinedGuard } from '../auth-combined.guard';
-import { AuthService } from '../auth.service';
-import { ApiKeyService } from '../../api-key/api-key.service';
-import { Ok, Failure } from '../../common/result';
+import { Test, TestingModule } from "@nestjs/testing";
+import { ExecutionContext } from "@nestjs/common";
+import { AuthCombinedGuard } from "../auth-combined.guard";
+import { AuthService } from "../auth.service";
+import { ApiKeyService } from "../../api-key/api-key.service";
+import { Ok, Failure } from "../../common/result";
 
-describe('AuthCombinedGuard', () => {
+describe("AuthCombinedGuard", () => {
   let guard: AuthCombinedGuard;
   let authService: AuthService;
   let apiKeyService: ApiKeyService;
@@ -42,25 +42,25 @@ describe('AuthCombinedGuard', () => {
     jest.clearAllMocks();
   });
 
-  it('should be defined', () => {
+  it("should be defined", () => {
     expect(guard).toBeDefined();
   });
 
-  it('should allow access with valid JWT token', async () => {
+  it("should allow access with valid JWT token", async () => {
     const mockContext = {
       switchToHttp: () => ({
         getRequest: () => ({
           headers: {
-            authorization: 'Bearer valid-jwt-token',
+            authorization: "Bearer valid-jwt-token",
           },
         }),
       }),
     } as ExecutionContext;
 
     const mockUser = {
-      id: 'test-id',
-      username: 'testuser',
-      email: 'test@example.com',
+      id: "test-id",
+      username: "testuser",
+      email: "test@example.com",
       isActive: true,
       isEmailVerified: false,
     };
@@ -70,26 +70,26 @@ describe('AuthCombinedGuard', () => {
     const result = await guard.canActivate(mockContext);
 
     expect(result).toBe(true);
-    expect(authService.validateToken).toHaveBeenCalledWith('valid-jwt-token');
+    expect(authService.validateToken).toHaveBeenCalledWith("valid-jwt-token");
   });
 
-  it('should throw exception without JWT token', async () => {
+  it("should throw exception without JWT token", async () => {
     const mockContext = {
       switchToHttp: () => ({
         getRequest: () => ({
           headers: {
-            'x-api-key': 'valid-api-key',
+            "x-api-key": "valid-api-key",
           },
         }),
       }),
     } as ExecutionContext;
 
     await expect(guard.canActivate(mockContext)).rejects.toThrow(
-      'Authentication required. Provide Bearer JWT token or ApiKey.'
+      "Authentication required. Provide Bearer JWT token or ApiKey.",
     );
   });
 
-  it('should throw exception without any authentication', async () => {
+  it("should throw exception without any authentication", async () => {
     const mockContext = {
       switchToHttp: () => ({
         getRequest: () => ({
@@ -99,7 +99,7 @@ describe('AuthCombinedGuard', () => {
     } as ExecutionContext;
 
     await expect(guard.canActivate(mockContext)).rejects.toThrow(
-      'Authentication required. Provide Bearer JWT token or ApiKey.'
+      "Authentication required. Provide Bearer JWT token or ApiKey.",
     );
   });
 });

--- a/api/src/auth/__tests__/auth.controller.spec.ts
+++ b/api/src/auth/__tests__/auth.controller.spec.ts
@@ -1,11 +1,11 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { UnauthorizedException } from '@nestjs/common';
-import { AuthController } from '../auth.controller';
-import { AuthService } from '../auth.service';
-import { ApiKeyService } from '@/api-key/api-key.service';
-import { Ok, Failure } from '../../common/result';
+import { Test, TestingModule } from "@nestjs/testing";
+import { UnauthorizedException } from "@nestjs/common";
+import { AuthController } from "../auth.controller";
+import { AuthService } from "../auth.service";
+import { ApiKeyService } from "@/api-key/api-key.service";
+import { Ok, Failure } from "../../common/result";
 
-describe('AuthController', () => {
+describe("AuthController", () => {
   let controller: AuthController;
   let authService: AuthService;
 
@@ -45,23 +45,23 @@ describe('AuthController', () => {
     jest.clearAllMocks();
   });
 
-  it('should be defined', () => {
+  it("should be defined", () => {
     expect(controller).toBeDefined();
   });
 
-  describe('login', () => {
-    it('should return success on valid credentials', async () => {
+  describe("login", () => {
+    it("should return success on valid credentials", async () => {
       const loginDto = {
-        email: 'test@example.com',
-        password: 'password123',
+        email: "test@example.com",
+        password: "password123",
       };
 
       const mockResult = Ok({
-        token: 'test-token',
+        token: "test-token",
         user: {
-          id: 'test-id',
-          username: 'testuser',
-          email: 'test@example.com',
+          id: "test-id",
+          username: "testuser",
+          email: "test@example.com",
           isActive: true,
           isEmailVerified: false,
         },
@@ -72,38 +72,42 @@ describe('AuthController', () => {
       const result = await controller.login(loginDto);
 
       expect(result.success).toBe(true);
-      expect(result.data.token).toBe('test-token');
+      expect(result.data.token).toBe("test-token");
       expect(authService.login).toHaveBeenCalledWith(loginDto);
     });
 
-    it('should return error on invalid credentials', async () => {
+    it("should return error on invalid credentials", async () => {
       const loginDto = {
-        email: 'test@example.com',
-        password: 'wrongpassword',
+        email: "test@example.com",
+        password: "wrongpassword",
       };
 
-      const mockResult = Failure('Invalid credentials');
+      const mockResult = Failure("Invalid credentials");
       mockAuthService.login.mockResolvedValue(mockResult);
 
-      await expect(controller.login(loginDto)).rejects.toThrow(UnauthorizedException);
-      await expect(controller.login(loginDto)).rejects.toThrow('Invalid credentials');
+      await expect(controller.login(loginDto)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(controller.login(loginDto)).rejects.toThrow(
+        "Invalid credentials",
+      );
     });
   });
 
-  describe('register', () => {
-    it('should register user successfully', async () => {
+  describe("register", () => {
+    it("should register user successfully", async () => {
       const registerDto = {
-        username: 'newuser',
-        email: 'new@example.com',
-        password: 'password123',
+        username: "newuser",
+        email: "new@example.com",
+        password: "password123",
       };
 
       const mockResult = Ok({
-        token: 'test-token',
+        token: "test-token",
         user: {
-          id: 'test-id',
-          username: 'newuser',
-          email: 'new@example.com',
+          id: "test-id",
+          username: "newuser",
+          email: "new@example.com",
           isActive: true,
           isEmailVerified: false,
         },
@@ -114,19 +118,19 @@ describe('AuthController', () => {
       const result = await controller.register(registerDto);
 
       expect(result.success).toBe(true);
-      expect(result.data.token).toBe('test-token');
+      expect(result.data.token).toBe("test-token");
       expect(authService.register).toHaveBeenCalledWith(registerDto);
     });
   });
 
-  describe('validate', () => {
-    it('should validate token successfully', async () => {
-      const validateDto = { token: 'valid-token' };
+  describe("validate", () => {
+    it("should validate token successfully", async () => {
+      const validateDto = { token: "valid-token" };
 
       const mockResult = Ok({
-        id: 'test-id',
-        username: 'testuser',
-        email: 'test@example.com',
+        id: "test-id",
+        username: "testuser",
+        email: "test@example.com",
         isActive: true,
         isEmailVerified: false,
       });
@@ -136,17 +140,21 @@ describe('AuthController', () => {
       const result = await controller.validate(validateDto);
 
       expect(result.success).toBe(true);
-      expect(authService.validateToken).toHaveBeenCalledWith('valid-token');
+      expect(authService.validateToken).toHaveBeenCalledWith("valid-token");
     });
 
-    it('should return error for invalid token', async () => {
-      const validateDto = { token: 'invalid-token' };
+    it("should return error for invalid token", async () => {
+      const validateDto = { token: "invalid-token" };
 
-      const mockResult = Failure('Invalid token');
+      const mockResult = Failure("Invalid token");
       mockAuthService.validateToken.mockResolvedValue(mockResult);
 
-      await expect(controller.validate(validateDto)).rejects.toThrow(UnauthorizedException);
-      await expect(controller.validate(validateDto)).rejects.toThrow('Invalid token');
+      await expect(controller.validate(validateDto)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(controller.validate(validateDto)).rejects.toThrow(
+        "Invalid token",
+      );
     });
   });
 });

--- a/api/src/auth/__tests__/auth.service.spec.ts
+++ b/api/src/auth/__tests__/auth.service.spec.ts
@@ -1,43 +1,47 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { AuthService } from '../auth.service';
-import { JwtService } from '@nestjs/jwt';
+import { Test, TestingModule } from "@nestjs/testing";
+import { AuthService } from "../auth.service";
+import { JwtService } from "@nestjs/jwt";
 
-jest.mock('../../database/connection', () => ({
+jest.mock("../../database/connection", () => ({
   getDatabase: jest.fn().mockReturnValue({
     select: jest.fn().mockReturnValue({
       from: jest.fn().mockReturnValue({
-        where: jest.fn().mockReturnValue([{
-          id: 'test-id',
-          username: 'testuser',
-          email: 'test@example.com',
-          firstName: 'Test',
-          lastName: 'User',
-          isActive: true,
-          isEmailVerified: false,
-        }]),
+        where: jest.fn().mockReturnValue([
+          {
+            id: "test-id",
+            username: "testuser",
+            email: "test@example.com",
+            firstName: "Test",
+            lastName: "User",
+            isActive: true,
+            isEmailVerified: false,
+          },
+        ]),
       }),
     }),
     insert: jest.fn().mockReturnValue({
       values: jest.fn().mockReturnValue({
-        returning: jest.fn().mockReturnValue([{
-          id: 'test-id',
-          username: 'testuser',
-          email: 'test@example.com',
-          isActive: true,
-          isEmailVerified: false,
-        }]),
+        returning: jest.fn().mockReturnValue([
+          {
+            id: "test-id",
+            username: "testuser",
+            email: "test@example.com",
+            isActive: true,
+            isEmailVerified: false,
+          },
+        ]),
       }),
     }),
   }),
-  getDatabaseConfig: jest.fn().mockReturnValue({ type: 'sqlite' }),
+  getDatabaseConfig: jest.fn().mockReturnValue({ type: "sqlite" }),
 }));
 
-jest.mock('bcrypt', () => ({
-  hash: jest.fn().mockResolvedValue('hashed-password'),
+jest.mock("bcrypt", () => ({
+  hash: jest.fn().mockResolvedValue("hashed-password"),
   compare: jest.fn().mockResolvedValue(true),
 }));
 
-describe('AuthService', () => {
+describe("AuthService", () => {
   let service: AuthService;
   let jwtService: JwtService;
 
@@ -48,8 +52,10 @@ describe('AuthService', () => {
         {
           provide: JwtService,
           useValue: {
-            verify: jest.fn().mockReturnValue({ sub: 'test-id', username: 'testuser' }),
-            sign: jest.fn().mockReturnValue('test-token'),
+            verify: jest
+              .fn()
+              .mockReturnValue({ sub: "test-id", username: "testuser" }),
+            sign: jest.fn().mockReturnValue("test-token"),
           },
         },
       ],
@@ -59,27 +65,27 @@ describe('AuthService', () => {
     jwtService = module.get<JwtService>(JwtService);
   });
 
-  it('should be defined', () => {
+  it("should be defined", () => {
     expect(service).toBeDefined();
   });
 
-  it('should validate JWT token successfully', async () => {
-    const token = 'valid-token';
+  it("should validate JWT token successfully", async () => {
+    const token = "valid-token";
     const result = await service.validateToken(token);
-    
+
     expect(result.success).toBe(true);
     expect(jwtService.verify).toHaveBeenCalledWith(token);
   });
 
-  it('should handle invalid JWT token', async () => {
-    const token = 'invalid-token';
+  it("should handle invalid JWT token", async () => {
+    const token = "invalid-token";
     (jwtService.verify as jest.Mock).mockImplementation(() => {
-      throw new Error('Invalid token');
+      throw new Error("Invalid token");
     });
 
     const result = await service.validateToken(token);
-    
+
     expect(result.success).toBe(false);
-    expect(result.error).toContain('Invalid token');
+    expect(result.error).toContain("Invalid token");
   });
 });

--- a/api/src/auth/auth-combined.decorator.ts
+++ b/api/src/auth/auth-combined.decorator.ts
@@ -1,14 +1,14 @@
-import { SetMetadata } from '@nestjs/common';
+import { SetMetadata } from "@nestjs/common";
 
-export const COMBINED_AUTH_KEY = 'combinedAuth';
+export const COMBINED_AUTH_KEY = "combinedAuth";
 export const CombinedAuth = () => SetMetadata(COMBINED_AUTH_KEY, true);
 
 // src/auth/decorators/auth-type.decorator.ts
-import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { createParamDecorator, ExecutionContext } from "@nestjs/common";
 
 export const AuthType = createParamDecorator(
   (data: unknown, ctx: ExecutionContext) => {
     const request = ctx.switchToHttp().getRequest();
-    return request.user?.authType || 'unknown';
+    return request.user?.authType || "unknown";
   },
 );

--- a/api/src/auth/auth-combined.guard.ts
+++ b/api/src/auth/auth-combined.guard.ts
@@ -3,9 +3,9 @@ import {
   CanActivate,
   ExecutionContext,
   UnauthorizedException,
-} from '@nestjs/common';
-import { AuthService } from './auth.service';
-import { ApiKeyService } from '@/api-key/api-key.service';
+} from "@nestjs/common";
+import { AuthService } from "./auth.service";
+import { ApiKeyService } from "@/api-key/api-key.service";
 
 @Injectable()
 export class AuthCombinedGuard implements CanActivate {
@@ -30,11 +30,14 @@ export class AuthCombinedGuard implements CanActivate {
     }
 
     throw new UnauthorizedException(
-      'Authentication required. Provide Bearer JWT token or ApiKey.',
+      "Authentication required. Provide Bearer JWT token or ApiKey.",
     );
   }
 
-  private async validateJwtToken(request: any, token: string): Promise<boolean> {
+  private async validateJwtToken(
+    request: any,
+    token: string,
+  ): Promise<boolean> {
     const result = await this.authService.validateToken(token);
 
     if (!result.success) {
@@ -51,7 +54,7 @@ export class AuthCombinedGuard implements CanActivate {
       lastName: result.data.lastName,
       isActive: result.data.isActive,
       isEmailVerified: result.data.isEmailVerified,
-      authType: 'jwt',
+      authType: "jwt",
     };
 
     return true;
@@ -68,13 +71,13 @@ export class AuthCombinedGuard implements CanActivate {
     request.user = {
       uid: result.data.userId,
       id: result.data.userId,
-      username: '', // API keys don't have username
-      email: '',    // API keys don't have email
+      username: "", // API keys don't have username
+      email: "", // API keys don't have email
       firstName: null,
       lastName: null,
       isActive: true,
       isEmailVerified: true,
-      authType: 'apikey',
+      authType: "apikey",
     };
 
     return true;
@@ -84,8 +87,8 @@ export class AuthCombinedGuard implements CanActivate {
     const authHeader = request.headers.authorization;
 
     if (authHeader) {
-      const [type, token] = authHeader.split(' ');
-      if (type === 'Bearer' && token) {
+      const [type, token] = authHeader.split(" ");
+      if (type === "Bearer" && token) {
         return token;
       }
     }
@@ -97,8 +100,8 @@ export class AuthCombinedGuard implements CanActivate {
     const authHeader = request.headers.authorization;
 
     if (authHeader) {
-      const [type, key] = authHeader.split(' ');
-      if (type === 'ApiKey' && key) {
+      const [type, key] = authHeader.split(" ");
+      if (type === "ApiKey" && key) {
         return key;
       }
     }

--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -5,12 +5,16 @@ import {
   Get,
   Headers,
   UnauthorizedException,
-} from '@nestjs/common';
-import { AuthService, LoginCredentials, RegisterCredentials } from './auth.service';
-import { ValidateTokenDto } from './dto/validate-token.dto';
-import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
-import { IsEmail, IsString, IsNotEmpty, IsOptional } from 'class-validator';
-import { ApiKeyService } from '@/api-key/api-key.service';
+} from "@nestjs/common";
+import {
+  AuthService,
+  LoginCredentials,
+  RegisterCredentials,
+} from "./auth.service";
+import { ValidateTokenDto } from "./dto/validate-token.dto";
+import { ApiTags, ApiBearerAuth } from "@nestjs/swagger";
+import { IsEmail, IsString, IsNotEmpty, IsOptional } from "class-validator";
+import { ApiKeyService } from "@/api-key/api-key.service";
 
 export class LoginDto {
   @IsEmail()
@@ -44,18 +48,18 @@ export class RegisterDto {
   lastName?: string;
 }
 
-@ApiTags('auth')
-@Controller('auth')
+@ApiTags("auth")
+@Controller("auth")
 export class AuthController {
   constructor(
     private readonly authService: AuthService,
     private readonly apiKeyService: ApiKeyService,
   ) {}
 
-  @Post('login')
+  @Post("login")
   async login(@Body() loginDto: LoginDto) {
     const result = await this.authService.login(loginDto);
-    
+
     if (!result.success) {
       throw new UnauthorizedException(result.error);
     }
@@ -63,14 +67,14 @@ export class AuthController {
     return {
       success: true,
       data: result.data,
-      message: 'Login successful',
+      message: "Login successful",
     };
   }
 
-  @Post('register')
+  @Post("register")
   async register(@Body() registerDto: RegisterDto) {
     const result = await this.authService.register(registerDto);
-    
+
     if (!result.success) {
       throw new UnauthorizedException(result.error);
     }
@@ -78,15 +82,15 @@ export class AuthController {
     return {
       success: true,
       data: result.data,
-      message: 'Registration successful',
+      message: "Registration successful",
     };
   }
 
-  @Post('validate')
+  @Post("validate")
   @ApiBearerAuth()
   async validate(@Body() validateTokenDto: ValidateTokenDto) {
     const result = await this.authService.validateToken(validateTokenDto.token);
-    
+
     if (!result.success) {
       throw new UnauthorizedException(result.error);
     }
@@ -94,20 +98,20 @@ export class AuthController {
     return {
       success: true,
       data: result.data,
-      message: 'Token is valid',
+      message: "Token is valid",
     };
   }
 
-  @Get('me')
+  @Get("me")
   @ApiBearerAuth()
-  async getCurrentUser(@Headers('authorization') authHeader?: string) {
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      throw new UnauthorizedException('Bearer token is required');
+  async getCurrentUser(@Headers("authorization") authHeader?: string) {
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      throw new UnauthorizedException("Bearer token is required");
     }
 
     const token = authHeader.substring(7);
     const result = await this.authService.validateToken(token);
-    
+
     if (!result.success) {
       throw new UnauthorizedException(result.error);
     }
@@ -115,28 +119,28 @@ export class AuthController {
     return {
       success: true,
       data: result.data,
-      message: 'User retrieved successfully',
+      message: "User retrieved successfully",
     };
   }
 
-  @Get('validate-api-key')
-  async validateApiKey(@Headers('authorization') authHeader?: string) {
+  @Get("validate-api-key")
+  async validateApiKey(@Headers("authorization") authHeader?: string) {
     if (!authHeader) {
-      throw new UnauthorizedException('Authorization header is required');
+      throw new UnauthorizedException("Authorization header is required");
     }
 
     // Extract API key from Authorization header
     let apiKey: string;
-    if (authHeader.startsWith('ApiKey ')) {
+    if (authHeader.startsWith("ApiKey ")) {
       apiKey = authHeader.substring(7);
-    } else if (authHeader.startsWith('Bearer ')) {
+    } else if (authHeader.startsWith("Bearer ")) {
       apiKey = authHeader.substring(7);
     } else {
-      throw new UnauthorizedException('Invalid authorization header format');
+      throw new UnauthorizedException("Invalid authorization header format");
     }
 
     const result = await this.apiKeyService.validateApiKey(apiKey);
-    
+
     if (!result.success) {
       throw new UnauthorizedException(result.error);
     }
@@ -148,9 +152,11 @@ export class AuthController {
         userId: result.data.userId,
         keyId: result.data.id,
         keyName: result.data.name,
-        lastUsedAt: result.data.lastUsedAt ? result.data.lastUsedAt.toISOString() : null,
+        lastUsedAt: result.data.lastUsedAt
+          ? result.data.lastUsedAt.toISOString()
+          : null,
       },
-      message: 'API key is valid',
+      message: "API key is valid",
     };
   }
 }

--- a/api/src/auth/auth.module.ts
+++ b/api/src/auth/auth.module.ts
@@ -1,21 +1,22 @@
-import { Global, Module } from '@nestjs/common';
-import { JwtModule } from '@nestjs/jwt';
-import { PassportModule } from '@nestjs/passport';
-import { AuthController } from './auth.controller';
-import { AuthService } from './auth.service';
-import { JwtStrategy } from './jwt.strategy';
-import { ApiKeyModule } from '@/api-key/api-key.module';
+import { Global, Module } from "@nestjs/common";
+import { JwtModule } from "@nestjs/jwt";
+import { PassportModule } from "@nestjs/passport";
+import { AuthController } from "./auth.controller";
+import { AuthService } from "./auth.service";
+import { JwtStrategy } from "./jwt.strategy";
+import { ApiKeyModule } from "@/api-key/api-key.module";
 
 @Global()
 @Module({
   imports: [
-    PassportModule.register({ defaultStrategy: 'jwt' }),
+    PassportModule.register({ defaultStrategy: "jwt" }),
     JwtModule.register({
-      secret: process.env.JWT_SECRET || 'the0-oss-jwt-secret-change-in-production',
-      signOptions: { 
-        expiresIn: process.env.JWT_EXPIRES_IN || '24h',
-        issuer: 'the0-oss-api',
-        audience: 'the0-oss-clients',
+      secret:
+        process.env.JWT_SECRET || "the0-oss-jwt-secret-change-in-production",
+      signOptions: {
+        expiresIn: process.env.JWT_EXPIRES_IN || "24h",
+        issuer: "the0-oss-api",
+        audience: "the0-oss-clients",
       },
     }),
     ApiKeyModule,

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -1,11 +1,11 @@
-import { Injectable, Scope } from '@nestjs/common';
-import { JwtService } from '@nestjs/jwt';
-import { getDatabase } from '../database/connection';
-import { usersTable, usersTableSqlite } from '../database/schema/users';
-import { eq } from 'drizzle-orm';
-import * as bcrypt from 'bcrypt';
-import { Result } from '../common/result';
-import { getDatabaseConfig } from '../database/connection';
+import { Injectable, Scope } from "@nestjs/common";
+import { JwtService } from "@nestjs/jwt";
+import { getDatabase } from "../database/connection";
+import { usersTable, usersTableSqlite } from "../database/schema/users";
+import { eq } from "drizzle-orm";
+import * as bcrypt from "bcrypt";
+import { Result } from "../common/result";
+import { getDatabaseConfig } from "../database/connection";
 
 export interface AuthUser {
   id: string;
@@ -39,14 +39,18 @@ export class AuthService {
       const payload = this.jwtService.verify(token);
       const db = getDatabase();
       const config = getDatabaseConfig();
-      
-      const userTable = config.type === 'sqlite' ? usersTableSqlite : usersTable;
-      const users = await db.select().from(userTable).where(eq(userTable.id, payload.sub));
-      
+
+      const userTable =
+        config.type === "sqlite" ? usersTableSqlite : usersTable;
+      const users = await db
+        .select()
+        .from(userTable)
+        .where(eq(userTable.id, payload.sub));
+
       if (users.length === 0) {
         return {
           success: false,
-          error: 'User not found',
+          error: "User not found",
           data: null,
         };
       }
@@ -55,7 +59,7 @@ export class AuthService {
       if (!user.isActive) {
         return {
           success: false,
-          error: 'User account is inactive',
+          error: "User account is inactive",
           data: null,
         };
       }
@@ -76,24 +80,30 @@ export class AuthService {
     } catch (error) {
       return {
         success: false,
-        error: 'Invalid token',
+        error: "Invalid token",
         data: null,
       };
     }
   }
 
-  async login(credentials: LoginCredentials): Promise<Result<{ token: string; user: AuthUser }, string>> {
+  async login(
+    credentials: LoginCredentials,
+  ): Promise<Result<{ token: string; user: AuthUser }, string>> {
     try {
       const db = getDatabase();
       const config = getDatabaseConfig();
-      
-      const userTable = config.type === 'sqlite' ? usersTableSqlite : usersTable;
-      const users = await db.select().from(userTable).where(eq(userTable.email, credentials.email));
-      
+
+      const userTable =
+        config.type === "sqlite" ? usersTableSqlite : usersTable;
+      const users = await db
+        .select()
+        .from(userTable)
+        .where(eq(userTable.email, credentials.email));
+
       if (users.length === 0) {
         return {
           success: false,
-          error: 'Invalid credentials',
+          error: "Invalid credentials",
           data: null,
         };
       }
@@ -102,33 +112,37 @@ export class AuthService {
       if (!user.isActive) {
         return {
           success: false,
-          error: 'User account is inactive',
+          error: "User account is inactive",
           data: null,
         };
       }
 
-      const isPasswordValid = await bcrypt.compare(credentials.password, user.passwordHash);
+      const isPasswordValid = await bcrypt.compare(
+        credentials.password,
+        user.passwordHash,
+      );
       if (!isPasswordValid) {
         return {
           success: false,
-          error: 'Invalid credentials',
+          error: "Invalid credentials",
           data: null,
         };
       }
 
       // Update last login
-      await db.update(userTable)
+      await db
+        .update(userTable)
         .set({ lastLoginAt: new Date() })
         .where(eq(userTable.id, user.id));
 
-      const payload = { 
-        sub: user.id, 
-        username: user.username, 
-        email: user.email 
+      const payload = {
+        sub: user.id,
+        username: user.username,
+        email: user.email,
       };
-      
+
       const token = this.jwtService.sign(payload);
-      
+
       return {
         success: true,
         error: null,
@@ -148,55 +162,63 @@ export class AuthService {
     } catch (error) {
       return {
         success: false,
-        error: 'Login failed',
+        error: "Login failed",
         data: null,
       };
     }
   }
 
-  async register(credentials: RegisterCredentials): Promise<Result<{ token: string; user: AuthUser }, string>> {
+  async register(
+    credentials: RegisterCredentials,
+  ): Promise<Result<{ token: string; user: AuthUser }, string>> {
     try {
       const db = getDatabase();
       const config = getDatabaseConfig();
-      
-      const userTable = config.type === 'sqlite' ? usersTableSqlite : usersTable;
-      
+
+      const userTable =
+        config.type === "sqlite" ? usersTableSqlite : usersTable;
+
       // Check if user already exists
-      const existingUsers = await db.select().from(userTable)
+      const existingUsers = await db
+        .select()
+        .from(userTable)
         .where(eq(userTable.email, credentials.email));
-      
+
       if (existingUsers.length > 0) {
         return {
           success: false,
-          error: 'User already exists',
+          error: "User already exists",
           data: null,
         };
       }
 
       // Hash password
       const passwordHash = await bcrypt.hash(credentials.password, 10);
-      
+
       // Create user
-      const newUsers = await db.insert(userTable).values({
-        username: credentials.username,
-        email: credentials.email,
-        passwordHash,
-        firstName: credentials.firstName,
-        lastName: credentials.lastName,
-        isActive: true,
-        isEmailVerified: false,
-      }).returning();
+      const newUsers = await db
+        .insert(userTable)
+        .values({
+          username: credentials.username,
+          email: credentials.email,
+          passwordHash,
+          firstName: credentials.firstName,
+          lastName: credentials.lastName,
+          isActive: true,
+          isEmailVerified: false,
+        })
+        .returning();
 
       const newUser = newUsers[0];
-      
-      const payload = { 
-        sub: newUser.id, 
-        username: newUser.username, 
-        email: newUser.email 
+
+      const payload = {
+        sub: newUser.id,
+        username: newUser.username,
+        email: newUser.email,
       };
-      
+
       const token = this.jwtService.sign(payload);
-      
+
       return {
         success: true,
         error: null,
@@ -216,7 +238,7 @@ export class AuthService {
     } catch (error) {
       return {
         success: false,
-        error: 'Registration failed',
+        error: "Registration failed",
         data: null,
       };
     }

--- a/api/src/auth/current-user.decorator.ts
+++ b/api/src/auth/current-user.decorator.ts
@@ -1,4 +1,4 @@
-import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { createParamDecorator, ExecutionContext } from "@nestjs/common";
 
 export const CurrentUser = createParamDecorator(
   (data: unknown, ctx: ExecutionContext) => {

--- a/api/src/auth/dto/validate-token.dto.ts
+++ b/api/src/auth/dto/validate-token.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsString } from "class-validator";
 
 export class ValidateTokenDto {
   @IsNotEmpty()

--- a/api/src/auth/jwt.strategy.ts
+++ b/api/src/auth/jwt.strategy.ts
@@ -1,10 +1,10 @@
-import { ExtractJwt, Strategy } from 'passport-jwt';
-import { PassportStrategy } from '@nestjs/passport';
-import { Injectable, UnauthorizedException } from '@nestjs/common';
-import { AuthService } from './auth.service';
-import { getDatabase, getDatabaseConfig } from '../database/connection';
-import { usersTable, usersTableSqlite } from '../database/schema/users';
-import { eq } from 'drizzle-orm';
+import { ExtractJwt, Strategy } from "passport-jwt";
+import { PassportStrategy } from "@nestjs/passport";
+import { Injectable, UnauthorizedException } from "@nestjs/common";
+import { AuthService } from "./auth.service";
+import { getDatabase, getDatabaseConfig } from "../database/connection";
+import { usersTable, usersTableSqlite } from "../database/schema/users";
+import { eq } from "drizzle-orm";
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -12,55 +12,63 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: process.env.JWT_SECRET || 'the0-oss-jwt-secret-change-in-production',
-      issuer: 'the0-oss-api',
-      audience: 'the0-oss-clients',
+      secretOrKey:
+        process.env.JWT_SECRET || "the0-oss-jwt-secret-change-in-production",
+      issuer: "the0-oss-api",
+      audience: "the0-oss-clients",
     });
   }
 
   async validate(payload: any) {
-    console.log('🔍 JWT Strategy validate called with payload:', JSON.stringify(payload, null, 2));
-    
+    console.log(
+      "🔍 JWT Strategy validate called with payload:",
+      JSON.stringify(payload, null, 2),
+    );
+
     if (!payload?.sub) {
-      console.log('❌ JWT payload missing sub field');
-      throw new UnauthorizedException('Invalid token payload');
+      console.log("❌ JWT payload missing sub field");
+      throw new UnauthorizedException("Invalid token payload");
     }
 
     try {
       const db = getDatabase();
       const config = getDatabaseConfig();
-      const userTable = config.type === 'sqlite' ? usersTableSqlite : usersTable;
-      
+      const userTable =
+        config.type === "sqlite" ? usersTableSqlite : usersTable;
+
       const users = await db
         .select()
         .from(userTable)
         .where(eq(userTable.id, String(payload.sub)));
-      
+
       if (!users || users.length === 0) {
-        throw new UnauthorizedException('User not found');
+        throw new UnauthorizedException("User not found");
       }
 
       const user = users[0];
       if (!user?.isActive) {
-        throw new UnauthorizedException('User inactive');
+        throw new UnauthorizedException("User inactive");
       }
 
       const userObj = {
-        uid: user.id || '',
-        id: user.id || '',
-        username: user.username || '',
-        email: user.email || '',
+        uid: user.id || "",
+        id: user.id || "",
+        username: user.username || "",
+        email: user.email || "",
         firstName: user.firstName || null,
         lastName: user.lastName || null,
         isActive: Boolean(user.isActive),
         isEmailVerified: Boolean(user.isEmailVerified),
       };
-      
-      console.log('🧑 JWT Strategy returning user:', JSON.stringify(userObj, null, 2));
+
+      console.log(
+        "🧑 JWT Strategy returning user:",
+        JSON.stringify(userObj, null, 2),
+      );
       return userObj;
     } catch (error) {
-      console.error('JWT validation error:', error);
-      throw new UnauthorizedException('Token validation failed');
+      console.error("JWT validation error:", error);
+      throw new UnauthorizedException("Token validation failed");
     }
   }
 }

--- a/api/src/backtest/__tests__/backtest-analysis.spec.ts
+++ b/api/src/backtest/__tests__/backtest-analysis.spec.ts
@@ -1,15 +1,15 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { ConfigService } from '@nestjs/config';
-import { BacktestService } from '../backtest.service';
-import { BacktestRepository } from '../backtest.repository';
-import { BacktestValidator } from '../backtest.validator';
-import { CustomBotService } from '@/custom-bot/custom-bot.service';
-import { NatsService } from '@/nats/nats.service';
-import { REQUEST } from '@nestjs/core';
-import { Ok, Failure } from '@/common';
-import { EventEmitter } from 'events';
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigService } from "@nestjs/config";
+import { BacktestService } from "../backtest.service";
+import { BacktestRepository } from "../backtest.repository";
+import { BacktestValidator } from "../backtest.validator";
+import { CustomBotService } from "@/custom-bot/custom-bot.service";
+import { NatsService } from "@/nats/nats.service";
+import { REQUEST } from "@nestjs/core";
+import { Ok, Failure } from "@/common";
+import { EventEmitter } from "events";
 
-describe('BacktestService Analysis Loading', () => {
+describe("BacktestService Analysis Loading", () => {
   let service: BacktestService;
   let configService: jest.Mocked<ConfigService>;
   let mockRepository: jest.Mocked<BacktestRepository>;
@@ -18,13 +18,13 @@ describe('BacktestService Analysis Loading', () => {
     getObject: jest.fn(),
   };
 
-  const uid = 'test-user-id';
+  const uid = "test-user-id";
 
   const createMockStream = (content: string) => {
     const stream = new EventEmitter();
     setTimeout(() => {
-      stream.emit('data', Buffer.from(content));
-      stream.emit('end');
+      stream.emit("data", Buffer.from(content));
+      stream.emit("end");
     }, 0);
     return stream;
   };
@@ -32,7 +32,7 @@ describe('BacktestService Analysis Loading', () => {
   const createErrorStream = (error: Error) => {
     const stream = new EventEmitter();
     setTimeout(() => {
-      stream.emit('error', error);
+      stream.emit("error", error);
     }, 0);
     return stream;
   };
@@ -44,7 +44,7 @@ describe('BacktestService Analysis Loading', () => {
         {
           provide: ConfigService,
           useValue: {
-            get: jest.fn().mockReturnValue('test-bucket'),
+            get: jest.fn().mockReturnValue("test-bucket"),
           },
         },
         {
@@ -89,10 +89,10 @@ describe('BacktestService Analysis Loading', () => {
     jest.clearAllMocks();
   });
 
-  describe('loadAnalysisFromGCS', () => {
-    it('should load analysis successfully for variation 1 format', async () => {
+  describe("loadAnalysisFromGCS", () => {
+    it("should load analysis successfully for variation 1 format", async () => {
       const mockAnalysis = {
-        status: 'success',
+        status: "success",
         results: {
           metrics: { total_return: 0.23, sharpe_ratio: 1.45 },
           plots: [{ data: [], layout: {} }],
@@ -100,96 +100,108 @@ describe('BacktestService Analysis Loading', () => {
         },
       };
 
-      mockMinioClient.getObject.mockResolvedValue(createMockStream(JSON.stringify(mockAnalysis)));
+      mockMinioClient.getObject.mockResolvedValue(
+        createMockStream(JSON.stringify(mockAnalysis)),
+      );
 
-      const result = await (service as any).loadAnalysisFromGCS('test-id');
+      const result = await (service as any).loadAnalysisFromGCS("test-id");
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual(mockAnalysis);
       expect(mockMinioClient.getObject).toHaveBeenCalledWith(
-        'test-bucket',
-        'test-id/analysis.json',
+        "test-bucket",
+        "test-id/analysis.json",
       );
     });
 
-    it('should load analysis successfully for variation 2 format', async () => {
+    it("should load analysis successfully for variation 2 format", async () => {
       const mockAnalysis = {
         metrics: { total_return: 0.23, sharpe_ratio: 1.45 },
         plots: [{ data: [], layout: {} }],
         tables: [],
-        status: 'success',
+        status: "success",
       };
 
-      mockMinioClient.getObject.mockResolvedValue(createMockStream(JSON.stringify(mockAnalysis)));
+      mockMinioClient.getObject.mockResolvedValue(
+        createMockStream(JSON.stringify(mockAnalysis)),
+      );
 
-      const result = await (service as any).loadAnalysisFromGCS('test-id');
+      const result = await (service as any).loadAnalysisFromGCS("test-id");
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual(mockAnalysis);
     });
 
-    it('should handle missing analysis file gracefully', async () => {
-      const noSuchKeyError = new Error('The specified key does not exist.');
-      (noSuchKeyError as any).code = 'NoSuchKey';
-      
-      mockMinioClient.getObject.mockResolvedValue(createErrorStream(noSuchKeyError));
+    it("should handle missing analysis file gracefully", async () => {
+      const noSuchKeyError = new Error("The specified key does not exist.");
+      (noSuchKeyError as any).code = "NoSuchKey";
 
-      const result = await (service as any).loadAnalysisFromGCS('test-id');
+      mockMinioClient.getObject.mockResolvedValue(
+        createErrorStream(noSuchKeyError),
+      );
+
+      const result = await (service as any).loadAnalysisFromGCS("test-id");
 
       expect(result.success).toBe(true);
       expect(result.data).toBeNull();
     });
 
-    it('should handle JSON parsing errors', async () => {
-      mockMinioClient.getObject.mockResolvedValue(createMockStream('invalid json'));
+    it("should handle JSON parsing errors", async () => {
+      mockMinioClient.getObject.mockResolvedValue(
+        createMockStream("invalid json"),
+      );
 
-      const result = await (service as any).loadAnalysisFromGCS('test-id');
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('Failed to parse analysis JSON');
-    });
-
-    it('should handle MinIO download errors', async () => {
-      const networkError = new Error('Network error');
-      mockMinioClient.getObject.mockResolvedValue(createErrorStream(networkError));
-
-      const result = await (service as any).loadAnalysisFromGCS('test-id');
+      const result = await (service as any).loadAnalysisFromGCS("test-id");
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Failed to load analysis: Network error');
+      expect(result.error).toContain("Failed to parse analysis JSON");
     });
 
-    it('should handle analysis with plots as JSON strings', async () => {
+    it("should handle MinIO download errors", async () => {
+      const networkError = new Error("Network error");
+      mockMinioClient.getObject.mockResolvedValue(
+        createErrorStream(networkError),
+      );
+
+      const result = await (service as any).loadAnalysisFromGCS("test-id");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Failed to load analysis: Network error");
+    });
+
+    it("should handle analysis with plots as JSON strings", async () => {
       const mockAnalysis = {
         metrics: { total_return: 0.23 },
         plots: ['{"data": [], "layout": {}}'],
         tables: [],
-        status: 'success',
+        status: "success",
       };
 
-      mockMinioClient.getObject.mockResolvedValue(createMockStream(JSON.stringify(mockAnalysis)));
+      mockMinioClient.getObject.mockResolvedValue(
+        createMockStream(JSON.stringify(mockAnalysis)),
+      );
 
-      const result = await (service as any).loadAnalysisFromGCS('test-id');
+      const result = await (service as any).loadAnalysisFromGCS("test-id");
 
       expect(result.success).toBe(true);
       expect(result.data.plots[0]).toBe('{"data": [], "layout": {}}');
     });
   });
 
-  describe('findOne with analysis loading', () => {
-    const createMockBacktest = (status = 'completed') => ({
-      id: 'test-id',
-      name: 'Test Backtest',
+  describe("findOne with analysis loading", () => {
+    const createMockBacktest = (status = "completed") => ({
+      id: "test-id",
+      name: "Test Backtest",
       status,
       userId: uid,
       config: {},
       analysis: null,
       createdAt: new Date(),
       updatedAt: new Date(),
-      customBotId: 'bot-id',
+      customBotId: "bot-id",
     });
 
-    it('should include analysis for completed backtests', async () => {
+    it("should include analysis for completed backtests", async () => {
       const mockAnalysisData = {
         metrics: { total_return: 0.23 },
         plots: [],
@@ -197,69 +209,77 @@ describe('BacktestService Analysis Loading', () => {
       };
 
       mockRepository.findOne.mockResolvedValue(
-        Ok(createMockBacktest('completed')),
+        Ok(createMockBacktest("completed")),
       );
-      mockMinioClient.getObject.mockResolvedValue(createMockStream(JSON.stringify(mockAnalysisData)));
+      mockMinioClient.getObject.mockResolvedValue(
+        createMockStream(JSON.stringify(mockAnalysisData)),
+      );
 
-      const result = await service.findOne('test-id');
+      const result = await service.findOne("test-id");
 
       expect(result.success).toBe(true);
       expect(result.data.analysis).toEqual(mockAnalysisData);
     });
 
-    it('should not load analysis for non-completed backtests', async () => {
-      const runningBacktest = createMockBacktest('running');
+    it("should not load analysis for non-completed backtests", async () => {
+      const runningBacktest = createMockBacktest("running");
       mockRepository.findOne.mockResolvedValue(Ok(runningBacktest));
 
-      const result = await service.findOne('test-id');
+      const result = await service.findOne("test-id");
 
       expect(result.success).toBe(true);
       expect(result.data.analysis).toBeNull();
       expect(mockMinioClient.getObject).not.toHaveBeenCalled();
     });
 
-    it('should continue even if analysis loading fails', async () => {
-      const completedBacktest = createMockBacktest('completed');
+    it("should continue even if analysis loading fails", async () => {
+      const completedBacktest = createMockBacktest("completed");
       mockRepository.findOne.mockResolvedValue(Ok(completedBacktest));
-      
-      const networkError = new Error('Network error');
-      mockMinioClient.getObject.mockResolvedValue(createErrorStream(networkError));
 
-      const result = await service.findOne('test-id');
+      const networkError = new Error("Network error");
+      mockMinioClient.getObject.mockResolvedValue(
+        createErrorStream(networkError),
+      );
+
+      const result = await service.findOne("test-id");
 
       expect(result.success).toBe(true);
       expect(result.data.analysis).toBeNull();
     });
 
-    it('should handle repository errors', async () => {
-      mockRepository.findOne.mockResolvedValue(Failure('Database error'));
+    it("should handle repository errors", async () => {
+      mockRepository.findOne.mockResolvedValue(Failure("Database error"));
 
-      const result = await service.findOne('test-id');
+      const result = await service.findOne("test-id");
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Database error');
+      expect(result.error).toBe("Database error");
     });
 
-    it('should handle missing analysis file gracefully for completed backtest', async () => {
-      const completedBacktest = createMockBacktest('completed');
+    it("should handle missing analysis file gracefully for completed backtest", async () => {
+      const completedBacktest = createMockBacktest("completed");
       mockRepository.findOne.mockResolvedValue(Ok(completedBacktest));
-      
-      const noSuchKeyError = new Error('The specified key does not exist.');
-      (noSuchKeyError as any).code = 'NoSuchKey';
-      mockMinioClient.getObject.mockResolvedValue(createErrorStream(noSuchKeyError));
 
-      const result = await service.findOne('test-id');
+      const noSuchKeyError = new Error("The specified key does not exist.");
+      (noSuchKeyError as any).code = "NoSuchKey";
+      mockMinioClient.getObject.mockResolvedValue(
+        createErrorStream(noSuchKeyError),
+      );
+
+      const result = await service.findOne("test-id");
 
       expect(result.success).toBe(true);
       expect(result.data.analysis).toBeNull();
     });
 
-    it('should set analysis to null when file exists but loading fails', async () => {
-      const completedBacktest = createMockBacktest('completed');
+    it("should set analysis to null when file exists but loading fails", async () => {
+      const completedBacktest = createMockBacktest("completed");
       mockRepository.findOne.mockResolvedValue(Ok(completedBacktest));
-      mockMinioClient.getObject.mockResolvedValue(createMockStream('invalid json'));
+      mockMinioClient.getObject.mockResolvedValue(
+        createMockStream("invalid json"),
+      );
 
-      const result = await service.findOne('test-id');
+      const result = await service.findOne("test-id");
 
       expect(result.success).toBe(true);
       expect(result.data.analysis).toBeNull();

--- a/api/src/backtest/__tests__/backtest.controller.spec.ts
+++ b/api/src/backtest/__tests__/backtest.controller.spec.ts
@@ -1,34 +1,34 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { BacktestController } from '../backtest.controller';
-import { BacktestService } from '../backtest.service';
-import { BacktestRepository } from '../backtest.repository';
-import { AuthCombinedGuard } from '@/auth/auth-combined.guard';
-import { Backtest } from '../entities/backtest.entity';
-import { REQUEST } from '@nestjs/core';
-import { BacktestValidator } from '../backtest.validator';
-import { CustomBotService } from '@/custom-bot/custom-bot.service';
-import { Ok } from '@/common';
+import { Test, TestingModule } from "@nestjs/testing";
+import { BacktestController } from "../backtest.controller";
+import { BacktestService } from "../backtest.service";
+import { BacktestRepository } from "../backtest.repository";
+import { AuthCombinedGuard } from "@/auth/auth-combined.guard";
+import { Backtest } from "../entities/backtest.entity";
+import { REQUEST } from "@nestjs/core";
+import { BacktestValidator } from "../backtest.validator";
+import { CustomBotService } from "@/custom-bot/custom-bot.service";
+import { Ok } from "@/common";
 
-describe('BacktestController', () => {
+describe("BacktestController", () => {
   let controller: BacktestController;
   let repository: BacktestRepository;
   let module: TestingModule;
-  const uid = 'test-user-id';
+  const uid = "test-user-id";
 
   const mockCustomBot = {
-    id: 'custom-bot-id',
-    name: 'test-bot',
-    version: '1.0.0',
-    userId: 'test-user-id', // Make the test user the owner
-    status: 'approved',
+    id: "custom-bot-id",
+    name: "test-bot",
+    version: "1.0.0",
+    userId: "test-user-id", // Make the test user the owner
+    status: "approved",
     marketplace: { isPublished: true },
     config: {
       schema: {
         backtest: {
-          type: 'object',
+          type: "object",
           properties: {
-            type: { type: 'string' },
-            version: { type: 'string' },
+            type: { type: "string" },
+            version: { type: "string" },
           },
         },
       },
@@ -82,12 +82,12 @@ describe('BacktestController', () => {
     repository = module.get<BacktestRepository>(BacktestRepository);
   });
 
-  it('should be able to create a backtest', async () => {
+  it("should be able to create a backtest", async () => {
     const backtest = {
-      name: 'Test backtest',
+      name: "Test backtest",
       config: {
-        type: 'scheduled/test-bot',
-        version: '1.0.0',
+        type: "scheduled/test-bot",
+        version: "1.0.0",
       },
     } as Backtest;
 
@@ -96,7 +96,7 @@ describe('BacktestController', () => {
       success: true,
       error: null,
       data: {
-        id: 'test-id',
+        id: "test-id",
         ...backtest,
         customBotId: mockCustomBot.id,
       },
@@ -104,21 +104,21 @@ describe('BacktestController', () => {
 
     const result = await controller.create(backtest);
     expect(result).toEqual({
-      id: 'test-id',
+      id: "test-id",
       ...backtest,
       customBotId: mockCustomBot.id,
     });
     expect(service.create).toHaveBeenCalledWith(backtest);
   });
 
-  it('should be able to get all backtests', async () => {
+  it("should be able to get all backtests", async () => {
     const backtests = [
       {
-        id: 'test-id',
-        name: 'Test backtest',
+        id: "test-id",
+        name: "Test backtest",
         config: {
-          type: 'scheduled/test-bot',
-          version: '1.0.0',
+          type: "scheduled/test-bot",
+          version: "1.0.0",
         },
       },
     ] as Backtest[];
@@ -134,13 +134,13 @@ describe('BacktestController', () => {
     expect(result).toEqual(backtests);
   });
 
-  it('should be able to get a backtest by id', async () => {
+  it("should be able to get a backtest by id", async () => {
     const backtest = {
-      id: 'test-id',
-      name: 'Test backtest',
+      id: "test-id",
+      name: "Test backtest",
       config: {
-        type: 'scheduled/test-bot',
-        version: '1.0.0',
+        type: "scheduled/test-bot",
+        version: "1.0.0",
       },
     } as Backtest;
 
@@ -151,11 +151,11 @@ describe('BacktestController', () => {
       data: backtest,
     });
 
-    const result = await controller.findOne('test-id');
+    const result = await controller.findOne("test-id");
     expect(result).toEqual(backtest);
   });
 
-  it('should be able to remove a backtest', async () => {
+  it("should be able to remove a backtest", async () => {
     const service = module.get<BacktestService>(BacktestService);
     (service.remove as jest.Mock).mockResolvedValue({
       success: true,
@@ -163,8 +163,8 @@ describe('BacktestController', () => {
       data: null,
     });
 
-    const result = await controller.remove('test-id');
+    const result = await controller.remove("test-id");
     expect(result).toBeUndefined();
-    expect(service.remove).toHaveBeenCalledWith('test-id');
+    expect(service.remove).toHaveBeenCalledWith("test-id");
   });
 });

--- a/api/src/backtest/__tests__/backtest.integration.spec.ts
+++ b/api/src/backtest/__tests__/backtest.integration.spec.ts
@@ -1,91 +1,90 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
-import request from 'supertest';
-import { BacktestModule } from '../backtest.module';
-import { BacktestRepository } from '../backtest.repository';
-import { BacktestValidator } from '../backtest.validator';
-import { CustomBotService } from '@/custom-bot/custom-bot.service';
-import { AuthCombinedGuard } from '@/auth/auth-combined.guard';
-import { NatsService } from '@/nats/nats.service';
-import { Ok, Failure } from '@/common/result';
-import { Backtest } from '../entities/backtest.entity';
-import { CustomBot } from '@/custom-bot/custom-bot.types';
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication } from "@nestjs/common";
+import request from "supertest";
+import { BacktestModule } from "../backtest.module";
+import { BacktestRepository } from "../backtest.repository";
+import { BacktestValidator } from "../backtest.validator";
+import { CustomBotService } from "@/custom-bot/custom-bot.service";
+import { AuthCombinedGuard } from "@/auth/auth-combined.guard";
+import { NatsService } from "@/nats/nats.service";
+import { Ok, Failure } from "@/common/result";
+import { Backtest } from "../entities/backtest.entity";
+import { CustomBot } from "@/custom-bot/custom-bot.types";
 
-
-describe('Backtest API Integration Tests', () => {
+describe("Backtest API Integration Tests", () => {
   let app: INestApplication;
   let repository: jest.Mocked<BacktestRepository>;
   let backtestValidator: jest.Mocked<BacktestValidator>;
   let customBotService: jest.Mocked<CustomBotService>;
 
   const validBacktestConfig = {
-    name: 'Test Backtest',
+    name: "Test Backtest",
     config: {
-      type: 'scheduled/test-bot',
-      version: '1.0.0',
-      schedule: '0 9 * * 1-5', // Valid cron for scheduled bots
-      symbol: 'AAPL',
-      strategy: 'sma-crossover',
+      type: "scheduled/test-bot",
+      version: "1.0.0",
+      schedule: "0 9 * * 1-5", // Valid cron for scheduled bots
+      symbol: "AAPL",
+      strategy: "sma-crossover",
     },
   };
 
   const mockPublishedBot: CustomBot = {
-    id: 'published-bot-id',
-    name: 'test-bot',
-    version: '1.0.0',
-    userId: 'other-user-id',
-    status: 'published',
+    id: "published-bot-id",
+    name: "test-bot",
+    version: "1.0.0",
+    userId: "other-user-id",
+    status: "published",
     marketplace: {
       isPublished: true,
       price: 0,
-      description: 'Test marketplace bot',
-      tags: ['test'],
+      description: "Test marketplace bot",
+      tags: ["test"],
       installCount: 100,
       totalReviews: 5,
       revenue: 0,
     },
     config: {
-      name: 'test-bot',
-      description: 'Test bot for integration testing',
-      version: '1.0.0',
-      type: 'scheduled',
-      runtime: 'python3.11',
-      author: 'Test Author',
+      name: "test-bot",
+      description: "Test bot for integration testing",
+      version: "1.0.0",
+      type: "scheduled",
+      runtime: "python3.11",
+      author: "Test Author",
       entrypoints: {
-        bot: 'main.py',
-        backtest: 'backtest.py',
+        bot: "main.py",
+        backtest: "backtest.py",
       },
       schema: {
         backtest: {
-          type: 'object',
+          type: "object",
           properties: {
-            type: { type: 'string' },
-            version: { type: 'string' },
-            schedule: { type: 'string' },
-            symbol: { type: 'string' },
-            strategy: { type: 'string' },
+            type: { type: "string" },
+            version: { type: "string" },
+            schedule: { type: "string" },
+            symbol: { type: "string" },
+            strategy: { type: "string" },
           },
-          required: ['type', 'version', 'schedule', 'symbol', 'strategy'],
+          required: ["type", "version", "schedule", "symbol", "strategy"],
         },
-        bot: { type: 'object' },
+        bot: { type: "object" },
       },
-      readme: 'Test bot readme',
+      readme: "Test bot readme",
     },
-    filePath: 'gs://test-bucket/test-bot.zip',
+    filePath: "gs://test-bucket/test-bot.zip",
     createdAt: new Date(),
     updatedAt: new Date(),
   };
 
   const mockApprovedBotOwnedByUser: CustomBot = {
     ...mockPublishedBot,
-    id: 'approved-bot-id',
-    userId: 'test-user-123', // Owned by test user
-    status: 'approved',
+    id: "approved-bot-id",
+    userId: "test-user-123", // Owned by test user
+    status: "approved",
     marketplace: {
       isPublished: false,
       price: 0,
-      description: 'Test approved bot',
-      tags: ['test'],
+      description: "Test approved bot",
+      tags: ["test"],
       installCount: 0,
       totalReviews: 0,
       revenue: 0,
@@ -94,8 +93,8 @@ describe('Backtest API Integration Tests', () => {
 
   // Mock auth middleware
   const mockAuthMiddleware = (req: any, res: any, next: any) => {
-    req.userId = 'test-user-123';
-    req.user = { uid: 'test-user-123' };
+    req.userId = "test-user-123";
+    req.user = { uid: "test-user-123" };
     next();
   };
 
@@ -132,7 +131,7 @@ describe('Backtest API Integration Tests', () => {
     app = moduleFixture.createNestApplication();
 
     // Apply mock auth middleware
-    app.use('/backtest', mockAuthMiddleware);
+    app.use("/backtest", mockAuthMiddleware);
 
     await app.init();
 
@@ -149,15 +148,15 @@ describe('Backtest API Integration Tests', () => {
     jest.clearAllMocks();
   });
 
-  describe('POST /backtest (Create Backtest)', () => {
-    it('should create backtest for published custom bot successfully', async () => {
+  describe("POST /backtest (Create Backtest)", () => {
+    it("should create backtest for published custom bot successfully", async () => {
       const mockCreatedBacktest: Backtest = {
-        id: 'new-backtest-id',
-        name: 'Test Backtest',
+        id: "new-backtest-id",
+        name: "Test Backtest",
         config: validBacktestConfig.config,
-        analysis: '',
-        status: 'pending',
-        userId: 'test-user-123',
+        analysis: "",
+        status: "pending",
+        userId: "test-user-123",
         customBotId: mockPublishedBot.id,
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -175,18 +174,18 @@ describe('Backtest API Integration Tests', () => {
       repository.create.mockResolvedValue(Ok(mockCreatedBacktest));
 
       const response = await request(app.getHttpServer())
-        .post('/backtest')
+        .post("/backtest")
         .send(validBacktestConfig)
         .expect(201);
 
-      expect(response.body.id).toBe('new-backtest-id');
+      expect(response.body.id).toBe("new-backtest-id");
       expect(response.body.customBotId).toBe(mockPublishedBot.id);
-      expect(response.body.status).toBe('pending');
+      expect(response.body.status).toBe("pending");
 
       // Verify service calls
       expect(customBotService.getGlobalSpecificVersion).toHaveBeenCalledWith(
-        'test-bot',
-        '1.0.0',
+        "test-bot",
+        "1.0.0",
       );
       expect(backtestValidator.validate).toHaveBeenCalledWith(
         validBacktestConfig.config,
@@ -194,20 +193,20 @@ describe('Backtest API Integration Tests', () => {
       );
       expect(repository.create).toHaveBeenCalledWith({
         ...validBacktestConfig,
-        status: 'pending',
-        userId: 'test-user-123',
+        status: "pending",
+        userId: "test-user-123",
         customBotId: mockPublishedBot.id,
       });
     });
 
-    it('should create backtest for user-owned approved custom bot successfully', async () => {
+    it("should create backtest for user-owned approved custom bot successfully", async () => {
       const mockCreatedBacktest: Backtest = {
-        id: 'approved-backtest-id',
-        name: 'Test Backtest',
+        id: "approved-backtest-id",
+        name: "Test Backtest",
         config: validBacktestConfig.config,
-        analysis: '',
-        status: 'pending',
-        userId: 'test-user-123',
+        analysis: "",
+        status: "pending",
+        userId: "test-user-123",
         customBotId: mockApprovedBotOwnedByUser.id,
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -225,93 +224,93 @@ describe('Backtest API Integration Tests', () => {
       repository.create.mockResolvedValue(Ok(mockCreatedBacktest));
 
       const response = await request(app.getHttpServer())
-        .post('/backtest')
+        .post("/backtest")
         .send(validBacktestConfig)
         .expect(201);
 
-      expect(response.body.id).toBe('approved-backtest-id');
+      expect(response.body.id).toBe("approved-backtest-id");
       expect(response.body.customBotId).toBe(mockApprovedBotOwnedByUser.id);
-      expect(response.body.status).toBe('pending');
+      expect(response.body.status).toBe("pending");
     });
 
-    it('should return 400 when bot type is missing', async () => {
+    it("should return 400 when bot type is missing", async () => {
       const invalidConfig = {
-        name: 'Test Backtest',
+        name: "Test Backtest",
         config: {
-          version: '1.0.0',
-          symbol: 'AAPL',
+          version: "1.0.0",
+          symbol: "AAPL",
         },
       };
 
       const response = await request(app.getHttpServer())
-        .post('/backtest')
+        .post("/backtest")
         .send(invalidConfig)
         .expect(400);
 
-      expect(response.body.message).toBe('Bot type is required');
+      expect(response.body.message).toBe("Bot type is required");
     });
 
-    it('should return 400 when bot version is missing', async () => {
+    it("should return 400 when bot version is missing", async () => {
       const invalidConfig = {
-        name: 'Test Backtest',
+        name: "Test Backtest",
         config: {
-          type: 'scheduled/test-bot',
-          symbol: 'AAPL',
+          type: "scheduled/test-bot",
+          symbol: "AAPL",
         },
       };
 
       const response = await request(app.getHttpServer())
-        .post('/backtest')
+        .post("/backtest")
         .send(invalidConfig)
         .expect(400);
 
-      expect(response.body.message).toBe('Bot version is required');
+      expect(response.body.message).toBe("Bot version is required");
     });
 
-    it('should return 400 when bot type format is invalid', async () => {
+    it("should return 400 when bot type format is invalid", async () => {
       const invalidConfig = {
-        name: 'Test Backtest',
+        name: "Test Backtest",
         config: {
-          type: 'invalid-format',
-          version: '1.0.0',
+          type: "invalid-format",
+          version: "1.0.0",
         },
       };
 
       const response = await request(app.getHttpServer())
-        .post('/backtest')
+        .post("/backtest")
         .send(invalidConfig)
         .expect(400);
 
       expect(response.body.message).toBe(
-        'Invalid bot type format. Expected format: type/name',
+        "Invalid bot type format. Expected format: type/name",
       );
     });
 
-    it('should return 400 when custom bot is not found', async () => {
+    it("should return 400 when custom bot is not found", async () => {
       customBotService.getGlobalSpecificVersion.mockResolvedValue(
-        Failure('Custom bot not found'),
+        Failure("Custom bot not found"),
       );
 
       const response = await request(app.getHttpServer())
-        .post('/backtest')
+        .post("/backtest")
         .send(validBacktestConfig)
         .expect(400);
 
       expect(response.body.message).toBe(
-        'Custom bot not found: test-bot@1.0.0',
+        "Custom bot not found: test-bot@1.0.0",
       );
     });
 
-    it('should return 400 when user lacks authorization for non-published bot', async () => {
+    it("should return 400 when user lacks authorization for non-published bot", async () => {
       const unauthorizedBot: CustomBot = {
         ...mockPublishedBot,
-        userId: 'other-user-id',
-        status: 'approved', // Not published, not owned by user
+        userId: "other-user-id",
+        status: "approved", // Not published, not owned by user
         marketplace: {
           isPublished: false,
           price: 0,
-          description: 'Test approved bot',
-          tags: ['test'],
+          description: "Test approved bot",
+          tags: ["test"],
           installCount: 0,
           totalReviews: 0,
           revenue: 0,
@@ -323,74 +322,74 @@ describe('Backtest API Integration Tests', () => {
       );
 
       const response = await request(app.getHttpServer())
-        .post('/backtest')
+        .post("/backtest")
         .send(validBacktestConfig)
         .expect(400);
 
       expect(response.body.message).toBe(
-        'Insufficient permissions: Can only backtest published bots or your own approved bots',
+        "Insufficient permissions: Can only backtest published bots or your own approved bots",
       );
     });
 
-    it('should return 400 when config validation fails', async () => {
+    it("should return 400 when config validation fails", async () => {
       customBotService.getGlobalSpecificVersion.mockResolvedValue(
         Ok(mockPublishedBot),
       );
 
       // Mock validator to return validation errors
       backtestValidator.validate.mockResolvedValue(
-        Failure(['schedule is required', 'symbol must be a string']),
+        Failure(["schedule is required", "symbol must be a string"]),
       );
 
       const response = await request(app.getHttpServer())
-        .post('/backtest')
+        .post("/backtest")
         .send(validBacktestConfig)
         .expect(400);
 
       expect(response.body.message).toBe(
-        'Validation failed: schedule is required, symbol must be a string',
+        "Validation failed: schedule is required, symbol must be a string",
       );
     });
 
-    it('should return 400 when repository creation fails', async () => {
+    it("should return 400 when repository creation fails", async () => {
       customBotService.getGlobalSpecificVersion.mockResolvedValue(
         Ok(mockPublishedBot),
       );
       backtestValidator.validate.mockResolvedValue(Ok(true));
       repository.create.mockResolvedValue(
-        Failure('Database connection failed'),
+        Failure("Database connection failed"),
       );
 
       const response = await request(app.getHttpServer())
-        .post('/backtest')
+        .post("/backtest")
         .send(validBacktestConfig)
         .expect(400);
 
-      expect(response.body.message).toBe('Database connection failed');
+      expect(response.body.message).toBe("Database connection failed");
     });
   });
 
-  describe('GET /backtest (List Backtests)', () => {
-    it('should return all user backtests successfully', async () => {
+  describe("GET /backtest (List Backtests)", () => {
+    it("should return all user backtests successfully", async () => {
       const mockBacktests: Backtest[] = [
         {
-          id: 'backtest-1',
-          name: 'Backtest 1',
+          id: "backtest-1",
+          name: "Backtest 1",
           config: validBacktestConfig.config,
-          analysis: 'Sample analysis',
-          status: 'completed',
-          userId: 'test-user-123',
+          analysis: "Sample analysis",
+          status: "completed",
+          userId: "test-user-123",
           customBotId: mockPublishedBot.id,
           createdAt: new Date(),
           updatedAt: new Date(),
         },
         {
-          id: 'backtest-2',
-          name: 'Backtest 2',
+          id: "backtest-2",
+          name: "Backtest 2",
           config: validBacktestConfig.config,
-          analysis: '',
-          status: 'pending',
-          userId: 'test-user-123',
+          analysis: "",
+          status: "pending",
+          userId: "test-user-123",
           customBotId: mockApprovedBotOwnedByUser.id,
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -400,35 +399,35 @@ describe('Backtest API Integration Tests', () => {
       repository.findAll.mockResolvedValue(Ok(mockBacktests));
 
       const response = await request(app.getHttpServer())
-        .get('/backtest')
+        .get("/backtest")
         .expect(200);
 
       expect(response.body).toHaveLength(2);
-      expect(response.body[0].id).toBe('backtest-1');
-      expect(response.body[1].id).toBe('backtest-2');
-      expect(repository.findAll).toHaveBeenCalledWith('test-user-123');
+      expect(response.body[0].id).toBe("backtest-1");
+      expect(response.body[1].id).toBe("backtest-2");
+      expect(repository.findAll).toHaveBeenCalledWith("test-user-123");
     });
 
-    it('should return 404 when no backtests found', async () => {
-      repository.findAll.mockResolvedValue(Failure('No backtests found'));
+    it("should return 404 when no backtests found", async () => {
+      repository.findAll.mockResolvedValue(Failure("No backtests found"));
 
       const response = await request(app.getHttpServer())
-        .get('/backtest')
+        .get("/backtest")
         .expect(404);
 
-      expect(response.body.message).toBe('No backtests found');
+      expect(response.body.message).toBe("No backtests found");
     });
   });
 
-  describe('GET /backtest/:id (Get Specific Backtest)', () => {
-    it('should return specific backtest successfully', async () => {
+  describe("GET /backtest/:id (Get Specific Backtest)", () => {
+    it("should return specific backtest successfully", async () => {
       const mockBacktest: Backtest = {
-        id: 'specific-backtest-id',
-        name: 'Specific Backtest',
+        id: "specific-backtest-id",
+        name: "Specific Backtest",
         config: validBacktestConfig.config,
-        analysis: 'Detailed analysis results',
-        status: 'completed',
-        userId: 'test-user-123',
+        analysis: "Detailed analysis results",
+        status: "completed",
+        userId: "test-user-123",
         customBotId: mockPublishedBot.id,
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -437,68 +436,68 @@ describe('Backtest API Integration Tests', () => {
       repository.findOne.mockResolvedValue(Ok(mockBacktest));
 
       const response = await request(app.getHttpServer())
-        .get('/backtest/specific-backtest-id')
+        .get("/backtest/specific-backtest-id")
         .expect(200);
 
-      expect(response.body.id).toBe('specific-backtest-id');
-      expect(response.body.name).toBe('Specific Backtest');
-      expect(response.body.status).toBe('completed');
+      expect(response.body.id).toBe("specific-backtest-id");
+      expect(response.body.name).toBe("Specific Backtest");
+      expect(response.body.status).toBe("completed");
       expect(repository.findOne).toHaveBeenCalledWith(
-        'test-user-123',
-        'specific-backtest-id',
+        "test-user-123",
+        "specific-backtest-id",
       );
     });
 
-    it('should return 404 when backtest not found', async () => {
-      repository.findOne.mockResolvedValue(Failure('Backtest not found'));
+    it("should return 404 when backtest not found", async () => {
+      repository.findOne.mockResolvedValue(Failure("Backtest not found"));
 
       const response = await request(app.getHttpServer())
-        .get('/backtest/non-existent-id')
+        .get("/backtest/non-existent-id")
         .expect(404);
 
-      expect(response.body.message).toBe('Backtest not found');
+      expect(response.body.message).toBe("Backtest not found");
     });
   });
 
-  describe('DELETE /backtest/:id (Delete Backtest)', () => {
-    it('should delete backtest successfully', async () => {
+  describe("DELETE /backtest/:id (Delete Backtest)", () => {
+    it("should delete backtest successfully", async () => {
       repository.remove.mockResolvedValue(Ok(undefined));
 
       const response = await request(app.getHttpServer())
-        .delete('/backtest/backtest-to-delete')
+        .delete("/backtest/backtest-to-delete")
         .expect(200);
 
       expect(response.body).toEqual({});
       expect(repository.remove).toHaveBeenCalledWith(
-        'test-user-123',
-        'backtest-to-delete',
+        "test-user-123",
+        "backtest-to-delete",
       );
     });
 
-    it('should return 404 when backtest to delete not found', async () => {
+    it("should return 404 when backtest to delete not found", async () => {
       repository.remove.mockResolvedValue(
-        Failure('Backtest not found for deletion'),
+        Failure("Backtest not found for deletion"),
       );
 
       const response = await request(app.getHttpServer())
-        .delete('/backtest/non-existent-id')
+        .delete("/backtest/non-existent-id")
         .expect(404);
 
-      expect(response.body.message).toBe('Backtest not found for deletion');
+      expect(response.body.message).toBe("Backtest not found for deletion");
     });
   });
 
-  describe('Authorization Scenarios', () => {
-    it('should allow backtest creation for published bots by any user', async () => {
+  describe("Authorization Scenarios", () => {
+    it("should allow backtest creation for published bots by any user", async () => {
       const publishedBot: CustomBot = {
         ...mockPublishedBot,
-        userId: 'different-owner-id', // Different owner
-        status: 'published',
+        userId: "different-owner-id", // Different owner
+        status: "published",
         marketplace: {
           isPublished: true,
           price: 0,
-          description: 'Test marketplace bot',
-          tags: ['test'],
+          description: "Test marketplace bot",
+          tags: ["test"],
           installCount: 100,
           totalReviews: 5,
           revenue: 0,
@@ -511,12 +510,12 @@ describe('Backtest API Integration Tests', () => {
       backtestValidator.validate.mockResolvedValue(Ok(true));
       repository.create.mockResolvedValue(
         Ok({
-          id: 'authorized-backtest-id',
-          name: 'Authorized Backtest',
+          id: "authorized-backtest-id",
+          name: "Authorized Backtest",
           config: validBacktestConfig.config,
-          analysis: '',
-          status: 'pending',
-          userId: 'test-user-123',
+          analysis: "",
+          status: "pending",
+          userId: "test-user-123",
           customBotId: publishedBot.id,
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -524,17 +523,17 @@ describe('Backtest API Integration Tests', () => {
       );
 
       const response = await request(app.getHttpServer())
-        .post('/backtest')
+        .post("/backtest")
         .send(validBacktestConfig)
         .expect(201);
 
       expect(response.body.customBotId).toBe(publishedBot.id);
     });
 
-    it('should deny backtest creation for non-approved owned bots', async () => {
+    it("should deny backtest creation for non-approved owned bots", async () => {
       const pendingBot: CustomBot = {
         ...mockApprovedBotOwnedByUser,
-        status: 'pending_review', // Not approved yet
+        status: "pending_review", // Not approved yet
       };
 
       customBotService.getGlobalSpecificVersion.mockResolvedValue(
@@ -542,25 +541,25 @@ describe('Backtest API Integration Tests', () => {
       );
 
       const response = await request(app.getHttpServer())
-        .post('/backtest')
+        .post("/backtest")
         .send(validBacktestConfig)
         .expect(400);
 
       expect(response.body.message).toBe(
-        'Insufficient permissions: Can only backtest published bots or your own approved bots',
+        "Insufficient permissions: Can only backtest published bots or your own approved bots",
       );
     });
 
-    it('should deny backtest creation for approved bots owned by others', async () => {
+    it("should deny backtest creation for approved bots owned by others", async () => {
       const otherUserBot: CustomBot = {
         ...mockApprovedBotOwnedByUser,
-        userId: 'other-user-id', // Different owner
-        status: 'approved',
+        userId: "other-user-id", // Different owner
+        status: "approved",
         marketplace: {
           isPublished: false,
           price: 0,
-          description: 'Test approved bot',
-          tags: ['test'],
+          description: "Test approved bot",
+          tags: ["test"],
           installCount: 0,
           totalReviews: 0,
           revenue: 0,
@@ -572,24 +571,24 @@ describe('Backtest API Integration Tests', () => {
       );
 
       const response = await request(app.getHttpServer())
-        .post('/backtest')
+        .post("/backtest")
         .send(validBacktestConfig)
         .expect(400);
 
       expect(response.body.message).toBe(
-        'Insufficient permissions: Can only backtest published bots or your own approved bots',
+        "Insufficient permissions: Can only backtest published bots or your own approved bots",
       );
     });
   });
 
-  describe('Validation Scenarios', () => {
-    it('should validate scheduled bot requires cron schedule', async () => {
+  describe("Validation Scenarios", () => {
+    it("should validate scheduled bot requires cron schedule", async () => {
       const configWithoutSchedule = {
-        name: 'Test Backtest',
+        name: "Test Backtest",
         config: {
-          type: 'scheduled/test-bot',
-          version: '1.0.0',
-          symbol: 'AAPL',
+          type: "scheduled/test-bot",
+          version: "1.0.0",
+          symbol: "AAPL",
           // Missing schedule
         },
       };
@@ -598,27 +597,27 @@ describe('Backtest API Integration Tests', () => {
         Ok(mockPublishedBot),
       );
       backtestValidator.validate.mockResolvedValue(
-        Failure(['No schedule provided']),
+        Failure(["No schedule provided"]),
       );
 
       const response = await request(app.getHttpServer())
-        .post('/backtest')
+        .post("/backtest")
         .send(configWithoutSchedule)
         .expect(400);
 
       expect(response.body.message).toBe(
-        'Validation failed: No schedule provided',
+        "Validation failed: No schedule provided",
       );
     });
 
-    it('should validate against custom bot backtest schema', async () => {
+    it("should validate against custom bot backtest schema", async () => {
       const configWithInvalidFields = {
-        name: 'Test Backtest',
+        name: "Test Backtest",
         config: {
-          type: 'scheduled/test-bot',
-          version: '1.0.0',
-          schedule: '0 9 * * 1-5',
-          invalidField: 'should not be allowed',
+          type: "scheduled/test-bot",
+          version: "1.0.0",
+          schedule: "0 9 * * 1-5",
+          invalidField: "should not be allowed",
         },
       };
 
@@ -626,30 +625,30 @@ describe('Backtest API Integration Tests', () => {
         Ok(mockPublishedBot),
       );
       backtestValidator.validate.mockResolvedValue(
-        Failure(['invalidField is not allowed']),
+        Failure(["invalidField is not allowed"]),
       );
 
       const response = await request(app.getHttpServer())
-        .post('/backtest')
+        .post("/backtest")
         .send(configWithInvalidFields)
         .expect(400);
 
       expect(response.body.message).toBe(
-        'Validation failed: invalidField is not allowed',
+        "Validation failed: invalidField is not allowed",
       );
     });
   });
 
-  describe('End-to-end Workflow', () => {
-    it('should complete full backtest lifecycle: create -> list -> get -> delete', async () => {
+  describe("End-to-end Workflow", () => {
+    it("should complete full backtest lifecycle: create -> list -> get -> delete", async () => {
       // Step 1: Create backtest
       const mockCreatedBacktest: Backtest = {
-        id: 'e2e-backtest-id',
-        name: 'E2E Test Backtest',
+        id: "e2e-backtest-id",
+        name: "E2E Test Backtest",
         config: validBacktestConfig.config,
-        analysis: '',
-        status: 'pending',
-        userId: 'test-user-123',
+        analysis: "",
+        status: "pending",
+        userId: "test-user-123",
         customBotId: mockPublishedBot.id,
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -662,91 +661,91 @@ describe('Backtest API Integration Tests', () => {
       repository.create.mockResolvedValueOnce(Ok(mockCreatedBacktest));
 
       const createResponse = await request(app.getHttpServer())
-        .post('/backtest')
+        .post("/backtest")
         .send({
-          name: 'E2E Test Backtest',
+          name: "E2E Test Backtest",
           config: validBacktestConfig.config,
         })
         .expect(201);
 
-      expect(createResponse.body.id).toBe('e2e-backtest-id');
+      expect(createResponse.body.id).toBe("e2e-backtest-id");
 
       // Step 2: List backtests
       repository.findAll.mockResolvedValueOnce(Ok([mockCreatedBacktest]));
 
       const listResponse = await request(app.getHttpServer())
-        .get('/backtest')
+        .get("/backtest")
         .expect(200);
 
       expect(listResponse.body).toHaveLength(1);
-      expect(listResponse.body[0].id).toBe('e2e-backtest-id');
+      expect(listResponse.body[0].id).toBe("e2e-backtest-id");
 
       // Step 3: Get specific backtest
       repository.findOne.mockResolvedValueOnce(Ok(mockCreatedBacktest));
 
       const getResponse = await request(app.getHttpServer())
-        .get('/backtest/e2e-backtest-id')
+        .get("/backtest/e2e-backtest-id")
         .expect(200);
 
-      expect(getResponse.body.id).toBe('e2e-backtest-id');
-      expect(getResponse.body.name).toBe('E2E Test Backtest');
+      expect(getResponse.body.id).toBe("e2e-backtest-id");
+      expect(getResponse.body.name).toBe("E2E Test Backtest");
 
       // Step 4: Delete backtest
       repository.remove.mockResolvedValueOnce(Ok(undefined));
 
       await request(app.getHttpServer())
-        .delete('/backtest/e2e-backtest-id')
+        .delete("/backtest/e2e-backtest-id")
         .expect(200);
 
       expect(repository.remove).toHaveBeenCalledWith(
-        'test-user-123',
-        'e2e-backtest-id',
+        "test-user-123",
+        "e2e-backtest-id",
       );
     });
   });
 
-  describe('Error Handling', () => {
-    it('should handle custom bot service errors gracefully', async () => {
+  describe("Error Handling", () => {
+    it("should handle custom bot service errors gracefully", async () => {
       customBotService.getGlobalSpecificVersion.mockResolvedValue(
-        Failure('Custom bot service unavailable'),
+        Failure("Custom bot service unavailable"),
       );
 
       const response = await request(app.getHttpServer())
-        .post('/backtest')
+        .post("/backtest")
         .send(validBacktestConfig)
         .expect(400);
 
       expect(response.body.message).toBe(
-        'Custom bot not found: test-bot@1.0.0',
+        "Custom bot not found: test-bot@1.0.0",
       );
     });
 
-    it('should handle validator service errors gracefully', async () => {
+    it("should handle validator service errors gracefully", async () => {
       customBotService.getGlobalSpecificVersion.mockResolvedValue(
         Ok(mockPublishedBot),
       );
       backtestValidator.validate.mockResolvedValue(
-        Failure(['Validation service error']),
+        Failure(["Validation service error"]),
       );
 
       const response = await request(app.getHttpServer())
-        .post('/backtest')
+        .post("/backtest")
         .send(validBacktestConfig)
         .expect(400);
 
       expect(response.body.message).toBe(
-        'Validation failed: Validation service error',
+        "Validation failed: Validation service error",
       );
     });
 
-    it('should handle repository errors gracefully', async () => {
-      repository.findAll.mockResolvedValue(Failure('Database connection lost'));
+    it("should handle repository errors gracefully", async () => {
+      repository.findAll.mockResolvedValue(Failure("Database connection lost"));
 
       const response = await request(app.getHttpServer())
-        .get('/backtest')
+        .get("/backtest")
         .expect(404);
 
-      expect(response.body.message).toBe('Database connection lost');
+      expect(response.body.message).toBe("Database connection lost");
     });
   });
 });

--- a/api/src/backtest/__tests__/backtest.service.spec.ts
+++ b/api/src/backtest/__tests__/backtest.service.spec.ts
@@ -1,44 +1,44 @@
-import { BacktestService } from '../backtest.service';
-import { BacktestRepository } from '../backtest.repository';
-import { Test, TestingModule } from '@nestjs/testing';
-import { ConfigService } from '@nestjs/config';
-import { Backtest } from '../entities/backtest.entity';
-import { REQUEST } from '@nestjs/core';
-import { BacktestValidator } from '../backtest.validator';
-import { CustomBotService } from '@/custom-bot/custom-bot.service';
-import { NatsService } from '@/nats/nats.service';
-import { Ok, Failure } from '@/common';
+import { BacktestService } from "../backtest.service";
+import { BacktestRepository } from "../backtest.repository";
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigService } from "@nestjs/config";
+import { Backtest } from "../entities/backtest.entity";
+import { REQUEST } from "@nestjs/core";
+import { BacktestValidator } from "../backtest.validator";
+import { CustomBotService } from "@/custom-bot/custom-bot.service";
+import { NatsService } from "@/nats/nats.service";
+import { Ok, Failure } from "@/common";
 
-describe('BacktestService', () => {
+describe("BacktestService", () => {
   let service: BacktestService;
   let repository: BacktestRepository;
   let backtestValidator: BacktestValidator;
   let customBotService: CustomBotService;
   let natsService: NatsService;
-  const uid = 'test-user-id';
+  const uid = "test-user-id";
 
   const mockCustomBot = {
-    id: 'custom-bot-id',
-    name: 'test-bot',
-    version: '1.0.0',
-    userId: 'test-user-id', // Make the test user the owner
-    status: 'approved',
+    id: "custom-bot-id",
+    name: "test-bot",
+    version: "1.0.0",
+    userId: "test-user-id", // Make the test user the owner
+    status: "approved",
     marketplace: { isPublished: true },
     config: {
       entrypoints: {
-        bot: 'main.py',
-        backtest: 'backtest.py',
+        bot: "main.py",
+        backtest: "backtest.py",
       },
       schema: {
         bot: {
-          type: 'object',
+          type: "object",
           properties: {},
         },
         backtest: {
-          type: 'object',
+          type: "object",
           properties: {
-            type: { type: 'string' },
-            version: { type: 'string' },
+            type: { type: "string" },
+            version: { type: "string" },
           },
         },
       },
@@ -73,7 +73,7 @@ describe('BacktestService', () => {
         {
           provide: ConfigService,
           useValue: {
-            get: jest.fn().mockReturnValue('test-bucket'),
+            get: jest.fn().mockReturnValue("test-bucket"),
           },
         },
         {
@@ -95,12 +95,12 @@ describe('BacktestService', () => {
     natsService = module.get<NatsService>(NatsService);
   });
 
-  it('should be able to create a backtest', async () => {
+  it("should be able to create a backtest", async () => {
     const backtest = {
-      name: 'Test backtest',
+      name: "Test backtest",
       config: {
-        type: 'scheduled/test-bot',
-        version: '1.0.0',
+        type: "scheduled/test-bot",
+        version: "1.0.0",
       },
     } as Backtest;
 
@@ -117,7 +117,7 @@ describe('BacktestService', () => {
       success: true,
       error: null,
       data: {
-        id: 'test-id',
+        id: "test-id",
         ...backtest,
         customBotId: mockCustomBot.id,
       },
@@ -128,7 +128,7 @@ describe('BacktestService', () => {
       success: true,
       error: null,
       data: {
-        id: 'test-id',
+        id: "test-id",
         ...backtest,
         customBotId: mockCustomBot.id,
       },
@@ -136,18 +136,18 @@ describe('BacktestService', () => {
     expect(repository.create).toHaveBeenCalledWith({
       ...backtest,
       userId: uid,
-      status: 'pending',
+      status: "pending",
       customBotId: mockCustomBot.id,
     });
   });
 
-  it('should be able to get all backtests', async () => {
+  it("should be able to get all backtests", async () => {
     const backtests = [
       {
-        id: 'test-id',
-        name: 'Test backtest',
+        id: "test-id",
+        name: "Test backtest",
         config: {
-          type: 'alpaca/sma',
+          type: "alpaca/sma",
         },
       },
     ];
@@ -167,12 +167,12 @@ describe('BacktestService', () => {
     expect(repository.findAll).toHaveBeenCalledWith(uid);
   });
 
-  it('should be able to get a backtest by id', async () => {
+  it("should be able to get a backtest by id", async () => {
     const backtest = {
-      id: 'test-id',
-      name: 'Test backtest',
+      id: "test-id",
+      name: "Test backtest",
       config: {
-        type: 'alpaca/sma',
+        type: "alpaca/sma",
       },
     } as Backtest;
 
@@ -182,39 +182,38 @@ describe('BacktestService', () => {
       data: backtest,
     });
 
-    const result = await service.findOne('test-id');
+    const result = await service.findOne("test-id");
     expect(result).toEqual({
       success: true,
       error: null,
       data: backtest,
     });
-    expect(repository.findOne).toHaveBeenCalledWith(uid, 'test-id');
+    expect(repository.findOne).toHaveBeenCalledWith(uid, "test-id");
   });
 
-  it('should be able to remove a backtest', async () => {
+  it("should be able to remove a backtest", async () => {
     repository.remove = jest.fn().mockReturnValue({
       success: true,
       error: null,
       data: null,
     });
 
-    const result = await service.remove('test-id');
+    const result = await service.remove("test-id");
     expect(result).toEqual({
       success: true,
       error: null,
       data: null,
     });
-    expect(repository.remove).toHaveBeenCalledWith(uid, 'test-id');
+    expect(repository.remove).toHaveBeenCalledWith(uid, "test-id");
   });
 
-
-  describe('Bot Validation Tests', () => {
-    it('should fail when bot has no backtest entrypoint', async () => {
+  describe("Bot Validation Tests", () => {
+    it("should fail when bot has no backtest entrypoint", async () => {
       const createBacktestDto = {
-        name: 'Test backtest',
+        name: "Test backtest",
         config: {
-          type: 'custom/test-bot',
-          version: '1.0.0',
+          type: "custom/test-bot",
+          version: "1.0.0",
         },
       };
 
@@ -223,7 +222,7 @@ describe('BacktestService', () => {
         config: {
           ...mockCustomBot.config,
           entrypoints: {
-            bot: 'main.py',
+            bot: "main.py",
             // Missing backtest entrypoint
           },
         },
@@ -237,16 +236,16 @@ describe('BacktestService', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe(
-        'Bot does not support backtesting: missing backtest entrypoint',
+        "Bot does not support backtesting: missing backtest entrypoint",
       );
     });
 
-    it('should fail when bot has no backtest schema', async () => {
+    it("should fail when bot has no backtest schema", async () => {
       const createBacktestDto = {
-        name: 'Test backtest',
+        name: "Test backtest",
         config: {
-          type: 'custom/test-bot',
-          version: '1.0.0',
+          type: "custom/test-bot",
+          version: "1.0.0",
         },
       };
 
@@ -255,8 +254,8 @@ describe('BacktestService', () => {
         config: {
           ...mockCustomBot.config,
           entrypoints: {
-            bot: 'main.py',
-            backtest: 'backtest.py',
+            bot: "main.py",
+            backtest: "backtest.py",
           },
           schema: {
             bot: {},
@@ -273,16 +272,16 @@ describe('BacktestService', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe(
-        'Bot does not support backtesting: missing backtest schema',
+        "Bot does not support backtesting: missing backtest schema",
       );
     });
 
-    it('should fail when bot has neither backtest entrypoint nor schema', async () => {
+    it("should fail when bot has neither backtest entrypoint nor schema", async () => {
       const createBacktestDto = {
-        name: 'Test backtest',
+        name: "Test backtest",
         config: {
-          type: 'custom/test-bot',
-          version: '1.0.0',
+          type: "custom/test-bot",
+          version: "1.0.0",
         },
       };
 
@@ -291,7 +290,7 @@ describe('BacktestService', () => {
         config: {
           ...mockCustomBot.config,
           entrypoints: {
-            bot: 'main.py',
+            bot: "main.py",
             // No backtest entrypoint
           },
           schema: {
@@ -309,7 +308,7 @@ describe('BacktestService', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe(
-        'Bot does not support backtesting: missing backtest entrypoint',
+        "Bot does not support backtesting: missing backtest entrypoint",
       );
     });
   });

--- a/api/src/backtest/__tests__/backtest.validator.spec.ts
+++ b/api/src/backtest/__tests__/backtest.validator.spec.ts
@@ -1,57 +1,57 @@
-import { BacktestValidator } from '../backtest.validator';
-import { CustomBot } from '@/custom-bot/custom-bot.types';
-import { Result } from '@/common';
-import Ajv from 'ajv';
+import { BacktestValidator } from "../backtest.validator";
+import { CustomBot } from "@/custom-bot/custom-bot.types";
+import { Result } from "@/common";
+import Ajv from "ajv";
 
 // Mock Ajv
-jest.mock('ajv');
+jest.mock("ajv");
 
 // Mock ajv-formats
-jest.mock('ajv-formats', () => jest.fn());
+jest.mock("ajv-formats", () => jest.fn());
 
-describe('BacktestValidator', () => {
+describe("BacktestValidator", () => {
   let validator: BacktestValidator;
   let mockAjv: jest.Mocked<Ajv>;
   let mockValidate: jest.Mock & { errors?: any[] | null };
 
   const mockCustomBot: CustomBot = {
-    id: 'test-bot-id',
-    name: 'test-bot',
-    version: '1.0.0',
+    id: "test-bot-id",
+    name: "test-bot",
+    version: "1.0.0",
     config: {
-      name: 'test-bot',
-      description: 'Test bot',
-      version: '1.0.0',
-      type: 'scheduled',
-      runtime: 'python3.11',
-      author: 'test-author',
+      name: "test-bot",
+      description: "Test bot",
+      version: "1.0.0",
+      type: "scheduled",
+      runtime: "python3.11",
+      author: "test-author",
       entrypoints: {
-        bot: 'main.py',
-        backtest: 'backtest.py',
+        bot: "main.py",
+        backtest: "backtest.py",
       },
       schema: {
         backtest: {
-          type: 'object',
+          type: "object",
           properties: {
-            type: { type: 'string' },
-            symbol: { type: 'string' },
-            amount: { type: 'number' },
+            type: { type: "string" },
+            symbol: { type: "string" },
+            amount: { type: "number" },
           },
-          required: ['type', 'symbol', 'amount'],
+          required: ["type", "symbol", "amount"],
         },
         bot: {
-          type: 'object',
+          type: "object",
           properties: {
-            type: { type: 'string' },
+            type: { type: "string" },
           },
-          required: ['type'],
+          required: ["type"],
         },
       },
-      readme: 'Test bot readme',
+      readme: "Test bot readme",
     },
-    filePath: 'gs://bucket/test-bot/1.0.0/bot.zip',
-    userId: 'test-user-id',
-    status: 'approved',
+    filePath: "gs://bucket/test-bot/1.0.0/bot.zip",
+    userId: "test-user-id",
+    status: "approved",
     createdAt: new Date(),
     updatedAt: new Date(),
   };
@@ -81,26 +81,26 @@ describe('BacktestValidator', () => {
     validator = new BacktestValidator();
   });
 
-  describe('validate', () => {
+  describe("validate", () => {
     const validConfig = {
-      type: 'scheduled/test-bot',
-      symbol: 'BTC/USD',
+      type: "scheduled/test-bot",
+      symbol: "BTC/USD",
       amount: 1000,
     };
 
-    it('should return failure when no type is provided', async () => {
-      const config = { symbol: 'BTC/USD', amount: 1000 };
+    it("should return failure when no type is provided", async () => {
+      const config = { symbol: "BTC/USD", amount: 1000 };
 
       const result = await validator.validate(config, mockCustomBot);
 
       expect(result.success).toBe(false);
-      expect(result.error).toEqual(['No type provided']);
+      expect(result.error).toEqual(["No type provided"]);
     });
 
-    it('should return failure when type format is invalid', async () => {
+    it("should return failure when type format is invalid", async () => {
       const config = {
-        type: 'invalid-type-format',
-        symbol: 'BTC/USD',
+        type: "invalid-type-format",
+        symbol: "BTC/USD",
         amount: 1000,
       };
 
@@ -108,14 +108,14 @@ describe('BacktestValidator', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toEqual([
-        'Invalid bot type format. Expected format: type/name',
+        "Invalid bot type format. Expected format: type/name",
       ]);
     });
 
-    it('should return failure when bot type is not supported', async () => {
+    it("should return failure when bot type is not supported", async () => {
       const config = {
-        type: 'unsupported/test-bot',
-        symbol: 'BTC/USD',
+        type: "unsupported/test-bot",
+        symbol: "BTC/USD",
         amount: 1000,
       };
 
@@ -123,11 +123,11 @@ describe('BacktestValidator', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toEqual([
-        'Invalid bot type. Supported types are: scheduled, realtime, event',
+        "Invalid bot type. Supported types are: scheduled, realtime, event",
       ]);
     });
 
-    it('should return success when validation passes', async () => {
+    it("should return success when validation passes", async () => {
       mockValidate.mockReturnValue(true);
 
       const result = await validator.validate(validConfig, mockCustomBot);
@@ -140,20 +140,20 @@ describe('BacktestValidator', () => {
       expect(mockValidate).toHaveBeenCalledWith(validConfig);
     });
 
-    it('should return failure when schema validation fails', async () => {
+    it("should return failure when schema validation fails", async () => {
       const mockErrors = [
         {
-          instancePath: '/symbol',
-          schemaPath: '#/properties/symbol/type',
-          keyword: 'type',
-          params: { type: 'string' },
-          message: 'must be string',
+          instancePath: "/symbol",
+          schemaPath: "#/properties/symbol/type",
+          keyword: "type",
+          params: { type: "string" },
+          message: "must be string",
         },
         {
-          instancePath: '',
-          schemaPath: '#/required',
-          keyword: 'required',
-          params: { missingProperty: 'amount' },
+          instancePath: "",
+          schemaPath: "#/required",
+          keyword: "required",
+          params: { missingProperty: "amount" },
           message: "must have required property 'amount'",
         },
       ];
@@ -165,18 +165,18 @@ describe('BacktestValidator', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toEqual([
-        '/symbol must be string',
+        "/symbol must be string",
         "must have required property 'amount'",
       ]);
     });
 
-    it('should handle errors without instancePath', async () => {
+    it("should handle errors without instancePath", async () => {
       const mockErrors = [
         {
-          instancePath: '',
-          schemaPath: '#/required',
-          keyword: 'required',
-          params: { missingProperty: 'type' },
+          instancePath: "",
+          schemaPath: "#/required",
+          keyword: "required",
+          params: { missingProperty: "type" },
           message: "must have required property 'type'",
         },
       ];
@@ -190,7 +190,7 @@ describe('BacktestValidator', () => {
       expect(result.error).toEqual(["must have required property 'type'"]);
     });
 
-    it('should handle empty errors array', async () => {
+    it("should handle empty errors array", async () => {
       mockValidate.mockReturnValue(false);
       mockValidate.errors = [];
 
@@ -200,7 +200,7 @@ describe('BacktestValidator', () => {
       expect(result.error).toEqual([]);
     });
 
-    it('should handle null errors', async () => {
+    it("should handle null errors", async () => {
       mockValidate.mockReturnValue(false);
       mockValidate.errors = null;
 
@@ -210,15 +210,15 @@ describe('BacktestValidator', () => {
       expect(result.error).toEqual([]);
     });
 
-    it('should work with all supported bot types', async () => {
-      const botTypes = ['scheduled', 'realtime', 'event'];
+    it("should work with all supported bot types", async () => {
+      const botTypes = ["scheduled", "realtime", "event"];
 
       for (const botType of botTypes) {
         mockValidate.mockReturnValue(true);
 
         const config = {
           type: `${botType}/test-bot`,
-          symbol: 'BTC/USD',
+          symbol: "BTC/USD",
           amount: 1000,
         };
         const result = await validator.validate(config, mockCustomBot);
@@ -228,12 +228,12 @@ describe('BacktestValidator', () => {
       }
     });
 
-    it('should handle complex bot names with hyphens', async () => {
+    it("should handle complex bot names with hyphens", async () => {
       mockValidate.mockReturnValue(true);
 
       const config = {
-        type: 'scheduled/my-complex-bot-name',
-        symbol: 'BTC/USD',
+        type: "scheduled/my-complex-bot-name",
+        symbol: "BTC/USD",
         amount: 1000,
       };
       const result = await validator.validate(config, mockCustomBot);
@@ -242,7 +242,7 @@ describe('BacktestValidator', () => {
       expect(result.data).toBe(true);
     });
 
-    it('should use the correct backtest schema from custom bot', async () => {
+    it("should use the correct backtest schema from custom bot", async () => {
       mockValidate.mockReturnValue(true);
 
       const customBotWithDifferentSchema = {
@@ -251,20 +251,20 @@ describe('BacktestValidator', () => {
           ...mockCustomBot.config,
           schema: {
             backtest: {
-              type: 'object',
+              type: "object",
               properties: {
-                type: { type: 'string' },
-                strategy: { type: 'string' },
-                timeframe: { type: 'string' },
+                type: { type: "string" },
+                strategy: { type: "string" },
+                timeframe: { type: "string" },
               },
-              required: ['type', 'strategy', 'timeframe'],
+              required: ["type", "strategy", "timeframe"],
             },
             bot: {
-              type: 'object',
+              type: "object",
               properties: {
-                type: { type: 'string' },
+                type: { type: "string" },
               },
-              required: ['type'],
+              required: ["type"],
             },
           },
         },
@@ -281,7 +281,7 @@ describe('BacktestValidator', () => {
       );
     });
 
-    it('should create new Ajv instance with allErrors: true', async () => {
+    it("should create new Ajv instance with allErrors: true", async () => {
       mockValidate.mockReturnValue(true);
 
       await validator.validate(validConfig, mockCustomBot);
@@ -289,11 +289,11 @@ describe('BacktestValidator', () => {
       expect(Ajv).toHaveBeenCalledWith({ allErrors: true });
     });
 
-    it('should handle mixed case in bot type validation', async () => {
+    it("should handle mixed case in bot type validation", async () => {
       // Bot type should be validated as lowercase
       const config = {
-        type: 'Scheduled/test-bot',
-        symbol: 'BTC/USD',
+        type: "Scheduled/test-bot",
+        symbol: "BTC/USD",
         amount: 1000,
       };
 
@@ -301,16 +301,16 @@ describe('BacktestValidator', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toEqual([
-        'Invalid bot type format. Expected format: type/name',
+        "Invalid bot type format. Expected format: type/name",
       ]);
     });
 
-    it('should handle validation with numeric and special characters in bot names', async () => {
+    it("should handle validation with numeric and special characters in bot names", async () => {
       mockValidate.mockReturnValue(true);
 
       const config = {
-        type: 'scheduled/bot-123',
-        symbol: 'BTC/USD',
+        type: "scheduled/bot-123",
+        symbol: "BTC/USD",
         amount: 1000,
       };
       const result = await validator.validate(config, mockCustomBot);
@@ -319,10 +319,10 @@ describe('BacktestValidator', () => {
       expect(result.data).toBe(true);
     });
 
-    it('should reject bot type with invalid characters', async () => {
+    it("should reject bot type with invalid characters", async () => {
       const config = {
-        type: 'scheduled/bot_invalid',
-        symbol: 'BTC/USD',
+        type: "scheduled/bot_invalid",
+        symbol: "BTC/USD",
         amount: 1000,
       };
 
@@ -330,14 +330,14 @@ describe('BacktestValidator', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toEqual([
-        'Invalid bot type format. Expected format: type/name',
+        "Invalid bot type format. Expected format: type/name",
       ]);
     });
 
-    it('should reject bot type with uppercase characters', async () => {
+    it("should reject bot type with uppercase characters", async () => {
       const config = {
-        type: 'scheduled/BotName',
-        symbol: 'BTC/USD',
+        type: "scheduled/BotName",
+        symbol: "BTC/USD",
         amount: 1000,
       };
 
@@ -345,25 +345,25 @@ describe('BacktestValidator', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toEqual([
-        'Invalid bot type format. Expected format: type/name',
+        "Invalid bot type format. Expected format: type/name",
       ]);
     });
 
-    it('should reject bot type without slash separator', async () => {
-      const config = { type: 'scheduledbot', symbol: 'BTC/USD', amount: 1000 };
+    it("should reject bot type without slash separator", async () => {
+      const config = { type: "scheduledbot", symbol: "BTC/USD", amount: 1000 };
 
       const result = await validator.validate(config, mockCustomBot);
 
       expect(result.success).toBe(false);
       expect(result.error).toEqual([
-        'Invalid bot type format. Expected format: type/name',
+        "Invalid bot type format. Expected format: type/name",
       ]);
     });
 
-    it('should reject bot type with multiple slashes', async () => {
+    it("should reject bot type with multiple slashes", async () => {
       const config = {
-        type: 'scheduled/test/bot',
-        symbol: 'BTC/USD',
+        type: "scheduled/test/bot",
+        symbol: "BTC/USD",
         amount: 1000,
       };
 
@@ -371,38 +371,38 @@ describe('BacktestValidator', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toEqual([
-        'Invalid bot type format. Expected format: type/name',
+        "Invalid bot type format. Expected format: type/name",
       ]);
     });
 
-    it('should handle edge case with empty bot name', async () => {
-      const config = { type: 'scheduled/', symbol: 'BTC/USD', amount: 1000 };
+    it("should handle edge case with empty bot name", async () => {
+      const config = { type: "scheduled/", symbol: "BTC/USD", amount: 1000 };
 
       const result = await validator.validate(config, mockCustomBot);
 
       expect(result.success).toBe(false);
       expect(result.error).toEqual([
-        'Invalid bot type format. Expected format: type/name',
+        "Invalid bot type format. Expected format: type/name",
       ]);
     });
 
-    it('should handle edge case with empty bot type', async () => {
-      const config = { type: '/test-bot', symbol: 'BTC/USD', amount: 1000 };
+    it("should handle edge case with empty bot type", async () => {
+      const config = { type: "/test-bot", symbol: "BTC/USD", amount: 1000 };
 
       const result = await validator.validate(config, mockCustomBot);
 
       expect(result.success).toBe(false);
       expect(result.error).toEqual([
-        'Invalid bot type format. Expected format: type/name',
+        "Invalid bot type format. Expected format: type/name",
       ]);
     });
   });
 
-  describe('validateWithSchema', () => {
-    it('should be called internally by validate method', async () => {
+  describe("validateWithSchema", () => {
+    it("should be called internally by validate method", async () => {
       const validConfig = {
-        type: 'scheduled/test-bot',
-        symbol: 'BTC/USD',
+        type: "scheduled/test-bot",
+        symbol: "BTC/USD",
         amount: 1000,
       };
 

--- a/api/src/backtest/backtest-events.service.ts
+++ b/api/src/backtest/backtest-events.service.ts
@@ -1,7 +1,7 @@
-import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
-import { NatsService } from '@/nats/nats.service';
-import { BacktestRepository } from './backtest.repository';
-import { StringCodec } from 'nats';
+import { Injectable, OnModuleInit, OnModuleDestroy } from "@nestjs/common";
+import { NatsService } from "@/nats/nats.service";
+import { BacktestRepository } from "./backtest.repository";
+import { StringCodec } from "nats";
 
 interface BacktestCompletionEvent {
   backtest_id: string;
@@ -30,7 +30,7 @@ export class BacktestEventsService implements OnModuleInit, OnModuleDestroy {
       try {
         await sub.unsubscribe();
       } catch (error) {
-        console.error('Error unsubscribing from backtest events:', error);
+        console.error("Error unsubscribing from backtest events:", error);
       }
     }
   }
@@ -40,39 +40,42 @@ export class BacktestEventsService implements OnModuleInit, OnModuleDestroy {
       // Wait for NATS connection to be established
       let retries = 0;
       const maxRetries = 10;
-      
+
       while (retries < maxRetries && !(await this.natsService.isConnected())) {
-        console.log(`⏳ Waiting for NATS connection for backtest events... (${retries + 1}/${maxRetries})`);
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        console.log(
+          `⏳ Waiting for NATS connection for backtest events... (${retries + 1}/${maxRetries})`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 1000));
         retries++;
       }
 
       if (!(await this.natsService.isConnected())) {
-        console.error('❌ Failed to establish NATS connection for backtest event listeners');
+        console.error(
+          "❌ Failed to establish NATS connection for backtest event listeners",
+        );
         return;
       }
 
-      console.log('📡 Setting up backtest completion event listeners...');
+      console.log("📡 Setting up backtest completion event listeners...");
 
       // Listen for backtest completion events (using regular NATS, not JetStream)
       await this.subscribeToCompletionEvents();
 
-      console.log('✅ Backtest event listeners setup complete');
-
+      console.log("✅ Backtest event listeners setup complete");
     } catch (error) {
-      console.error('❌ Failed to setup backtest event listeners:', error);
+      console.error("❌ Failed to setup backtest event listeners:", error);
     }
   }
 
   private async subscribeToCompletionEvents() {
     const connection = (this.natsService as any).connection;
     if (!connection) {
-      throw new Error('NATS connection not available');
+      throw new Error("NATS connection not available");
     }
 
     // Subscribe to backtest completion events using regular NATS (not JetStream)
-    const subscription = connection.subscribe('the0.backtest.completed', {
-      queue: 'backtest-api-handlers',
+    const subscription = connection.subscribe("the0.backtest.completed", {
+      queue: "backtest-api-handlers",
     });
 
     this.subscriptions.push(subscription);
@@ -81,23 +84,29 @@ export class BacktestEventsService implements OnModuleInit, OnModuleDestroy {
     (async () => {
       for await (const msg of subscription) {
         try {
-          const eventData: BacktestCompletionEvent = JSON.parse(this.sc.decode(msg.data));
+          const eventData: BacktestCompletionEvent = JSON.parse(
+            this.sc.decode(msg.data),
+          );
           await this.handleCompletionEvent(eventData);
         } catch (error) {
-          console.error('Error processing backtest completion event:', error);
+          console.error("Error processing backtest completion event:", error);
         }
       }
     })();
 
-    console.log('📨 Subscribed to backtest completion events (the0.backtest.completed)');
+    console.log(
+      "📨 Subscribed to backtest completion events (the0.backtest.completed)",
+    );
   }
 
   private async handleCompletionEvent(event: BacktestCompletionEvent) {
     try {
-      console.log(`📥 Received backtest completion event for ${event.backtest_id}, success: ${event.success}`);
+      console.log(
+        `📥 Received backtest completion event for ${event.backtest_id}, success: ${event.success}`,
+      );
 
       // Determine the final status
-      const status = event.success ? 'completed' : 'failed';
+      const status = event.success ? "completed" : "failed";
 
       // Update the backtest status in PostgreSQL
       const updateResult = await this.backtestRepository.updateStatus(
@@ -106,22 +115,33 @@ export class BacktestEventsService implements OnModuleInit, OnModuleDestroy {
       );
 
       if (!updateResult.success) {
-        console.error(`❌ Failed to update backtest ${event.backtest_id} status:`, updateResult.error);
+        console.error(
+          `❌ Failed to update backtest ${event.backtest_id} status:`,
+          updateResult.error,
+        );
         return;
       }
 
-      console.log(`✅ Updated backtest ${event.backtest_id} status to ${status}`);
+      console.log(
+        `✅ Updated backtest ${event.backtest_id} status to ${status}`,
+      );
 
       // Log completion details
       if (event.error) {
-        console.log(`❌ Backtest ${event.backtest_id} failed with error: ${event.error}`);
+        console.log(
+          `❌ Backtest ${event.backtest_id} failed with error: ${event.error}`,
+        );
       } else {
         console.log(`🎉 Backtest ${event.backtest_id} completed successfully`);
-        console.log(`📁 Logs and analysis should be available at: backtests/${event.backtest_id}/logs.txt and backtests/${event.backtest_id}/analysis.json`);
+        console.log(
+          `📁 Logs and analysis should be available at: backtests/${event.backtest_id}/logs.txt and backtests/${event.backtest_id}/analysis.json`,
+        );
       }
-
     } catch (error) {
-      console.error(`❌ Error handling completion event for backtest ${event.backtest_id}:`, error);
+      console.error(
+        `❌ Error handling completion event for backtest ${event.backtest_id}:`,
+        error,
+      );
       throw error;
     }
   }

--- a/api/src/backtest/backtest.constants.ts
+++ b/api/src/backtest/backtest.constants.ts
@@ -1,4 +1,4 @@
 // NATS topics for backtest events
 export const BACKTEST_TOPICS = {
-  CREATED: 'the0.backtest.created',
+  CREATED: "the0.backtest.created",
 } as const;

--- a/api/src/backtest/backtest.controller.ts
+++ b/api/src/backtest/backtest.controller.ts
@@ -8,12 +8,12 @@ import {
   NotFoundException,
   BadRequestException,
   UseGuards,
-} from '@nestjs/common';
-import { BacktestService } from './backtest.service';
-import { CreateBacktestDto } from './dto/create-backtest.dto';
-import { AuthCombinedGuard } from '@/auth/auth-combined.guard';
+} from "@nestjs/common";
+import { BacktestService } from "./backtest.service";
+import { CreateBacktestDto } from "./dto/create-backtest.dto";
+import { AuthCombinedGuard } from "@/auth/auth-combined.guard";
 
-@Controller('backtest')
+@Controller("backtest")
 @UseGuards(AuthCombinedGuard)
 export class BacktestController {
   constructor(private readonly backtestService: BacktestService) {}
@@ -36,8 +36,8 @@ export class BacktestController {
     return result.data;
   }
 
-  @Get(':id')
-  async findOne(@Param('id') id: string) {
+  @Get(":id")
+  async findOne(@Param("id") id: string) {
     const result = await this.backtestService.findOne(id);
     if (!result.success) {
       throw new NotFoundException(result.error);
@@ -45,22 +45,22 @@ export class BacktestController {
     return result.data;
   }
 
-  @Delete(':id')
-  async remove(@Param('id') id: string) {
+  @Delete(":id")
+  async remove(@Param("id") id: string) {
     const result = await this.backtestService.remove(id);
     if (!result.success) {
       throw new NotFoundException(result.error);
     }
   }
 
-  @Get(':id/logs')
-  async getBacktestLogs(@Param('id') id: string) {
+  @Get(":id/logs")
+  async getBacktestLogs(@Param("id") id: string) {
     const result = await this.backtestService.getBacktestLogs(id);
 
     if (!result.success) {
       if (
-        result.error?.includes('not found') ||
-        result.error?.includes('access denied')
+        result.error?.includes("not found") ||
+        result.error?.includes("access denied")
       ) {
         throw new NotFoundException(result.error);
       }
@@ -70,7 +70,7 @@ export class BacktestController {
     return {
       success: true,
       data: result.data,
-      message: 'Logs retrieved successfully',
+      message: "Logs retrieved successfully",
     };
   }
 }

--- a/api/src/backtest/backtest.module.ts
+++ b/api/src/backtest/backtest.module.ts
@@ -1,21 +1,21 @@
-import { Module, forwardRef } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
-import { BacktestService } from './backtest.service';
-import { BacktestController } from './backtest.controller';
-import { BacktestRepository } from './backtest.repository';
-import { BacktestValidator } from './backtest.validator';
-import { BacktestEventsService } from './backtest-events.service';
-import { CustomBotModule } from '@/custom-bot/custom-bot.module';
-import { ApiKeyModule } from '@/api-key/api-key.module';
-import { NatsModule } from '@/nats/nats.module';
+import { Module, forwardRef } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { BacktestService } from "./backtest.service";
+import { BacktestController } from "./backtest.controller";
+import { BacktestRepository } from "./backtest.repository";
+import { BacktestValidator } from "./backtest.validator";
+import { BacktestEventsService } from "./backtest-events.service";
+import { CustomBotModule } from "@/custom-bot/custom-bot.module";
+import { ApiKeyModule } from "@/api-key/api-key.module";
+import { NatsModule } from "@/nats/nats.module";
 @Module({
-  imports: [
-    ConfigModule,
-    ApiKeyModule,
-    CustomBotModule,
-    NatsModule,
-  ],
+  imports: [ConfigModule, ApiKeyModule, CustomBotModule, NatsModule],
   controllers: [BacktestController],
-  providers: [BacktestService, BacktestRepository, BacktestValidator, BacktestEventsService],
+  providers: [
+    BacktestService,
+    BacktestRepository,
+    BacktestValidator,
+    BacktestEventsService,
+  ],
 })
 export class BacktestModule {}

--- a/api/src/backtest/backtest.repository.ts
+++ b/api/src/backtest/backtest.repository.ts
@@ -1,20 +1,23 @@
-import { Injectable } from '@nestjs/common';
-import { RoleRepository } from '@/common/role.repository';
-import { Backtest } from './entities/backtest.entity';
-import { Result, Ok, Failure } from '@/common/result';
-import { eq } from 'drizzle-orm';
+import { Injectable } from "@nestjs/common";
+import { RoleRepository } from "@/common/role.repository";
+import { Backtest } from "./entities/backtest.entity";
+import { Result, Ok, Failure } from "@/common/result";
+import { eq } from "drizzle-orm";
 
 @Injectable()
 export class BacktestRepository extends RoleRepository<Backtest> {
-  protected readonly tableName = 'backtests' as const;
+  protected readonly tableName = "backtests" as const;
 
-  async updateStatus(backtestId: string, status: string): Promise<Result<void, string>> {
+  async updateStatus(
+    backtestId: string,
+    status: string,
+  ): Promise<Result<void, string>> {
     try {
       console.log(`🔄 Updating backtest ${backtestId} status to ${status}`);
-      
+
       const result = await this.db
         .update(this.table)
-        .set({ 
+        .set({
           status,
           updatedAt: new Date(),
         })
@@ -26,7 +29,9 @@ export class BacktestRepository extends RoleRepository<Backtest> {
         return Failure(`Backtest not found: ${backtestId}`);
       }
 
-      console.log(`✅ Successfully updated backtest ${backtestId} status to ${status}`);
+      console.log(
+        `✅ Successfully updated backtest ${backtestId} status to ${status}`,
+      );
       return Ok(undefined);
     } catch (error: any) {
       console.error(`❌ Error updating backtest status:`, error);

--- a/api/src/backtest/backtest.validator.ts
+++ b/api/src/backtest/backtest.validator.ts
@@ -1,10 +1,10 @@
-import { Injectable } from '@nestjs/common';
-import { Result, Failure, Ok } from '@/common/result';
-import Ajv from 'ajv';
-import addFormats from 'ajv-formats';
-import { CustomBot } from '@/custom-bot/custom-bot.types';
-import { BOT_TYPE_PATTERN } from '@/bot/bot.constants';
-import { BOT_TYPES } from '@/custom-bot/custom-bot.types';
+import { Injectable } from "@nestjs/common";
+import { Result, Failure, Ok } from "@/common/result";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { CustomBot } from "@/custom-bot/custom-bot.types";
+import { BOT_TYPE_PATTERN } from "@/bot/bot.constants";
+import { BOT_TYPES } from "@/custom-bot/custom-bot.types";
 
 @Injectable()
 export class BacktestValidator {
@@ -16,20 +16,20 @@ export class BacktestValidator {
     const { type } = config;
 
     if (!type) {
-      return Failure<boolean, string[]>(['No type provided']);
+      return Failure<boolean, string[]>(["No type provided"]);
     }
 
     if (BOT_TYPE_PATTERN.test(type) === false) {
       return Failure<boolean, string[]>([
-        'Invalid bot type format. Expected format: type/name',
+        "Invalid bot type format. Expected format: type/name",
       ]);
     }
 
-    const [botType] = type.split('/');
+    const [botType] = type.split("/");
 
     if (!BOT_TYPES.includes(botType as any)) {
       return Failure<boolean, string[]>([
-        `Invalid bot type. Supported types are: ${BOT_TYPES.join(', ')}`,
+        `Invalid bot type. Supported types are: ${BOT_TYPES.join(", ")}`,
       ]);
     }
 
@@ -83,7 +83,7 @@ export class BacktestValidator {
   }
 
   private filterObjectProperties(obj: any, schema: any): any {
-    if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
+    if (!obj || typeof obj !== "object" || Array.isArray(obj)) {
       return obj;
     }
 
@@ -93,9 +93,9 @@ export class BacktestValidator {
     for (const key of Object.keys(schemaProperties)) {
       if (obj[key] !== undefined) {
         const propertySchema = schemaProperties[key];
-        
+
         // If property is an object and has its own schema, recursively filter
-        if (propertySchema.type === 'object' && propertySchema.properties) {
+        if (propertySchema.type === "object" && propertySchema.properties) {
           filtered[key] = this.filterObjectProperties(obj[key], propertySchema);
         } else {
           filtered[key] = obj[key];

--- a/api/src/backtest/dto/create-backtest.dto.ts
+++ b/api/src/backtest/dto/create-backtest.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsObject, IsString } from 'class-validator';
+import { IsNotEmpty, IsObject, IsString } from "class-validator";
 
 export class CreateBacktestDto {
   @IsNotEmpty()

--- a/api/src/bot/__tests__/bot.controller.spec.ts
+++ b/api/src/bot/__tests__/bot.controller.spec.ts
@@ -1,65 +1,65 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { BotController } from '../bot.controller';
-import { BotService } from '../bot.service';
-import { REQUEST } from '@nestjs/core';
-import { BotRepository } from '../bot.repository';
-import { Bot } from '../entities/bot.entity';
+import { Test, TestingModule } from "@nestjs/testing";
+import { BotController } from "../bot.controller";
+import { BotService } from "../bot.service";
+import { REQUEST } from "@nestjs/core";
+import { BotRepository } from "../bot.repository";
+import { Bot } from "../entities/bot.entity";
 import {
   BadRequestException,
   CanActivate,
   NotFoundException,
-} from '@nestjs/common';
-import { BotValidator } from '../bot.validator';
-import { ConfigModule } from '@nestjs/config';
-import { CustomBotService } from '@/custom-bot/custom-bot.service';
-import { AuthCombinedGuard } from '@/auth/auth-combined.guard';
-import { ApiKeyService } from '@/api-key/api-key.service';
-import { NatsService } from '@/nats/nats.service';
+} from "@nestjs/common";
+import { BotValidator } from "../bot.validator";
+import { ConfigModule } from "@nestjs/config";
+import { CustomBotService } from "@/custom-bot/custom-bot.service";
+import { AuthCombinedGuard } from "@/auth/auth-combined.guard";
+import { ApiKeyService } from "@/api-key/api-key.service";
+import { NatsService } from "@/nats/nats.service";
 // FeatureGateService removed for OSS version
-import { Ok } from '@/common/result';
+import { Ok } from "@/common/result";
 
-describe('BotController - Enhanced Tests', () => {
+describe("BotController - Enhanced Tests", () => {
   let controller: BotController;
   let service: BotService;
   let repository: BotRepository;
   let validator: BotValidator;
   let customBotService: CustomBotService;
-  const uid = 'test-user-id';
+  const uid = "test-user-id";
 
   const mockCustomBot = {
-    id: 'test-custom-bot',
-    name: 'test-custom-bot',
-    version: '1.0.0',
-    filePath: 'gs://test-bucket/test-custom-bot',
-    userId: 'another-user-id',
-    status: 'approved',
+    id: "test-custom-bot",
+    name: "test-custom-bot",
+    version: "1.0.0",
+    filePath: "gs://test-bucket/test-custom-bot",
+    userId: "another-user-id",
+    status: "approved",
     createdAt: new Date(),
     updatedAt: new Date(),
     config: {
-      name: 'test-custom-bot',
-      type: 'scheduled',
-      runtime: 'python3.11',
-      description: 'A test custom bot',
+      name: "test-custom-bot",
+      type: "scheduled",
+      runtime: "python3.11",
+      description: "A test custom bot",
       entrypoints: {
-        bot: 'bot.py',
-        backtest: 'backtest.py',
+        bot: "bot.py",
+        backtest: "backtest.py",
       },
       schema: {
         bot: {
-          type: 'object',
+          type: "object",
           properties: {
-            foo: { type: 'string' },
-            bar: { type: 'number' },
+            foo: { type: "string" },
+            bar: { type: "number" },
           },
-          required: ['foo', 'bar'],
+          required: ["foo", "bar"],
         },
       },
-      readme: 'This is a test custom bot',
+      readme: "This is a test custom bot",
       metadata: {
-        categories: ['test'],
-        instruments: ['BTC'],
-        exchanges: ['Binance'],
-        tags: ['test', 'bot'],
+        categories: ["test"],
+        instruments: ["BTC"],
+        exchanges: ["Binance"],
+        tags: ["test", "bot"],
       },
     },
     marketplace: {
@@ -67,7 +67,6 @@ describe('BotController - Enhanced Tests', () => {
       price: 0,
     },
   };
-
 
   const mockCustomBotService = {
     getGlobalSpecificVersion: jest.fn().mockResolvedValue({
@@ -91,9 +90,7 @@ describe('BotController - Enhanced Tests', () => {
     const mockForceGuard: CanActivate = { canActivate: jest.fn(() => true) };
 
     const module: TestingModule = await Test.createTestingModule({
-      imports: [
-        ConfigModule,
-      ],
+      imports: [ConfigModule],
       controllers: [BotController],
       providers: [
         BotService,
@@ -134,13 +131,13 @@ describe('BotController - Enhanced Tests', () => {
     jest.clearAllMocks();
   });
 
-  describe('create', () => {
+  describe("create", () => {
     const validBot = {
-      name: 'Test Bot',
+      name: "Test Bot",
       config: {
-        type: 'scheduled/test-bot',
-        version: '1.0.0',
-        foo: 'test',
+        type: "scheduled/test-bot",
+        version: "1.0.0",
+        foo: "test",
         bar: 123,
       },
     };
@@ -152,55 +149,55 @@ describe('BotController - Enhanced Tests', () => {
         data: null,
       });
 
-      jest.spyOn(repository, 'findAll').mockResolvedValue({
+      jest.spyOn(repository, "findAll").mockResolvedValue({
         success: true,
         error: null,
         data: [],
       });
 
-      jest.spyOn(repository, 'create').mockResolvedValue({
+      jest.spyOn(repository, "create").mockResolvedValue({
         success: true,
         error: null,
         data: {
-          id: 'test-id',
+          id: "test-id",
           ...validBot,
           userId: uid,
-          topic: 'the0-scheduled-custom-bot',
+          topic: "the0-scheduled-custom-bot",
         } as Bot,
       });
     });
 
-    it('should create a bot successfully', async () => {
-      jest.spyOn(repository, 'findOne').mockResolvedValue({
+    it("should create a bot successfully", async () => {
+      jest.spyOn(repository, "findOne").mockResolvedValue({
         success: true,
         error: null,
         data: {
-          id: 'test-id',
+          id: "test-id",
           ...validBot,
           userId: uid,
-          topic: 'the0-scheduled-custom-bot',
+          topic: "the0-scheduled-custom-bot",
         } as Bot,
       });
       const result = await controller.create(validBot);
 
       expect(result).toEqual({
-        id: 'test-id',
+        id: "test-id",
         ...validBot,
         userId: uid,
-        topic: 'the0-scheduled-custom-bot',
+        topic: "the0-scheduled-custom-bot",
       });
       expect(repository.create).toHaveBeenCalledWith({
         ...validBot,
         userId: uid,
-        topic: 'the0-scheduled-custom-bot',
+        topic: "the0-scheduled-custom-bot",
         customBotId: mockCustomBot.id,
       });
     });
 
-    it('should throw BadRequestException when service fails', async () => {
-      jest.spyOn(repository, 'create').mockResolvedValue({
+    it("should throw BadRequestException when service fails", async () => {
+      jest.spyOn(repository, "create").mockResolvedValue({
         success: false,
-        error: 'Creation failed',
+        error: "Creation failed",
         data: null,
       });
 
@@ -209,10 +206,10 @@ describe('BotController - Enhanced Tests', () => {
       );
     });
 
-    it('should throw BadRequestException for invalid bot type format', async () => {
+    it("should throw BadRequestException for invalid bot type format", async () => {
       const invalidBot = {
         ...validBot,
-        config: { ...validBot.config, type: 'invalid-format' },
+        config: { ...validBot.config, type: "invalid-format" },
       };
 
       await expect(controller.create(invalidBot)).rejects.toThrow(
@@ -220,10 +217,10 @@ describe('BotController - Enhanced Tests', () => {
       );
     });
 
-    it('should throw BadRequestException for invalid version format', async () => {
+    it("should throw BadRequestException for invalid version format", async () => {
       const invalidBot = {
         ...validBot,
-        config: { ...validBot.config, version: 'invalid-version' },
+        config: { ...validBot.config, version: "invalid-version" },
       };
 
       await expect(controller.create(invalidBot)).rejects.toThrow(
@@ -231,11 +228,11 @@ describe('BotController - Enhanced Tests', () => {
       );
     });
 
-    it('should throw BadRequestException when bot limit exceeded', async () => {
-      jest.spyOn(repository, 'findAll').mockResolvedValue({
+    it("should throw BadRequestException when bot limit exceeded", async () => {
+      jest.spyOn(repository, "findAll").mockResolvedValue({
         success: true,
         error: null,
-        data: [{ id: 'bot1' }, { id: 'bot2' }, { id: 'bot3' }] as Bot[],
+        data: [{ id: "bot1" }, { id: "bot2" }, { id: "bot3" }] as Bot[],
       });
 
       await expect(controller.create(validBot)).rejects.toThrow(
@@ -243,12 +240,12 @@ describe('BotController - Enhanced Tests', () => {
       );
     });
 
-    it('should throw BadRequestException when custom bot not found', async () => {
+    it("should throw BadRequestException when custom bot not found", async () => {
       mockCustomBotService.getGlobalSpecificVersion = jest
         .fn()
         .mockResolvedValue({
           success: false,
-          error: 'Bot not found',
+          error: "Bot not found",
           data: null,
         });
 
@@ -257,10 +254,10 @@ describe('BotController - Enhanced Tests', () => {
       );
     });
 
-    it('should throw BadRequestException when validation fails', async () => {
+    it("should throw BadRequestException when validation fails", async () => {
       validator.validate = jest.fn().mockReturnValue({
         success: false,
-        error: ['Invalid configuration'],
+        error: ["Invalid configuration"],
         data: null,
       });
 
@@ -272,14 +269,14 @@ describe('BotController - Enhanced Tests', () => {
     // Test removed - UserBotsService dependency not needed in OSS version
   });
 
-  describe('findAll', () => {
-    it('should return all bots successfully', async () => {
+  describe("findAll", () => {
+    it("should return all bots successfully", async () => {
       const bots = [
-        { id: 'bot1', name: 'Bot 1' },
-        { id: 'bot2', name: 'Bot 2' },
+        { id: "bot1", name: "Bot 1" },
+        { id: "bot2", name: "Bot 2" },
       ] as Bot[];
 
-      jest.spyOn(repository, 'findAll').mockResolvedValue({
+      jest.spyOn(repository, "findAll").mockResolvedValue({
         success: true,
         error: null,
         data: bots,
@@ -291,18 +288,18 @@ describe('BotController - Enhanced Tests', () => {
       expect(repository.findAll).toHaveBeenCalledWith(uid);
     });
 
-    it('should throw NotFoundException when service fails', async () => {
-      jest.spyOn(repository, 'findAll').mockResolvedValue({
+    it("should throw NotFoundException when service fails", async () => {
+      jest.spyOn(repository, "findAll").mockResolvedValue({
         success: false,
-        error: 'Database error',
+        error: "Database error",
         data: null,
       });
 
       await expect(controller.findAll()).rejects.toThrow(NotFoundException);
     });
 
-    it('should return empty array when no bots exist', async () => {
-      jest.spyOn(repository, 'findAll').mockResolvedValue({
+    it("should return empty array when no bots exist", async () => {
+      jest.spyOn(repository, "findAll").mockResolvedValue({
         success: true,
         error: null,
         data: [],
@@ -314,58 +311,58 @@ describe('BotController - Enhanced Tests', () => {
     });
   });
 
-  describe('findOne', () => {
+  describe("findOne", () => {
     const mockBot = {
-      id: 'test-id',
-      name: 'Test Bot',
-      config: { type: 'scheduled/test-bot', version: '1.0.0' },
+      id: "test-id",
+      name: "Test Bot",
+      config: { type: "scheduled/test-bot", version: "1.0.0" },
     } as Bot;
 
-    it('should return a bot successfully', async () => {
-      jest.spyOn(repository, 'findOne').mockResolvedValue({
+    it("should return a bot successfully", async () => {
+      jest.spyOn(repository, "findOne").mockResolvedValue({
         success: true,
         error: null,
         data: mockBot,
       });
 
-      const result = await controller.findOne('test-id');
+      const result = await controller.findOne("test-id");
 
       expect(result).toEqual(mockBot);
-      expect(repository.findOne).toHaveBeenCalledWith(uid, 'test-id');
+      expect(repository.findOne).toHaveBeenCalledWith(uid, "test-id");
     });
 
-    it('should throw NotFoundException when bot not found', async () => {
-      jest.spyOn(repository, 'findOne').mockResolvedValue({
+    it("should throw NotFoundException when bot not found", async () => {
+      jest.spyOn(repository, "findOne").mockResolvedValue({
         success: false,
-        error: 'Bot not found',
+        error: "Bot not found",
         data: null,
       });
 
-      await expect(controller.findOne('nonexistent-id')).rejects.toThrow(
+      await expect(controller.findOne("nonexistent-id")).rejects.toThrow(
         NotFoundException,
       );
     });
 
-    it('should handle invalid bot ID format', async () => {
-      jest.spyOn(repository, 'findOne').mockResolvedValue({
+    it("should handle invalid bot ID format", async () => {
+      jest.spyOn(repository, "findOne").mockResolvedValue({
         success: false,
-        error: 'Invalid ID format',
+        error: "Invalid ID format",
         data: null,
       });
 
-      await expect(controller.findOne('invalid-id')).rejects.toThrow(
+      await expect(controller.findOne("invalid-id")).rejects.toThrow(
         NotFoundException,
       );
     });
   });
 
-  describe('update', () => {
+  describe("update", () => {
     const updateData = {
-      name: 'Updated Bot',
+      name: "Updated Bot",
       config: {
-        type: 'scheduled/test-bot',
-        version: '1.0.0',
-        foo: 'updated',
+        type: "scheduled/test-bot",
+        version: "1.0.0",
+        foo: "updated",
         bar: 456,
       },
     };
@@ -378,120 +375,122 @@ describe('BotController - Enhanced Tests', () => {
       });
     });
 
-    it('should update a bot successfully', async () => {
-      const updatedBot = { id: 'test-id', ...updateData } as Bot;
+    it("should update a bot successfully", async () => {
+      const updatedBot = { id: "test-id", ...updateData } as Bot;
 
       // Reset the mock to return success for this test
-      mockCustomBotService.getGlobalSpecificVersion = jest.fn().mockResolvedValue({
-        success: true,
-        error: null,
-        data: mockCustomBot,
-      });
+      mockCustomBotService.getGlobalSpecificVersion = jest
+        .fn()
+        .mockResolvedValue({
+          success: true,
+          error: null,
+          data: mockCustomBot,
+        });
 
-      jest.spyOn(repository, 'update').mockResolvedValue({
+      jest.spyOn(repository, "update").mockResolvedValue({
         success: true,
         error: null,
         data: updatedBot,
       });
 
-      const result = await controller.update('test-id', updateData);
+      const result = await controller.update("test-id", updateData);
 
       expect(result).toEqual(updatedBot);
       expect(repository.update).toHaveBeenCalledWith(
         uid,
-        'test-id',
+        "test-id",
         updateData,
       );
     });
 
-    it('should throw BadRequestException when update fails', async () => {
-      jest.spyOn(repository, 'update').mockResolvedValue({
+    it("should throw BadRequestException when update fails", async () => {
+      jest.spyOn(repository, "update").mockResolvedValue({
         success: false,
-        error: 'Update failed',
+        error: "Update failed",
         data: null,
       });
 
-      await expect(controller.update('test-id', updateData)).rejects.toThrow(
+      await expect(controller.update("test-id", updateData)).rejects.toThrow(
         BadRequestException,
       );
     });
 
-    it('should throw BadRequestException when validation fails', async () => {
+    it("should throw BadRequestException when validation fails", async () => {
       validator.validate = jest.fn().mockReturnValue({
         success: false,
-        error: ['Invalid configuration'],
+        error: ["Invalid configuration"],
         data: null,
       });
 
-      await expect(controller.update('test-id', updateData)).rejects.toThrow(
+      await expect(controller.update("test-id", updateData)).rejects.toThrow(
         BadRequestException,
       );
     });
 
-    it('should throw BadRequestException for invalid bot type on update', async () => {
+    it("should throw BadRequestException for invalid bot type on update", async () => {
       mockCustomBotService.getGlobalSpecificVersion = jest
         .fn()
         .mockResolvedValue({
           success: false,
-          error: 'Bot type not found',
+          error: "Bot type not found",
           data: null,
         });
 
-      await expect(controller.update('test-id', updateData)).rejects.toThrow(
+      await expect(controller.update("test-id", updateData)).rejects.toThrow(
         BadRequestException,
       );
     });
   });
 
-  describe('remove', () => {
-    it('should remove a bot successfully', async () => {
+  describe("remove", () => {
+    it("should remove a bot successfully", async () => {
       const mockBot = {
-        id: 'test-id',
-        name: 'Test Bot',
-        config: { type: 'scheduled/test-bot', version: '1.0.0' },
-        topic: 'the0-scheduled-custom-bot',
+        id: "test-id",
+        name: "Test Bot",
+        config: { type: "scheduled/test-bot", version: "1.0.0" },
+        topic: "the0-scheduled-custom-bot",
         userId: uid,
         createdAt: new Date(),
         updatedAt: new Date(),
-        customBotId: 'custom-bot-123',
+        customBotId: "custom-bot-123",
       } as Bot;
 
-      jest.spyOn(repository, 'findOne').mockResolvedValue({
+      jest.spyOn(repository, "findOne").mockResolvedValue({
         success: true,
         error: null,
         data: mockBot,
       });
 
-      jest.spyOn(repository, 'remove').mockResolvedValue({
+      jest.spyOn(repository, "remove").mockResolvedValue({
         success: true,
         error: null,
         data: null,
       });
 
-      await expect(controller.remove('test-id')).resolves.toBeUndefined();
-      expect(repository.remove).toHaveBeenCalledWith(uid, 'test-id');
+      await expect(controller.remove("test-id")).resolves.toBeUndefined();
+      expect(repository.remove).toHaveBeenCalledWith(uid, "test-id");
     });
 
-    it('should throw BadRequestException when removal fails', async () => {
-      jest.spyOn(repository, 'remove').mockResolvedValue({
+    it("should throw BadRequestException when removal fails", async () => {
+      jest.spyOn(repository, "remove").mockResolvedValue({
         success: false,
-        error: 'Bot not found',
+        error: "Bot not found",
         data: null,
       });
 
-      await expect(controller.remove('test-id')).rejects.toThrow(
+      await expect(controller.remove("test-id")).rejects.toThrow(
         BadRequestException,
       );
     });
 
-    it('should handle unauthorized removal attempt', async () => {
-      jest.spyOn(repository, 'remove').mockResolvedValue({
+    it("should handle unauthorized removal attempt", async () => {
+      jest.spyOn(repository, "remove").mockResolvedValue({
         success: false,
-        error: 'Unauthorized',
+        error: "Unauthorized",
         data: null,
       });
 
-      await expect(controller.remove('test-id')).rejects.toThrow(
+      await expect(controller.remove("test-id")).rejects.toThrow(
         BadRequestException,
       );
     });

--- a/api/src/bot/__tests__/bot.repository.spec.ts
+++ b/api/src/bot/__tests__/bot.repository.spec.ts
@@ -1,8 +1,8 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { BotRepository } from '../bot.repository';
-import { Ok, Failure } from '@/common/result';
+import { Test, TestingModule } from "@nestjs/testing";
+import { BotRepository } from "../bot.repository";
+import { Ok, Failure } from "@/common/result";
 
-describe('BotRepository', () => {
+describe("BotRepository", () => {
   let repository: BotRepository;
 
   beforeEach(async () => {
@@ -16,87 +16,89 @@ describe('BotRepository', () => {
     jest.clearAllMocks();
   });
 
-  describe('create', () => {
+  describe("create", () => {
     const botData = {
-      name: 'Test Bot',
+      name: "Test Bot",
       config: {
-        type: 'scheduled/test-bot',
-        version: '1.0.0',
-        foo: 'test',
+        type: "scheduled/test-bot",
+        version: "1.0.0",
+        foo: "test",
         bar: 123,
       },
-      userId: 'user-123',
-      topic: 'the0-scheduled-custom-bot',
-      customBotId: 'custom-bot-123',
+      userId: "user-123",
+      topic: "the0-scheduled-custom-bot",
+      customBotId: "custom-bot-123",
     };
 
-    it('should create a bot successfully', async () => {
+    it("should create a bot successfully", async () => {
       const mockBotResult = {
-        id: 'test-bot-id',
+        id: "test-bot-id",
         ...botData,
         createdAt: new Date(),
         updatedAt: new Date(),
       };
 
-      jest.spyOn(repository, 'create').mockResolvedValue(Ok(mockBotResult));
+      jest.spyOn(repository, "create").mockResolvedValue(Ok(mockBotResult));
 
       const result = await repository.create(botData);
 
       expect(result.success).toBe(true);
-      expect(result.data.id).toBe('test-bot-id');
-      expect(result.data.name).toBe('Test Bot');
-      expect(result.data.userId).toBe('user-123');
+      expect(result.data.id).toBe("test-bot-id");
+      expect(result.data.name).toBe("Test Bot");
+      expect(result.data.userId).toBe("user-123");
     });
 
-    it('should handle creation errors', async () => {
-      jest.spyOn(repository, 'create').mockResolvedValue(Failure('Database error'));
+    it("should handle creation errors", async () => {
+      jest
+        .spyOn(repository, "create")
+        .mockResolvedValue(Failure("Database error"));
 
       const result = await repository.create(botData);
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Database error');
+      expect(result.error).toBe("Database error");
     });
   });
 
-  describe('findAll', () => {
-    const userId = 'user-123';
+  describe("findAll", () => {
+    const userId = "user-123";
 
-    it('should find all bots for a user', async () => {
+    it("should find all bots for a user", async () => {
       const mockBots = [
         {
-          id: 'bot-1',
-          name: 'Bot 1',
-          userId: 'user-123',
-          config: { type: 'scheduled/bot1', version: '1.0.0' },
-          topic: 'the0-scheduled-custom-bot',
-          customBotId: 'custom-bot-1',
+          id: "bot-1",
+          name: "Bot 1",
+          userId: "user-123",
+          config: { type: "scheduled/bot1", version: "1.0.0" },
+          topic: "the0-scheduled-custom-bot",
+          customBotId: "custom-bot-1",
           createdAt: new Date(),
           updatedAt: new Date(),
         },
         {
-          id: 'bot-2',
-          name: 'Bot 2',
-          userId: 'user-123',
-          config: { type: 'scheduled/bot2', version: '1.0.0' },
-          topic: 'the0-scheduled-custom-bot',
-          customBotId: 'custom-bot-2',
+          id: "bot-2",
+          name: "Bot 2",
+          userId: "user-123",
+          config: { type: "scheduled/bot2", version: "1.0.0" },
+          topic: "the0-scheduled-custom-bot",
+          customBotId: "custom-bot-2",
           createdAt: new Date(),
           updatedAt: new Date(),
         },
       ];
 
-      jest.spyOn(repository, 'findAll').mockResolvedValue(Ok(mockBots));
+      jest.spyOn(repository, "findAll").mockResolvedValue(Ok(mockBots));
 
       const result = await repository.findAll(userId);
 
       expect(result.success).toBe(true);
       expect(result.data).toHaveLength(2);
-      expect(result.data[0].name).toBe('Bot 1');
-      expect(result.data[1].name).toBe('Bot 2');
+      expect(result.data[0].name).toBe("Bot 1");
+      expect(result.data[1].name).toBe("Bot 2");
     });
 
-    it('should return empty array when no bots exist', async () => {
-      jest.spyOn(repository, 'findAll').mockResolvedValue(Ok([]));
+    it("should return empty array when no bots exist", async () => {
+      jest.spyOn(repository, "findAll").mockResolvedValue(Ok([]));
 
       const result = await repository.findAll(userId);
 
@@ -104,144 +106,152 @@ describe('BotRepository', () => {
       expect(result.data).toEqual([]);
     });
 
-    it('should handle query errors', async () => {
-      jest.spyOn(repository, 'findAll').mockResolvedValue(Failure('Query error'));
+    it("should handle query errors", async () => {
+      jest
+        .spyOn(repository, "findAll")
+        .mockResolvedValue(Failure("Query error"));
 
       const result = await repository.findAll(userId);
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Query error');
+      expect(result.error).toBe("Query error");
     });
   });
 
-  describe('findOne', () => {
-    const userId = 'user-123';
-    const botId = 'bot-123';
+  describe("findOne", () => {
+    const userId = "user-123";
+    const botId = "bot-123";
 
-    it('should find a specific bot', async () => {
+    it("should find a specific bot", async () => {
       const mockBot = {
         id: botId,
-        name: 'Test Bot',
+        name: "Test Bot",
         userId: userId,
         config: {
-          type: 'scheduled/test',
-          version: '1.0.0',
+          type: "scheduled/test",
+          version: "1.0.0",
         },
-        topic: 'the0-scheduled-custom-bot',
-        customBotId: 'custom-bot-123',
+        topic: "the0-scheduled-custom-bot",
+        customBotId: "custom-bot-123",
         createdAt: new Date(),
         updatedAt: new Date(),
       };
 
-      jest.spyOn(repository, 'findOne').mockResolvedValue(Ok(mockBot));
+      jest.spyOn(repository, "findOne").mockResolvedValue(Ok(mockBot));
 
       const result = await repository.findOne(userId, botId);
 
       expect(result.success).toBe(true);
       expect(result.data.id).toBe(botId);
-      expect(result.data.name).toBe('Test Bot');
+      expect(result.data.name).toBe("Test Bot");
       expect(result.data.userId).toBe(userId);
     });
 
-    it('should return failure when bot not found', async () => {
-      jest.spyOn(repository, 'findOne').mockResolvedValue(Failure('Not found'));
+    it("should return failure when bot not found", async () => {
+      jest.spyOn(repository, "findOne").mockResolvedValue(Failure("Not found"));
 
       const result = await repository.findOne(userId, botId);
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Not found');
+      expect(result.error).toBe("Not found");
     });
 
-    it('should handle query errors', async () => {
-      jest.spyOn(repository, 'findOne').mockResolvedValue(Failure('Database error'));
+    it("should handle query errors", async () => {
+      jest
+        .spyOn(repository, "findOne")
+        .mockResolvedValue(Failure("Database error"));
 
       const result = await repository.findOne(userId, botId);
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Database error');
+      expect(result.error).toBe("Database error");
     });
   });
 
-  describe('update', () => {
-    const userId = 'user-123';
-    const botId = 'bot-123';
+  describe("update", () => {
+    const userId = "user-123";
+    const botId = "bot-123";
     const updateData = {
-      name: 'Updated Bot',
+      name: "Updated Bot",
       config: {
-        type: 'scheduled/updated',
-        version: '1.1.0',
-        foo: 'updated',
+        type: "scheduled/updated",
+        version: "1.1.0",
+        foo: "updated",
       },
     };
 
-    it('should update a bot successfully', async () => {
+    it("should update a bot successfully", async () => {
       const updatedBot = {
         id: botId,
         ...updateData,
         userId: userId,
-        topic: 'the0-scheduled-custom-bot',
-        customBotId: 'custom-bot-123',
-        createdAt: new Date('2024-01-01'),
+        topic: "the0-scheduled-custom-bot",
+        customBotId: "custom-bot-123",
+        createdAt: new Date("2024-01-01"),
         updatedAt: new Date(),
       };
 
-      jest.spyOn(repository, 'update').mockResolvedValue(Ok(updatedBot));
+      jest.spyOn(repository, "update").mockResolvedValue(Ok(updatedBot));
 
       const result = await repository.update(userId, botId, updateData);
 
       expect(result.success).toBe(true);
       expect(result.data.id).toBe(botId);
-      expect(result.data.name).toBe('Updated Bot');
-      expect(result.data.config.version).toBe('1.1.0');
+      expect(result.data.name).toBe("Updated Bot");
+      expect(result.data.config.version).toBe("1.1.0");
     });
 
-    it('should return failure when bot not found', async () => {
-      jest.spyOn(repository, 'update').mockResolvedValue(Failure('Not found'));
+    it("should return failure when bot not found", async () => {
+      jest.spyOn(repository, "update").mockResolvedValue(Failure("Not found"));
 
       const result = await repository.update(userId, botId, updateData);
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Not found');
+      expect(result.error).toBe("Not found");
     });
 
-    it('should handle update errors', async () => {
-      jest.spyOn(repository, 'update').mockResolvedValue(Failure('Update error'));
+    it("should handle update errors", async () => {
+      jest
+        .spyOn(repository, "update")
+        .mockResolvedValue(Failure("Update error"));
 
       const result = await repository.update(userId, botId, updateData);
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Update error');
+      expect(result.error).toBe("Update error");
     });
   });
 
-  describe('remove', () => {
-    const userId = 'user-123';
-    const botId = 'bot-123';
+  describe("remove", () => {
+    const userId = "user-123";
+    const botId = "bot-123";
 
-    it('should remove a bot successfully', async () => {
-      jest.spyOn(repository, 'remove').mockResolvedValue(Ok(undefined));
+    it("should remove a bot successfully", async () => {
+      jest.spyOn(repository, "remove").mockResolvedValue(Ok(undefined));
 
       const result = await repository.remove(userId, botId);
 
       expect(result.success).toBe(true);
     });
 
-    it('should return failure when bot not found', async () => {
-      jest.spyOn(repository, 'remove').mockResolvedValue(Failure('Not found'));
+    it("should return failure when bot not found", async () => {
+      jest.spyOn(repository, "remove").mockResolvedValue(Failure("Not found"));
 
       const result = await repository.remove(userId, botId);
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Not found');
+      expect(result.error).toBe("Not found");
     });
 
-    it('should handle deletion errors', async () => {
-      jest.spyOn(repository, 'remove').mockResolvedValue(Failure('Deletion error'));
+    it("should handle deletion errors", async () => {
+      jest
+        .spyOn(repository, "remove")
+        .mockResolvedValue(Failure("Deletion error"));
 
       const result = await repository.remove(userId, botId);
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Deletion error');
+      expect(result.error).toBe("Deletion error");
     });
   });
 });

--- a/api/src/bot/__tests__/bot.service.spec.ts
+++ b/api/src/bot/__tests__/bot.service.spec.ts
@@ -1,59 +1,59 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { BotService } from '../bot.service';
-import { BotRepository } from '../bot.repository';
-import { Bot } from '../entities/bot.entity';
-import { REQUEST } from '@nestjs/core';
-import { BotValidator } from '../bot.validator';
-import { HttpModule } from '@nestjs/axios';
-import { ConfigModule } from '@nestjs/config';
-import { CustomBotModule } from '@/custom-bot/custom-bot.module';
-import { CustomBotService } from '@/custom-bot/custom-bot.service';
-import { NatsService } from '@/nats/nats.service';
+import { Test, TestingModule } from "@nestjs/testing";
+import { BotService } from "../bot.service";
+import { BotRepository } from "../bot.repository";
+import { Bot } from "../entities/bot.entity";
+import { REQUEST } from "@nestjs/core";
+import { BotValidator } from "../bot.validator";
+import { HttpModule } from "@nestjs/axios";
+import { ConfigModule } from "@nestjs/config";
+import { CustomBotModule } from "@/custom-bot/custom-bot.module";
+import { CustomBotService } from "@/custom-bot/custom-bot.service";
+import { NatsService } from "@/nats/nats.service";
 // FeatureGateService removed for OSS version
-import { Ok, Failure } from '@/common/result';
+import { Ok, Failure } from "@/common/result";
 
-describe('BotService - Enhanced Tests', () => {
+describe("BotService - Enhanced Tests", () => {
   let service: BotService;
   let repository: BotRepository;
   let validator: BotValidator;
   let mockCustomBotService: CustomBotService;
   // FeatureGateService removed for OSS version
-  const uid = 'test-user-id';
+  const uid = "test-user-id";
 
   const mockCustomBot = {
-    id: 'test-custom-bot',
-    name: 'test-custom-bot',
-    version: '1.0.0',
-    filePath: 'gs://test-bucket/test-custom-bot',
-    userId: 'another-user-id',
-    status: 'approved',
+    id: "test-custom-bot",
+    name: "test-custom-bot",
+    version: "1.0.0",
+    filePath: "gs://test-bucket/test-custom-bot",
+    userId: "another-user-id",
+    status: "approved",
     createdAt: new Date(),
     updatedAt: new Date(),
     config: {
-      name: 'test-custom-bot',
-      type: 'scheduled',
-      runtime: 'python3.11',
-      description: 'A test custom bot',
+      name: "test-custom-bot",
+      type: "scheduled",
+      runtime: "python3.11",
+      description: "A test custom bot",
       entrypoints: {
-        bot: 'bot.py',
-        backtest: 'backtest.py',
+        bot: "bot.py",
+        backtest: "backtest.py",
       },
       schema: {
         bot: {
-          type: 'object',
+          type: "object",
           properties: {
-            foo: { type: 'string' },
-            bar: { type: 'number' },
+            foo: { type: "string" },
+            bar: { type: "number" },
           },
-          required: ['foo', 'bar'],
+          required: ["foo", "bar"],
         },
       },
-      readme: 'This is a test custom bot',
+      readme: "This is a test custom bot",
       metadata: {
-        categories: ['test'],
-        instruments: ['BTC'],
-        exchanges: ['Binance'],
-        tags: ['test', 'bot'],
+        categories: ["test"],
+        instruments: ["BTC"],
+        exchanges: ["Binance"],
+        tags: ["test", "bot"],
       },
     },
     marketplace: {
@@ -80,7 +80,6 @@ describe('BotService - Enhanced Tests', () => {
       getAllGlobalVersions: jest.fn(),
       getAllUserSpecificVersions: jest.fn(),
     } as unknown as CustomBotService;
-
 
     // FeatureGateService removed for OSS version
 
@@ -115,13 +114,13 @@ describe('BotService - Enhanced Tests', () => {
     jest.clearAllMocks();
   });
 
-  describe('create', () => {
+  describe("create", () => {
     const validBotData = {
-      name: 'Test Bot',
+      name: "Test Bot",
       config: {
-        type: 'scheduled/test-custom-bot',
-        version: '1.0.0',
-        foo: 'test',
+        type: "scheduled/test-custom-bot",
+        version: "1.0.0",
+        foo: "test",
         bar: 123,
       },
     };
@@ -133,119 +132,119 @@ describe('BotService - Enhanced Tests', () => {
         data: null,
       });
 
-      jest.spyOn(repository, 'findAll').mockResolvedValue({
+      jest.spyOn(repository, "findAll").mockResolvedValue({
         success: true,
         error: null,
         data: [],
       });
 
-      jest.spyOn(repository, 'create').mockResolvedValue({
+      jest.spyOn(repository, "create").mockResolvedValue({
         success: true,
         error: null,
         data: {
-          id: 'test-id',
+          id: "test-id",
           ...validBotData,
           userId: uid,
-          topic: 'the0-scheduled-custom-bot',
+          topic: "the0-scheduled-custom-bot",
         } as Bot,
       });
     });
 
-    it('should create a bot successfully', async () => {
-      jest.spyOn(repository, 'findOne').mockResolvedValue({
+    it("should create a bot successfully", async () => {
+      jest.spyOn(repository, "findOne").mockResolvedValue({
         success: true,
         error: null,
         data: {
-          id: 'test-id',
+          id: "test-id",
           ...validBotData,
           userId: uid,
-          topic: 'the0-scheduled-custom-bot',
+          topic: "the0-scheduled-custom-bot",
         } as Bot,
       });
       const result = await service.create(validBotData);
 
       expect(result.success).toBe(true);
-      expect(result.data.id).toBe('test-id');
+      expect(result.data.id).toBe("test-id");
       // FeatureGateService removed for OSS version
       expect(repository.create).toHaveBeenCalledWith({
         ...validBotData,
-        topic: 'the0-scheduled-custom-bot',
+        topic: "the0-scheduled-custom-bot",
         userId: uid,
         customBotId: mockCustomBot.id,
       });
     });
 
-    it('should validate bot type and version format', async () => {
+    it("should validate bot type and version format", async () => {
       const invalidTypeBot = {
         ...validBotData,
-        config: { ...validBotData.config, type: 'invalid-format' },
+        config: { ...validBotData.config, type: "invalid-format" },
       };
 
       const result = await service.create(invalidTypeBot);
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Invalid bot type format');
+      expect(result.error).toContain("Invalid bot type format");
     });
 
-    it('should validate semantic version format', async () => {
+    it("should validate semantic version format", async () => {
       const invalidVersionBot = {
         ...validBotData,
-        config: { ...validBotData.config, version: 'invalid-version' },
+        config: { ...validBotData.config, version: "invalid-version" },
       };
 
       const result = await service.create(invalidVersionBot);
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Invalid version format');
+      expect(result.error).toContain("Invalid version format");
     });
 
     // Feature gate tests removed for OSS version
 
-    it('should fail when custom bot type not found', async () => {
+    it("should fail when custom bot type not found", async () => {
       mockCustomBotService.getGlobalSpecificVersion = jest
         .fn()
         .mockResolvedValue({
           success: false,
-          error: 'Not found',
+          error: "Not found",
           data: null,
         });
 
       const result = await service.create(validBotData);
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('not found');
+      expect(result.error).toContain("not found");
     });
 
-    it('should fail when bot config validation fails', async () => {
+    it("should fail when bot config validation fails", async () => {
       validator.validate = jest.fn().mockReturnValue({
         success: false,
-        error: ['Missing required field'],
+        error: ["Missing required field"],
         data: null,
       });
 
       const result = await service.create(validBotData);
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Missing required field');
+      expect(result.error).toContain("Missing required field");
     });
 
-    describe('deployment authorization', () => {
-      it('should allow deployment for bot owner with approved bot', async () => {
-        jest.spyOn(repository, 'findOne').mockResolvedValue({
+    describe("deployment authorization", () => {
+      it("should allow deployment for bot owner with approved bot", async () => {
+        jest.spyOn(repository, "findOne").mockResolvedValue({
           success: true,
           error: null,
           data: {
-            id: 'test-id',
+            id: "test-id",
             ...validBotData,
             userId: uid,
-            topic: 'the0-scheduled-custom-bot',
+            topic: "the0-scheduled-custom-bot",
           } as Bot,
         });
         mockCustomBotService.getGlobalSpecificVersion = jest
           .fn()
           .mockResolvedValue({
             success: true,
-            data: { ...mockCustomBot, userId: uid, status: 'approved' },
+            data: { ...mockCustomBot, userId: uid, status: "approved" },
           });
 
         const result = await service.create(validBotData);
@@ -254,29 +253,29 @@ describe('BotService - Enhanced Tests', () => {
         // Owner doesn't need to check hasUserBot
       });
 
-      it('should reject deployment for bot owner with unapproved bot', async () => {
+      it("should reject deployment for bot owner with unapproved bot", async () => {
         mockCustomBotService.getGlobalSpecificVersion = jest
           .fn()
           .mockResolvedValue({
             success: true,
-            data: { ...mockCustomBot, userId: uid, status: 'pending' },
+            data: { ...mockCustomBot, userId: uid, status: "pending" },
           });
 
         const result = await service.create(validBotData);
 
         expect(result.success).toBe(false);
-        expect(result.error).toContain('must be approved');
+        expect(result.error).toContain("must be approved");
       });
 
-      it('should auto-install free bots for non-owners', async () => {
-        jest.spyOn(repository, 'findOne').mockResolvedValue({
+      it("should auto-install free bots for non-owners", async () => {
+        jest.spyOn(repository, "findOne").mockResolvedValue({
           success: true,
           error: null,
           data: {
-            id: 'test-id',
+            id: "test-id",
             ...validBotData,
             userId: uid,
-            topic: 'the0-scheduled-custom-bot',
+            topic: "the0-scheduled-custom-bot",
           } as Bot,
         });
         const result = await service.create(validBotData);
@@ -284,7 +283,7 @@ describe('BotService - Enhanced Tests', () => {
         expect(result.success).toBe(true);
       });
 
-      it('should allow deployment of all bots in OSS version', async () => {
+      it("should allow deployment of all bots in OSS version", async () => {
         mockCustomBotService.getGlobalSpecificVersion = jest
           .fn()
           .mockResolvedValue({
@@ -293,26 +292,26 @@ describe('BotService - Enhanced Tests', () => {
           });
 
         // Mock successful repository operations - using repository instead of mockRepository
-        jest.spyOn(repository, 'create').mockResolvedValue({
+        jest.spyOn(repository, "create").mockResolvedValue({
           success: true,
-          data: { ...validBotData, id: 'test-id' },
+          data: { ...validBotData, id: "test-id" },
         } as any);
 
-        jest.spyOn(repository, 'findOne').mockResolvedValue({
+        jest.spyOn(repository, "findOne").mockResolvedValue({
           success: true,
           error: null,
           data: {
-            id: 'test-id',
+            id: "test-id",
             ...validBotData,
             userId: uid,
-            topic: 'the0-scheduled-custom-bot',
+            topic: "the0-scheduled-custom-bot",
           } as Bot,
         });
 
         const result = await service.create(validBotData);
 
         if (!result.success) {
-          console.log('Bot service create failed with error:', result.error);
+          console.log("Bot service create failed with error:", result.error);
         }
         expect(result.success).toBe(true);
         // OSS version allows all bots regardless of price
@@ -320,14 +319,14 @@ describe('BotService - Enhanced Tests', () => {
     });
   });
 
-  describe('findAll', () => {
-    it('should return all user bots', async () => {
+  describe("findAll", () => {
+    it("should return all user bots", async () => {
       const bots = [
-        { id: 'bot1', name: 'Bot 1' },
-        { id: 'bot2', name: 'Bot 2' },
+        { id: "bot1", name: "Bot 1" },
+        { id: "bot2", name: "Bot 2" },
       ] as Bot[];
 
-      jest.spyOn(repository, 'findAll').mockResolvedValue({
+      jest.spyOn(repository, "findAll").mockResolvedValue({
         success: true,
         error: null,
         data: bots,
@@ -340,58 +339,58 @@ describe('BotService - Enhanced Tests', () => {
       expect(repository.findAll).toHaveBeenCalledWith(uid);
     });
 
-    it('should handle repository errors', async () => {
-      jest.spyOn(repository, 'findAll').mockResolvedValue({
+    it("should handle repository errors", async () => {
+      jest.spyOn(repository, "findAll").mockResolvedValue({
         success: false,
-        error: 'Database error',
+        error: "Database error",
         data: null,
       });
 
       const result = await service.findAll();
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Database error');
+      expect(result.error).toBe("Database error");
     });
   });
 
-  describe('findOne', () => {
-    it('should return a specific bot', async () => {
-      const bot = { id: 'test-id', name: 'Test Bot' } as Bot;
+  describe("findOne", () => {
+    it("should return a specific bot", async () => {
+      const bot = { id: "test-id", name: "Test Bot" } as Bot;
 
-      jest.spyOn(repository, 'findOne').mockResolvedValue({
+      jest.spyOn(repository, "findOne").mockResolvedValue({
         success: true,
         error: null,
         data: bot,
       });
 
-      const result = await service.findOne('test-id');
+      const result = await service.findOne("test-id");
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual(bot);
-      expect(repository.findOne).toHaveBeenCalledWith(uid, 'test-id');
+      expect(repository.findOne).toHaveBeenCalledWith(uid, "test-id");
     });
 
-    it('should handle bot not found', async () => {
-      jest.spyOn(repository, 'findOne').mockResolvedValue({
+    it("should handle bot not found", async () => {
+      jest.spyOn(repository, "findOne").mockResolvedValue({
         success: false,
-        error: 'Bot not found',
+        error: "Bot not found",
         data: null,
       });
 
-      const result = await service.findOne('nonexistent-id');
+      const result = await service.findOne("nonexistent-id");
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Bot not found');
+      expect(result.error).toBe("Bot not found");
     });
   });
 
-  describe('update', () => {
+  describe("update", () => {
     const updateData = {
-      name: 'Updated Bot',
+      name: "Updated Bot",
       config: {
-        type: 'scheduled/test-custom-bot',
-        version: '1.0.0',
-        foo: 'updated',
+        type: "scheduled/test-custom-bot",
+        version: "1.0.0",
+        foo: "updated",
         bar: 456,
       },
     };
@@ -404,93 +403,93 @@ describe('BotService - Enhanced Tests', () => {
       });
     });
 
-    it('should update a bot successfully', async () => {
-      const updatedBot = { id: 'test-id', ...updateData } as Bot;
+    it("should update a bot successfully", async () => {
+      const updatedBot = { id: "test-id", ...updateData } as Bot;
 
-      jest.spyOn(repository, 'update').mockResolvedValue({
+      jest.spyOn(repository, "update").mockResolvedValue({
         success: true,
         error: null,
         data: updatedBot,
       });
 
-      const result = await service.update('test-id', updateData);
+      const result = await service.update("test-id", updateData);
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual(updatedBot);
       expect(repository.update).toHaveBeenCalledWith(
         uid,
-        'test-id',
+        "test-id",
         updateData,
       );
     });
 
-    it('should validate update data', async () => {
+    it("should validate update data", async () => {
       validator.validate = jest.fn().mockReturnValue({
         success: false,
-        error: ['Invalid configuration'],
+        error: ["Invalid configuration"],
         data: null,
       });
 
-      const result = await service.update('test-id', updateData);
+      const result = await service.update("test-id", updateData);
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Invalid configuration');
+      expect(result.error).toContain("Invalid configuration");
     });
 
-    it('should handle repository update failures', async () => {
-      jest.spyOn(repository, 'update').mockResolvedValue({
+    it("should handle repository update failures", async () => {
+      jest.spyOn(repository, "update").mockResolvedValue({
         success: false,
-        error: 'Update failed',
+        error: "Update failed",
         data: null,
       });
 
-      const result = await service.update('test-id', updateData);
+      const result = await service.update("test-id", updateData);
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Update failed');
+      expect(result.error).toBe("Update failed");
     });
   });
 
-  describe('remove', () => {
-    it('should remove a bot successfully', async () => {
+  describe("remove", () => {
+    it("should remove a bot successfully", async () => {
       const mockBot = {
-        id: 'test-id',
-        name: 'Test Bot',
-        config: { type: 'scheduled/test-bot', version: '1.0.0' },
-        topic: 'the0-scheduled-custom-bot',
+        id: "test-id",
+        name: "Test Bot",
+        config: { type: "scheduled/test-bot", version: "1.0.0" },
+        topic: "the0-scheduled-custom-bot",
         userId: uid,
       } as Bot;
 
-      jest.spyOn(repository, 'findOne').mockResolvedValue({
+      jest.spyOn(repository, "findOne").mockResolvedValue({
         success: true,
         error: null,
         data: mockBot,
       });
 
-      jest.spyOn(repository, 'remove').mockResolvedValue({
+      jest.spyOn(repository, "remove").mockResolvedValue({
         success: true,
         error: null,
         data: undefined,
       });
 
-      const result = await service.remove('test-id');
+      const result = await service.remove("test-id");
 
       expect(result.success).toBe(true);
-      expect(repository.findOne).toHaveBeenCalledWith(uid, 'test-id');
-      expect(repository.remove).toHaveBeenCalledWith(uid, 'test-id');
+      expect(repository.findOne).toHaveBeenCalledWith(uid, "test-id");
+      expect(repository.remove).toHaveBeenCalledWith(uid, "test-id");
     });
 
-    it('should handle removal failures', async () => {
-      jest.spyOn(repository, 'remove').mockResolvedValue({
+    it("should handle removal failures", async () => {
+      jest.spyOn(repository, "remove").mockResolvedValue({
         success: false,
-        error: 'Bot not found',
+        error: "Bot not found",
         data: null,
       });
 
-      const result = await service.remove('test-id');
+      const result = await service.remove("test-id");
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Bot not found');
+      expect(result.error).toBe("Bot not found");
     });
   });
 });

--- a/api/src/bot/__tests__/bot.validator.spec.ts
+++ b/api/src/bot/__tests__/bot.validator.spec.ts
@@ -1,9 +1,9 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { BotValidator } from '../bot.validator';
-import { Failure, Ok } from '@/common';
-import { CustomBot } from '@/custom-bot/custom-bot.types';
+import { Test, TestingModule } from "@nestjs/testing";
+import { BotValidator } from "../bot.validator";
+import { Failure, Ok } from "@/common";
+import { CustomBot } from "@/custom-bot/custom-bot.types";
 
-describe('BotValidator', () => {
+describe("BotValidator", () => {
   let validator: BotValidator;
   let customBot: CustomBot;
   let nonScheduledCustomBot: CustomBot;
@@ -15,122 +15,122 @@ describe('BotValidator', () => {
 
     validator = module.get<BotValidator>(BotValidator);
     customBot = {
-      id: 'test-bot',
-      name: 'test-bot',
-      version: '1.0.0',
-      status: 'pending_review',
+      id: "test-bot",
+      name: "test-bot",
+      version: "1.0.0",
+      status: "pending_review",
       config: {
-        name: 'test-bot',
-        description: 'A test bot',
-        version: '1.0.0',
-        type: 'scheduled',
-        runtime: 'python3.11',
-        author: 'test-author',
+        name: "test-bot",
+        description: "A test bot",
+        version: "1.0.0",
+        type: "scheduled",
+        runtime: "python3.11",
+        author: "test-author",
         entrypoints: {
-          bot: 'bot.py',
-          backtest: 'backtest.py',
+          bot: "bot.py",
+          backtest: "backtest.py",
         },
         schema: {
           backtest: {},
           bot: {
-            type: 'object',
+            type: "object",
             properties: {
-              foo: { type: 'string' },
-              bar: { type: 'number' },
+              foo: { type: "string" },
+              bar: { type: "number" },
             },
-            required: ['foo', 'bar'],
+            required: ["foo", "bar"],
           },
         },
-        readme: 'This is a test bot',
+        readme: "This is a test bot",
         metadata: {
-          categories: ['test'],
-          instruments: ['BTC'],
-          exchanges: ['Binance'],
-          tags: ['test', 'bot'],
+          categories: ["test"],
+          instruments: ["BTC"],
+          exchanges: ["Binance"],
+          tags: ["test", "bot"],
         },
       },
-      filePath: 'gs://test-bucket/test-bot',
-      userId: 'test-user',
+      filePath: "gs://test-bucket/test-bot",
+      userId: "test-user",
       createdAt: new Date(),
       updatedAt: new Date(),
     };
 
     nonScheduledCustomBot = {
-      id: 'test-non-scheduled-bot',
-      name: 'test-non-scheduled-bot',
-      version: '1.0.0',
-      status: 'pending_review',
+      id: "test-non-scheduled-bot",
+      name: "test-non-scheduled-bot",
+      version: "1.0.0",
+      status: "pending_review",
       config: {
-        name: 'test-bot',
-        description: 'A test bot',
-        version: '1.0.0',
-        type: 'event',
-        runtime: 'python3.11',
-        author: 'test-author',
+        name: "test-bot",
+        description: "A test bot",
+        version: "1.0.0",
+        type: "event",
+        runtime: "python3.11",
+        author: "test-author",
         entrypoints: {
-          bot: 'bot.py',
-          backtest: 'backtest.py',
+          bot: "bot.py",
+          backtest: "backtest.py",
         },
         schema: {
           backtest: {},
           bot: {
-            type: 'object',
+            type: "object",
             properties: {
-              foo: { type: 'string' },
-              bar: { type: 'number' },
+              foo: { type: "string" },
+              bar: { type: "number" },
             },
-            required: ['foo', 'bar'],
+            required: ["foo", "bar"],
           },
         },
-        readme: 'This is a test bot',
+        readme: "This is a test bot",
         metadata: {
-          categories: ['test'],
-          instruments: ['BTC'],
-          exchanges: ['Binance'],
-          tags: ['test', 'bot'],
+          categories: ["test"],
+          instruments: ["BTC"],
+          exchanges: ["Binance"],
+          tags: ["test", "bot"],
         },
       },
-      filePath: 'gs://test-bucket/test-bot',
-      userId: 'test-user',
+      filePath: "gs://test-bucket/test-bot",
+      userId: "test-user",
       createdAt: new Date(),
       updatedAt: new Date(),
     };
   });
 
-  describe('bot type validation', () => {
-    it('should return an error if the bot type string is invalid', async () => {
+  describe("bot type validation", () => {
+    it("should return an error if the bot type string is invalid", async () => {
       // Arrange
-      const config = { type: 'invalid-bot-type' };
+      const config = { type: "invalid-bot-type" };
       const result = await validator.validate(config, customBot);
 
       // Assert
       expect(result).toEqual(
         Failure<boolean, string[]>([
-          'Invalid bot type format. Expected format: type/name',
+          "Invalid bot type format. Expected format: type/name",
         ]),
       );
     });
   });
 
-  describe('scheduled bots', () => {
-    it('should always have a schedule in the configuration', async () => {
+  describe("scheduled bots", () => {
+    it("should always have a schedule in the configuration", async () => {
       //Arrange
-      const config = { type: 'scheduled/test-bot', foo: 'bar' };
+      const config = { type: "scheduled/test-bot", foo: "bar" };
 
       const result = await validator.validate(config, customBot);
 
       //Assert
       expect(result).toEqual(
-        Failure<boolean, string[]>(['No schedule provided']),
+        Failure<boolean, string[]>(["No schedule provided"]),
       );
     });
 
-    it('should validate that the schedule is correctly formatted', async () => {
+    it("should validate that the schedule is correctly formatted", async () => {
       // Arrange
       const config = {
-        type: 'scheduled/test-bot',
-        schedule: 'invalid-schedule',
-        foo: 'bar',
+        type: "scheduled/test-bot",
+        schedule: "invalid-schedule",
+        foo: "bar",
       };
 
       const result = await validator.validate(config, customBot);
@@ -143,11 +143,11 @@ describe('BotValidator', () => {
       );
     });
 
-    it('should not validate the schedule if the bot type is not scheduled', async () => {
+    it("should not validate the schedule if the bot type is not scheduled", async () => {
       // Arrange
       const config = {
-        type: 'other/test-bot',
-        foo: 'bar',
+        type: "other/test-bot",
+        foo: "bar",
         bar: 42,
       };
 
@@ -158,12 +158,12 @@ describe('BotValidator', () => {
     });
   });
 
-  describe('validation against schema', () => {
-    it('should validate successfully if config is valid (scheduled)', async () => {
+  describe("validation against schema", () => {
+    it("should validate successfully if config is valid (scheduled)", async () => {
       const config = {
-        type: 'scheduled/test-bot',
-        schedule: '*/5 * * * *',
-        foo: 'bar',
+        type: "scheduled/test-bot",
+        schedule: "*/5 * * * *",
+        foo: "bar",
         bar: 42,
       };
 
@@ -172,10 +172,10 @@ describe('BotValidator', () => {
       expect(result).toEqual(Ok<boolean, string[]>(true));
     });
 
-    it('should return an error if config does not match schema (scheduled)', async () => {
+    it("should return an error if config does not match schema (scheduled)", async () => {
       const config = {
-        type: 'scheduled/test-bot',
-        schedule: '*/5 * * * *',
+        type: "scheduled/test-bot",
+        schedule: "*/5 * * * *",
         foo: 123,
       };
 
@@ -184,15 +184,15 @@ describe('BotValidator', () => {
       expect(result).toEqual(
         Failure<boolean, string[]>([
           "must have required property 'bar'",
-          '/foo must be string',
+          "/foo must be string",
         ]),
       );
     });
 
-    it('should validate successfully if config is valid (non-scheduled)', async () => {
+    it("should validate successfully if config is valid (non-scheduled)", async () => {
       const config = {
-        type: 'other/test-bot',
-        foo: 'bar',
+        type: "other/test-bot",
+        foo: "bar",
         bar: 42,
       };
 
@@ -201,9 +201,9 @@ describe('BotValidator', () => {
       expect(result).toEqual(Ok<boolean, string[]>(true));
     });
 
-    it('should return an error if config does not match schema (non-scheduled)', async () => {
+    it("should return an error if config does not match schema (non-scheduled)", async () => {
       const config = {
-        type: 'other/test-bot',
+        type: "other/test-bot",
         foo: 123,
       };
 
@@ -212,7 +212,7 @@ describe('BotValidator', () => {
       expect(result).toEqual(
         Failure<boolean, string[]>([
           "must have required property 'bar'",
-          '/foo must be string',
+          "/foo must be string",
         ]),
       );
     });

--- a/api/src/bot/bot.constants.ts
+++ b/api/src/bot/bot.constants.ts
@@ -3,14 +3,14 @@ export const BOT_TYPE_PATTERN =
 
 // NATS topics for bot events (match runtime expectations)
 export const BOT_TOPICS = {
-  CREATED: 'the0.bot.created',
-  UPDATED: 'the0.bot.updated', 
-  DELETED: 'the0.bot.deleted',
+  CREATED: "the0.bot.created",
+  UPDATED: "the0.bot.updated",
+  DELETED: "the0.bot.deleted",
 } as const;
 
 // NATS topics for scheduled bot events
 export const SCHEDULED_BOT_TOPICS = {
-  CREATED: 'the0.bot-schedule.created',
-  UPDATED: 'the0.bot-schedule.updated',
-  DELETED: 'the0.bot-schedule.deleted',
+  CREATED: "the0.bot-schedule.created",
+  UPDATED: "the0.bot-schedule.updated",
+  DELETED: "the0.bot-schedule.deleted",
 } as const;

--- a/api/src/bot/bot.controller.ts
+++ b/api/src/bot/bot.controller.ts
@@ -9,13 +9,13 @@ import {
   Put,
   BadRequestException,
   NotFoundException,
-} from '@nestjs/common';
-import { BotService } from './bot.service';
-import { CreateBotDto } from './dto/create-bot.dto';
-import { UpdateBotDto } from './dto/update-bot.dto';
-import { AuthCombinedGuard } from '@/auth/auth-combined.guard';
+} from "@nestjs/common";
+import { BotService } from "./bot.service";
+import { CreateBotDto } from "./dto/create-bot.dto";
+import { UpdateBotDto } from "./dto/update-bot.dto";
+import { AuthCombinedGuard } from "@/auth/auth-combined.guard";
 
-@Controller('bot')
+@Controller("bot")
 @UseGuards(AuthCombinedGuard)
 export class BotController {
   constructor(private readonly botService: BotService) {}
@@ -38,8 +38,8 @@ export class BotController {
     return result.data;
   }
 
-  @Get(':id')
-  async findOne(@Param('id') id: string) {
+  @Get(":id")
+  async findOne(@Param("id") id: string) {
     const result = await this.botService.findOne(id);
     if (!result.success) {
       throw new NotFoundException(result.error);
@@ -47,8 +47,8 @@ export class BotController {
     return result.data;
   }
 
-  @Put(':id')
-  async update(@Param('id') id: string, @Body() updateBotDto: UpdateBotDto) {
+  @Put(":id")
+  async update(@Param("id") id: string, @Body() updateBotDto: UpdateBotDto) {
     const result = await this.botService.update(id, updateBotDto);
     if (!result.success) {
       throw new BadRequestException(result.error);
@@ -56,8 +56,8 @@ export class BotController {
     return result.data;
   }
 
-  @Delete(':id')
-  async remove(@Param('id') id: string) {
+  @Delete(":id")
+  async remove(@Param("id") id: string) {
     const result = await this.botService.remove(id);
     if (!result.success) {
       throw new BadRequestException(result.error);

--- a/api/src/bot/bot.module.ts
+++ b/api/src/bot/bot.module.ts
@@ -1,14 +1,14 @@
-import { Module, forwardRef } from '@nestjs/common';
-import { BotService } from './bot.service';
-import { BotController } from './bot.controller';
-import { BotRepository } from './bot.repository';
-import { HttpModule } from '@nestjs/axios';
-import { BotValidator } from './bot.validator';
-import { ConfigModule } from '@nestjs/config';
-import { CustomBotModule } from '@/custom-bot/custom-bot.module';
-import { ApiKeyModule } from '@/api-key/api-key.module';
+import { Module, forwardRef } from "@nestjs/common";
+import { BotService } from "./bot.service";
+import { BotController } from "./bot.controller";
+import { BotRepository } from "./bot.repository";
+import { HttpModule } from "@nestjs/axios";
+import { BotValidator } from "./bot.validator";
+import { ConfigModule } from "@nestjs/config";
+import { CustomBotModule } from "@/custom-bot/custom-bot.module";
+import { ApiKeyModule } from "@/api-key/api-key.module";
 // UserBotsModule removed for OSS version
-import { NatsModule } from '@/nats/nats.module';
+import { NatsModule } from "@/nats/nats.module";
 // FeatureGateModule removed for OSS version
 
 @Module({

--- a/api/src/bot/bot.repository.ts
+++ b/api/src/bot/bot.repository.ts
@@ -1,10 +1,10 @@
-import { Injectable } from '@nestjs/common';
-import { Bot } from './entities/bot.entity';
-import { RoleRepository } from '@/common/role.repository';
+import { Injectable } from "@nestjs/common";
+import { Bot } from "./entities/bot.entity";
+import { RoleRepository } from "@/common/role.repository";
 
 @Injectable()
 export class BotRepository extends RoleRepository<Bot> {
-  protected readonly tableName = 'bots' as const;
+  protected readonly tableName = "bots" as const;
 
   constructor() {
     super();

--- a/api/src/bot/bot.validator.ts
+++ b/api/src/bot/bot.validator.ts
@@ -1,10 +1,10 @@
-import { Injectable } from '@nestjs/common';
-import { Result, Failure, Ok } from '@/common/result';
-import Ajv from 'ajv';
-import addFormats from 'ajv-formats';
-import { isValidCron } from 'cron-validator';
-import { CustomBot } from '@/custom-bot/custom-bot.types';
-import { BOT_TYPE_PATTERN } from '@/bot/bot.constants';
+import { Injectable } from "@nestjs/common";
+import { Result, Failure, Ok } from "@/common/result";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { isValidCron } from "cron-validator";
+import { CustomBot } from "@/custom-bot/custom-bot.types";
+import { BOT_TYPE_PATTERN } from "@/bot/bot.constants";
 
 @Injectable()
 export class BotValidator {
@@ -16,21 +16,21 @@ export class BotValidator {
     const { type } = config;
 
     if (!type) {
-      return Failure<boolean, string[]>(['No type provided']);
+      return Failure<boolean, string[]>(["No type provided"]);
     }
 
     if (BOT_TYPE_PATTERN.test(type) === false) {
       return Failure<boolean, string[]>([
-        'Invalid bot type format. Expected format: type/name',
+        "Invalid bot type format. Expected format: type/name",
       ]);
     }
 
-    const [botType, _] = type.split('/');
+    const [botType, _] = type.split("/");
 
     //Check if it has a schedule
-    if (botType === 'scheduled') {
+    if (botType === "scheduled") {
       if (!config.schedule) {
-        return Failure<boolean, string[]>(['No schedule provided']);
+        return Failure<boolean, string[]>(["No schedule provided"]);
       }
 
       if (!isValidCron(config.schedule)) {
@@ -89,7 +89,7 @@ export class BotValidator {
   }
 
   private filterObjectProperties(obj: any, schema: any): any {
-    if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
+    if (!obj || typeof obj !== "object" || Array.isArray(obj)) {
       return obj;
     }
 
@@ -99,9 +99,9 @@ export class BotValidator {
     for (const key of Object.keys(schemaProperties)) {
       if (obj[key] !== undefined) {
         const propertySchema = schemaProperties[key];
-        
+
         // If property is an object and has its own schema, recursively filter
-        if (propertySchema.type === 'object' && propertySchema.properties) {
+        if (propertySchema.type === "object" && propertySchema.properties) {
           filtered[key] = this.filterObjectProperties(obj[key], propertySchema);
         } else {
           filtered[key] = obj[key];

--- a/api/src/bot/dto/create-bot.dto.ts
+++ b/api/src/bot/dto/create-bot.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsObject, IsString } from 'class-validator';
+import { IsNotEmpty, IsObject, IsString } from "class-validator";
 
 export class CreateBotDto {
   @IsNotEmpty()

--- a/api/src/bot/dto/update-bot.dto.ts
+++ b/api/src/bot/dto/update-bot.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateBotDto } from './create-bot.dto';
+import { PartialType } from "@nestjs/mapped-types";
+import { CreateBotDto } from "./create-bot.dto";
 
 export class UpdateBotDto extends PartialType(CreateBotDto) {}

--- a/api/src/common/index.ts
+++ b/api/src/common/index.ts
@@ -1,1 +1,1 @@
-export { Result, Ok, Failure } from './result';
+export { Result, Ok, Failure } from "./result";

--- a/api/src/common/repository.ts
+++ b/api/src/common/repository.ts
@@ -1,4 +1,4 @@
-import { Result } from './result';
+import { Result } from "./result";
 
 export default interface Repository {
   create: (args: any) => Promise<Result<any, string>>;

--- a/api/src/common/role-revision.repository.ts
+++ b/api/src/common/role-revision.repository.ts
@@ -1,7 +1,7 @@
-import { Result, Ok, Failure } from './result';
-import { getDatabase, getTables } from '@/database/connection';
-import { eq, and, desc, asc } from 'drizzle-orm';
-import { createId } from '@paralleldrive/cuid2';
+import { Result, Ok, Failure } from "./result";
+import { getDatabase, getTables } from "@/database/connection";
+import { eq, and, desc, asc } from "drizzle-orm";
+import { createId } from "@paralleldrive/cuid2";
 
 export interface RevisionEntity {
   id?: string;
@@ -16,7 +16,7 @@ export abstract class RoleRevisionRepository<T extends RevisionEntity> {
   protected abstract readonly tableName: keyof typeof this.tables;
   protected keyField: string;
 
-  constructor(revisionKeyField = 'name') {
+  constructor(revisionKeyField = "name") {
     this.keyField = revisionKeyField;
   }
 
@@ -31,92 +31,105 @@ export abstract class RoleRevisionRepository<T extends RevisionEntity> {
         createdAt: new Date(),
         updatedAt: new Date(),
       };
-      
+
       const records = await this.db.insert(this.table).values(data).returning();
-      
+
       return Ok({
         id: records[0].id,
         ...data,
       } as T);
     } catch (error: any) {
-      console.log('Error creating document:', error);
+      console.log("Error creating document:", error);
       return Failure(error.message);
     }
   }
 
   async findAll(userId: string): Promise<Result<T[], string>> {
     try {
-      console.log('🔍 RoleRevisionRepository.findAll called with userId:', userId, 'type:', typeof userId);
-      
+      console.log(
+        "🔍 RoleRevisionRepository.findAll called with userId:",
+        userId,
+        "type:",
+        typeof userId,
+      );
+
       if (!userId) {
-        console.log('❌ User ID is missing or falsy in RoleRevisionRepository');
-        return Failure('User ID is required');
+        console.log("❌ User ID is missing or falsy in RoleRevisionRepository");
+        return Failure("User ID is required");
       }
 
-      console.log('📊 Executing query on revision table:', this.tableName);
-      const records = await this.db.select().from(this.table)
+      console.log("📊 Executing query on revision table:", this.tableName);
+      const records = await this.db
+        .select()
+        .from(this.table)
         .where(eq(this.table.userId, userId))
         .orderBy(desc(this.table.createdAt));
 
-      console.log('✅ Revision query executed successfully, found', records.length, 'records');
-      return Ok(records.map(record => this.transformRecordToData(record)));
+      console.log(
+        "✅ Revision query executed successfully, found",
+        records.length,
+        "records",
+      );
+      return Ok(records.map((record) => this.transformRecordToData(record)));
     } catch (error: any) {
-      console.log('❌ RoleRevisionRepository.findAll - Error fetching documents:', error);
+      console.log(
+        "❌ RoleRevisionRepository.findAll - Error fetching documents:",
+        error,
+      );
       return Failure(error.message);
     }
   }
 
   async findOne(userId: string, id: string): Promise<Result<T, string>> {
     try {
-      const records = await this.db.select().from(this.table)
-        .where(and(
-          eq(this.table.userId, userId),
-          eq(this.table.id, id)
-        ));
+      const records = await this.db
+        .select()
+        .from(this.table)
+        .where(and(eq(this.table.userId, userId), eq(this.table.id, id)));
 
       if (records.length === 0) {
-        return Failure('Not found');
+        return Failure("Not found");
       }
 
       return Ok(this.transformRecordToData(records[0]));
     } catch (error: any) {
-      console.log('Error fetching document:', error);
+      console.log("Error fetching document:", error);
       return Failure(error.message);
     }
   }
 
-  async update(userId: string, id: string, args: Partial<T>): Promise<Result<T, string>> {
+  async update(
+    userId: string,
+    id: string,
+    args: Partial<T>,
+  ): Promise<Result<T, string>> {
     try {
       const updateData = {
         ...args,
         updatedAt: new Date(),
       };
 
-      await this.db.update(this.table)
+      await this.db
+        .update(this.table)
         .set(updateData)
-        .where(and(
-          eq(this.table.userId, userId),
-          eq(this.table.id, id)
-        ));
+        .where(and(eq(this.table.userId, userId), eq(this.table.id, id)));
 
       return this.findOne(userId, id);
     } catch (error: any) {
-      console.log('Error updating document:', error);
+      console.log("Error updating document:", error);
       return Failure(error.message);
     }
   }
 
   async remove(userId: string, id: string): Promise<Result<void, string>> {
     try {
-      await this.db.delete(this.table)
-        .where(and(
-          eq(this.table.userId, userId),
-          eq(this.table.id, id)
-        ));
+      await this.db
+        .delete(this.table)
+        .where(and(eq(this.table.userId, userId), eq(this.table.id, id)));
 
       return Ok(null);
     } catch (error: any) {
-      console.log('Error deleting document:', error);
+      console.log("Error deleting document:", error);
       return Failure(error.message);
     }
   }
@@ -124,57 +137,79 @@ export abstract class RoleRevisionRepository<T extends RevisionEntity> {
   // Generic revision methods using configurable key field
   async findByKey(userId: string, key: string): Promise<Result<T[], string>> {
     try {
-      const records = await this.db.select().from(this.table)
-        .where(and(
-          eq(this.table.userId, userId),
-          eq(this.table[this.keyField], key)
-        ))
+      const records = await this.db
+        .select()
+        .from(this.table)
+        .where(
+          and(
+            eq(this.table.userId, userId),
+            eq(this.table[this.keyField], key),
+          ),
+        )
         .orderBy(desc(this.table.createdAt));
 
-      return Ok(records.map(record => this.transformRecordToData(record)));
+      return Ok(records.map((record) => this.transformRecordToData(record)));
     } catch (error: any) {
       console.log(`Error fetching documents by ${this.keyField}:`, error);
       return Failure(error.message);
     }
   }
 
-  async findByKeyAndVersion(userId: string, key: string, version: string): Promise<Result<T, string>> {
+  async findByKeyAndVersion(
+    userId: string,
+    key: string,
+    version: string,
+  ): Promise<Result<T, string>> {
     try {
-      const records = await this.db.select().from(this.table)
-        .where(and(
-          eq(this.table.userId, userId),
-          eq(this.table[this.keyField], key),
-          eq(this.table.version, version)
-        ));
+      const records = await this.db
+        .select()
+        .from(this.table)
+        .where(
+          and(
+            eq(this.table.userId, userId),
+            eq(this.table[this.keyField], key),
+            eq(this.table.version, version),
+          ),
+        );
 
       if (records.length === 0) {
-        return Failure('Not found');
+        return Failure("Not found");
       }
 
       return Ok(this.transformRecordToData(records[0]));
     } catch (error: any) {
-      console.log(`Error fetching document by ${this.keyField} and version:`, error);
+      console.log(
+        `Error fetching document by ${this.keyField} and version:`,
+        error,
+      );
       return Failure(error.message);
     }
   }
 
-  async getLatestVersion(userId: string, keyValue: string): Promise<Result<T, string>> {
+  async getLatestVersion(
+    userId: string,
+    keyValue: string,
+  ): Promise<Result<T, string>> {
     try {
-      const records = await this.db.select().from(this.table)
-        .where(and(
-          eq(this.table.userId, userId),
-          eq(this.table[this.keyField], keyValue)
-        ))
+      const records = await this.db
+        .select()
+        .from(this.table)
+        .where(
+          and(
+            eq(this.table.userId, userId),
+            eq(this.table[this.keyField], keyValue),
+          ),
+        )
         .orderBy(desc(this.table.createdAt))
         .limit(1);
 
       if (records.length === 0) {
-        return Failure('Not found');
+        return Failure("Not found");
       }
 
       return Ok(this.transformRecordToData(records[0]));
     } catch (error: any) {
-      console.log('Error fetching latest version:', error);
+      console.log("Error fetching latest version:", error);
       return Failure(error.message);
     }
   }
@@ -182,31 +217,38 @@ export abstract class RoleRevisionRepository<T extends RevisionEntity> {
   // Global methods (not user-scoped) for checking uniqueness
   async getGlobalLatestVersion(key: string): Promise<Result<T, string>> {
     try {
-      const records = await this.db.select().from(this.table)
+      const records = await this.db
+        .select()
+        .from(this.table)
         .where(eq(this.table[this.keyField], key))
         .orderBy(desc(this.table.createdAt))
         .limit(1);
 
       if (records.length === 0) {
-        return Failure('Not found');
+        return Failure("Not found");
       }
 
       return Ok(this.transformRecordToData(records[0]));
     } catch (error: any) {
-      console.log('Error fetching global latest version:', error);
+      console.log("Error fetching global latest version:", error);
       return Failure(error.message);
     }
   }
 
   async findGlobalByKey(key: string): Promise<Result<T[], string>> {
     try {
-      const records = await this.db.select().from(this.table)
+      const records = await this.db
+        .select()
+        .from(this.table)
         .where(eq(this.table[this.keyField], key))
         .orderBy(desc(this.table.createdAt));
 
-      return Ok(records.map(record => this.transformRecordToData(record)));
+      return Ok(records.map((record) => this.transformRecordToData(record)));
     } catch (error: any) {
-      console.log(`Error fetching global documents by ${this.keyField}:`, error);
+      console.log(
+        `Error fetching global documents by ${this.keyField}:`,
+        error,
+      );
       return Failure(error.message);
     }
   }
@@ -223,21 +265,31 @@ export abstract class RoleRevisionRepository<T extends RevisionEntity> {
     }
   }
 
-  async findGlobalByKeyAndVersion(key: string, version: string): Promise<Result<T, string>> {
+  async findGlobalByKeyAndVersion(
+    key: string,
+    version: string,
+  ): Promise<Result<T, string>> {
     try {
-      const records = await this.db.select().from(this.table)
-        .where(and(
-          eq(this.table[this.keyField], key),
-          eq(this.table.version, version)
-        ));
+      const records = await this.db
+        .select()
+        .from(this.table)
+        .where(
+          and(
+            eq(this.table[this.keyField], key),
+            eq(this.table.version, version),
+          ),
+        );
 
       if (records.length === 0) {
-        return Failure('Not found');
+        return Failure("Not found");
       }
 
       return Ok(this.transformRecordToData(records[0]));
     } catch (error: any) {
-      console.log(`Error fetching global document by ${this.keyField} and version:`, error);
+      console.log(
+        `Error fetching global document by ${this.keyField} and version:`,
+        error,
+      );
       return Failure(error.message);
     }
   }

--- a/api/src/common/role.repository.ts
+++ b/api/src/common/role.repository.ts
@@ -1,8 +1,8 @@
-import { Result, Ok, Failure } from './result';
-import { getDatabase, getTables } from '@/database/connection';
-import { eq, and, desc } from 'drizzle-orm';
-import Repository from './repository';
-import { createId } from '@paralleldrive/cuid2';
+import { Result, Ok, Failure } from "./result";
+import { getDatabase, getTables } from "@/database/connection";
+import { eq, and, desc } from "drizzle-orm";
+import Repository from "./repository";
+import { createId } from "@paralleldrive/cuid2";
 
 export abstract class RoleRepository<T> implements Repository {
   protected readonly db = getDatabase();
@@ -20,37 +20,53 @@ export abstract class RoleRepository<T> implements Repository {
         createdAt: new Date(),
         updatedAt: new Date(),
       };
-      
+
       const records = await this.db.insert(this.table).values(data).returning();
-      
+
       return Ok({
         id: records[0].id,
         ...data,
       } as T);
     } catch (error: any) {
-      console.log('Error creating document:', error);
+      console.log("Error creating document:", error);
       return Failure(error.message);
     }
   }
 
   async findAll(userId: string): Promise<Result<T[], string>> {
     try {
-      console.log('🔍 RoleRepository.findAll called with userId:', userId, 'type:', typeof userId);
-      
+      console.log(
+        "🔍 RoleRepository.findAll called with userId:",
+        userId,
+        "type:",
+        typeof userId,
+      );
+
       if (!userId) {
-        console.log('❌ User ID is missing or falsy');
-        return Failure('User ID is required');
+        console.log("❌ User ID is missing or falsy");
+        return Failure("User ID is required");
       }
 
-      console.log('📊 Executing query on table:', this.tableName);
-      const records = await this.db.select().from(this.table)
+      console.log("📊 Executing query on table:", this.tableName);
+      const records = await this.db
+        .select()
+        .from(this.table)
         .where(eq(this.table.userId, userId))
         .orderBy(desc(this.table.createdAt));
 
-      console.log('✅ Query executed successfully, found', records.length, 'records');
-      return Ok(records.map(record => this.transformSnapshotToData<T>(record)));
+      console.log(
+        "✅ Query executed successfully, found",
+        records.length,
+        "records",
+      );
+      return Ok(
+        records.map((record) => this.transformSnapshotToData<T>(record)),
+      );
     } catch (error: any) {
-      console.log('❌ RoleRepository.findAll - Error fetching documents:', error);
+      console.log(
+        "❌ RoleRepository.findAll - Error fetching documents:",
+        error,
+      );
       return Failure(error.message);
     }
   }
@@ -58,30 +74,33 @@ export abstract class RoleRepository<T> implements Repository {
   async findOne(userId: string, id: string): Promise<Result<T, string>> {
     try {
       if (!userId || !id) {
-        return Failure('User ID and ID are required');
+        return Failure("User ID and ID are required");
       }
 
-      const records = await this.db.select().from(this.table)
-        .where(and(
-          eq(this.table.userId, userId),
-          eq(this.table.id, id)
-        ));
+      const records = await this.db
+        .select()
+        .from(this.table)
+        .where(and(eq(this.table.userId, userId), eq(this.table.id, id)));
 
       if (records.length === 0) {
-        return Failure('Not found');
+        return Failure("Not found");
       }
 
       return Ok(this.transformSnapshotToData<T>(records[0]));
     } catch (error: any) {
-      console.log('Error fetching document:', error);
+      console.log("Error fetching document:", error);
       return Failure(error.message);
     }
   }
 
-  async update(userId: string, id: string, args: Partial<T>): Promise<Result<T, string>> {
+  async update(
+    userId: string,
+    id: string,
+    args: Partial<T>,
+  ): Promise<Result<T, string>> {
     try {
       if (!userId || !id) {
-        return Failure('User ID and ID are required');
+        return Failure("User ID and ID are required");
       }
 
       const updateData = {
@@ -89,16 +108,14 @@ export abstract class RoleRepository<T> implements Repository {
         updatedAt: new Date(),
       };
 
-      await this.db.update(this.table)
+      await this.db
+        .update(this.table)
         .set(updateData)
-        .where(and(
-          eq(this.table.userId, userId),
-          eq(this.table.id, id)
-        ));
+        .where(and(eq(this.table.userId, userId), eq(this.table.id, id)));
 
       return this.findOne(userId, id);
     } catch (error: any) {
-      console.log('Error updating document:', error);
+      console.log("Error updating document:", error);
       return Failure(error.message);
     }
   }
@@ -106,18 +123,16 @@ export abstract class RoleRepository<T> implements Repository {
   async remove(userId: string, id: string): Promise<Result<void, string>> {
     try {
       if (!userId || !id) {
-        return Failure('User ID and ID are required');
+        return Failure("User ID and ID are required");
       }
 
-      await this.db.delete(this.table)
-        .where(and(
-          eq(this.table.userId, userId),
-          eq(this.table.id, id)
-        ));
+      await this.db
+        .delete(this.table)
+        .where(and(eq(this.table.userId, userId), eq(this.table.id, id)));
 
       return Ok(null);
     } catch (error: any) {
-      console.log('Error deleting document:', error);
+      console.log("Error deleting document:", error);
       return Failure(error.message);
     }
   }

--- a/api/src/config/configuration.ts
+++ b/api/src/config/configuration.ts
@@ -1,30 +1,33 @@
 export default () => ({
   // Bot runtime configuration
-  BOT_TYPE_API_KEY: process.env.BOT_TYPE_API_KEY || '',
-  
+  BOT_TYPE_API_KEY: process.env.BOT_TYPE_API_KEY || "",
+
   // Frontend configuration
-  FRONTEND_URL: process.env.FRONTEND_URL || 'http://localhost:3001',
-  
+  FRONTEND_URL: process.env.FRONTEND_URL || "http://localhost:3001",
+
   // MinIO/S3 storage configuration for OSS
-  MINIO_ENDPOINT: process.env.MINIO_ENDPOINT || 'localhost',
-  MINIO_EXTERNAL_ENDPOINT: process.env.MINIO_EXTERNAL_ENDPOINT || process.env.MINIO_ENDPOINT || 'localhost:9000',
-  MINIO_PORT: process.env.MINIO_PORT || '9000',
-  MINIO_USE_SSL: process.env.MINIO_USE_SSL || 'false',
-  MINIO_ACCESS_KEY: process.env.MINIO_ACCESS_KEY || 'minioadmin',
-  MINIO_SECRET_KEY: process.env.MINIO_SECRET_KEY || 'minioadmin',
-  
+  MINIO_ENDPOINT: process.env.MINIO_ENDPOINT || "localhost",
+  MINIO_EXTERNAL_ENDPOINT:
+    process.env.MINIO_EXTERNAL_ENDPOINT ||
+    process.env.MINIO_ENDPOINT ||
+    "localhost:9000",
+  MINIO_PORT: process.env.MINIO_PORT || "9000",
+  MINIO_USE_SSL: process.env.MINIO_USE_SSL || "false",
+  MINIO_ACCESS_KEY: process.env.MINIO_ACCESS_KEY || "minioadmin",
+  MINIO_SECRET_KEY: process.env.MINIO_SECRET_KEY || "minioadmin",
+
   // Storage buckets
-  CUSTOM_BOTS_BUCKET: process.env.CUSTOM_BOTS_BUCKET || 'custom-bots',
-  LOG_BUCKET: process.env.LOG_BUCKET || 'logs',
-  BACKTEST_BUCKET: process.env.BACKTEST_BUCKET || 'backtests',
-  
+  CUSTOM_BOTS_BUCKET: process.env.CUSTOM_BOTS_BUCKET || "custom-bots",
+  LOG_BUCKET: process.env.LOG_BUCKET || "logs",
+  BACKTEST_BUCKET: process.env.BACKTEST_BUCKET || "backtests",
+
   // Database configuration
-  DATABASE_URL: process.env.DATABASE_URL || 'sqlite:data.db',
-  
+  DATABASE_URL: process.env.DATABASE_URL || "sqlite:data.db",
+
   // NATS configuration
-  NATS_URLs: process.env.NATS_URLS || 'nats://localhost:4222',
-  
+  NATS_URLs: process.env.NATS_URLS || "nats://localhost:4222",
+
   // JWT configuration
-  JWT_SECRET: process.env.JWT_SECRET || 'your-secret-key-change-in-production',
-  JWT_EXPIRES_IN: process.env.JWT_EXPIRES_IN || '24h',
+  JWT_SECRET: process.env.JWT_SECRET || "your-secret-key-change-in-production",
+  JWT_EXPIRES_IN: process.env.JWT_EXPIRES_IN || "24h",
 });

--- a/api/src/config/database.config.ts
+++ b/api/src/config/database.config.ts
@@ -1,7 +1,7 @@
-import { ConfigService } from '@nestjs/config';
+import { ConfigService } from "@nestjs/config";
 
 export interface DatabaseConfig {
-  type: 'postgresql' | 'sqlite';
+  type: "postgresql" | "sqlite";
   url: string;
   host?: string;
   port?: number;
@@ -14,14 +14,15 @@ export interface DatabaseConfig {
 
 export function loadConfig(): DatabaseConfig {
   const databaseUrl = process.env.DATABASE_URL;
-  const databaseType = process.env.DATABASE_TYPE as 'postgresql' | 'sqlite' || 'sqlite';
+  const databaseType =
+    (process.env.DATABASE_TYPE as "postgresql" | "sqlite") || "sqlite";
 
-  if (databaseType === 'sqlite') {
+  if (databaseType === "sqlite") {
     return {
-      type: 'sqlite',
-      url: databaseUrl || './data/the0.db',
-      synchronize: process.env.NODE_ENV === 'development',
-      logging: process.env.NODE_ENV === 'development',
+      type: "sqlite",
+      url: databaseUrl || "./data/the0.db",
+      synchronize: process.env.NODE_ENV === "development",
+      logging: process.env.NODE_ENV === "development",
     };
   }
 
@@ -29,35 +30,35 @@ export function loadConfig(): DatabaseConfig {
   if (databaseUrl) {
     const url = new URL(databaseUrl);
     return {
-      type: 'postgresql',
+      type: "postgresql",
       url: databaseUrl,
       host: url.hostname,
       port: parseInt(url.port) || 5432,
       username: url.username,
       password: url.password,
       database: url.pathname.slice(1),
-      synchronize: process.env.NODE_ENV === 'development',
-      logging: process.env.NODE_ENV === 'development',
+      synchronize: process.env.NODE_ENV === "development",
+      logging: process.env.NODE_ENV === "development",
     };
   }
 
   // Fallback to individual environment variables
   return {
-    type: 'postgresql',
-    url: '', // Will be constructed
-    host: process.env.DB_HOST || 'localhost',
+    type: "postgresql",
+    url: "", // Will be constructed
+    host: process.env.DB_HOST || "localhost",
     port: parseInt(process.env.DB_PORT) || 5432,
-    username: process.env.DB_USERNAME || 'the0',
-    password: process.env.DB_PASSWORD || 'the0_password',
-    database: process.env.DB_DATABASE || 'the0_oss',
-    synchronize: process.env.NODE_ENV === 'development',
-    logging: process.env.NODE_ENV === 'development',
+    username: process.env.DB_USERNAME || "the0",
+    password: process.env.DB_PASSWORD || "the0_password",
+    database: process.env.DB_DATABASE || "the0_oss",
+    synchronize: process.env.NODE_ENV === "development",
+    logging: process.env.NODE_ENV === "development",
   };
 }
 
 export function createDatabaseConfigFactory() {
   return {
-    provide: 'DATABASE_CONFIG',
+    provide: "DATABASE_CONFIG",
     useFactory: (configService: ConfigService): DatabaseConfig => {
       return loadConfig();
     },

--- a/api/src/custom-bot/__tests__/custom-bot.controller.spec.ts
+++ b/api/src/custom-bot/__tests__/custom-bot.controller.spec.ts
@@ -1,41 +1,41 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { CustomBotController } from '../custom-bot.controller';
+import { BadRequestException, NotFoundException } from "@nestjs/common";
+import { CustomBotController } from "../custom-bot.controller";
 import {
   CustomBot,
   CustomBotConfig,
   CustomBotWithVersions,
-} from '../custom-bot.types';
-import { Ok, Failure } from '@/common/result';
-import { StorageService } from '../storage.service';
+} from "../custom-bot.types";
+import { Ok, Failure } from "@/common/result";
+import { StorageService } from "../storage.service";
 
-describe('CustomBotController', () => {
+describe("CustomBotController", () => {
   let controller: CustomBotController;
   let mockService: any;
   let mockStorageService: jest.Mocked<StorageService>;
   // Removed duplicate declaration
 
   const mockRequest = {
-    user: { uid: 'user123' },
-    userId: 'user123',
+    user: { uid: "user123" },
+    userId: "user123",
   } as any;
 
   const validConfig: CustomBotConfig = {
-    name: 'test-bot',
-    description: 'Test bot description',
-    version: '1.0.0',
-    type: 'scheduled',
-    runtime: 'python3.11',
-    author: 'Test Author',
+    name: "test-bot",
+    description: "Test bot description",
+    version: "1.0.0",
+    type: "scheduled",
+    runtime: "python3.11",
+    author: "Test Author",
     entrypoints: {
-      bot: 'main.py',
-      backtest: 'backtest.py',
+      bot: "main.py",
+      backtest: "backtest.py",
     },
     schema: {
-      bot: { type: 'object' },
-      backtest: { type: 'object' },
+      bot: { type: "object" },
+      backtest: { type: "object" },
     },
     readme:
-      'This is a test bot with enough content to pass validation requirements.',
+      "This is a test bot with enough content to pass validation requirements.",
   };
 
   beforeEach(() => {
@@ -61,32 +61,29 @@ describe('CustomBotController', () => {
     // Removed GcsService - using StorageService
 
     // Directly instantiate the controller with the mock services
-    controller = new CustomBotController(
-      mockService,
-      mockStorageService,
-    );
+    controller = new CustomBotController(mockService, mockStorageService);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('createCustomBot', () => {
-    it('should create custom bot successfully', async () => {
+  describe("createCustomBot", () => {
+    it("should create custom bot successfully", async () => {
       const mockBot = {
-        id: 'new-bot-id',
-        name: 'test-bot',
-        version: '1.0.0',
+        id: "new-bot-id",
+        name: "test-bot",
+        version: "1.0.0",
         config: validConfig,
         filePath:
-          'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip',
-        userId: 'user123',
+          "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip",
+        userId: "user123",
         createdAt: new Date(),
         updatedAt: new Date(),
       };
 
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
       const body = { config: JSON.stringify(validConfig), filePath };
 
       // Mock GCS file validation
@@ -98,43 +95,43 @@ describe('CustomBotController', () => {
       mockService.createCustomBot.mockResolvedValue(Ok(mockBot));
 
       const result = await controller.createCustomBot(
-        'test-bot',
+        "test-bot",
         body,
         mockRequest,
       );
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual(mockBot);
-      expect(result.message).toBe('Custom bot created successfully');
+      expect(result.message).toBe("Custom bot created successfully");
       expect(mockService.createCustomBot).toHaveBeenCalledWith(
-        'user123',
+        "user123",
         validConfig,
         filePath,
       );
     });
 
-    it('should throw BadRequestException when user ID is missing', async () => {
+    it("should throw BadRequestException when user ID is missing", async () => {
       const requestWithoutUser = {} as any;
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
       const body = { config: JSON.stringify(validConfig), filePath };
 
       await expect(
-        controller.createCustomBot('test-bot', body, requestWithoutUser),
+        controller.createCustomBot("test-bot", body, requestWithoutUser),
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('should throw BadRequestException when filePath is missing', async () => {
+    it("should throw BadRequestException when filePath is missing", async () => {
       const body = { config: JSON.stringify(validConfig) } as any;
 
       await expect(
-        controller.createCustomBot('test-bot', body, mockRequest),
+        controller.createCustomBot("test-bot", body, mockRequest),
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('should throw BadRequestException when file does not exist at filePath', async () => {
+    it("should throw BadRequestException when file does not exist at filePath", async () => {
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
       const body = { config: JSON.stringify(validConfig), filePath };
 
       // Mock GCS file validation to return file not found
@@ -145,31 +142,31 @@ describe('CustomBotController', () => {
       });
 
       await expect(
-        controller.createCustomBot('test-bot', body, mockRequest),
+        controller.createCustomBot("test-bot", body, mockRequest),
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('should throw BadRequestException when GCS validation fails', async () => {
+    it("should throw BadRequestException when GCS validation fails", async () => {
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
       const body = { config: JSON.stringify(validConfig), filePath };
 
       // Mock GCS file validation to return error
       mockStorageService.fileExists.mockResolvedValue({
         success: false,
         data: null,
-        error: 'GCS error',
+        error: "GCS error",
       });
 
       await expect(
-        controller.createCustomBot('test-bot', body, mockRequest),
+        controller.createCustomBot("test-bot", body, mockRequest),
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('should throw BadRequestException when config is missing', async () => {
+    it("should throw BadRequestException when config is missing", async () => {
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
-      const body = { config: '', filePath };
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
+      const body = { config: "", filePath };
 
       mockStorageService.fileExists.mockResolvedValue({
         success: true,
@@ -178,14 +175,14 @@ describe('CustomBotController', () => {
       });
 
       await expect(
-        controller.createCustomBot('test-bot', body, mockRequest),
+        controller.createCustomBot("test-bot", body, mockRequest),
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('should throw BadRequestException when config is invalid JSON', async () => {
+    it("should throw BadRequestException when config is invalid JSON", async () => {
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
-      const body = { config: 'invalid json', filePath };
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
+      const body = { config: "invalid json", filePath };
 
       mockStorageService.fileExists.mockResolvedValue({
         success: true,
@@ -194,18 +191,21 @@ describe('CustomBotController', () => {
       });
 
       await expect(
-        controller.createCustomBot('test-bot', body, mockRequest),
+        controller.createCustomBot("test-bot", body, mockRequest),
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('should throw BadRequestException when bot name mismatch', async () => {
+    it("should throw BadRequestException when bot name mismatch", async () => {
       const configWithDifferentName = {
         ...validConfig,
-        name: 'different-bot',
+        name: "different-bot",
       };
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
-      const body = { config: JSON.stringify(configWithDifferentName), filePath };
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
+      const body = {
+        config: JSON.stringify(configWithDifferentName),
+        filePath,
+      };
 
       mockStorageService.fileExists.mockResolvedValue({
         success: true,
@@ -214,13 +214,13 @@ describe('CustomBotController', () => {
       });
 
       await expect(
-        controller.createCustomBot('test-bot', body, mockRequest),
+        controller.createCustomBot("test-bot", body, mockRequest),
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('should throw BadRequestException when service returns error', async () => {
+    it("should throw BadRequestException when service returns error", async () => {
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
       const body = { config: JSON.stringify(validConfig), filePath };
 
       mockStorageService.fileExists.mockResolvedValue({
@@ -229,36 +229,36 @@ describe('CustomBotController', () => {
         error: null,
       });
       mockService.createCustomBot.mockResolvedValue(
-        Failure('Bot already exists'),
+        Failure("Bot already exists"),
       );
 
       await expect(
-        controller.createCustomBot('test-bot', body, mockRequest),
+        controller.createCustomBot("test-bot", body, mockRequest),
       ).rejects.toThrow(BadRequestException);
     });
   });
 
-  describe('updateCustomBot', () => {
-    it('should update custom bot successfully', async () => {
+  describe("updateCustomBot", () => {
+    it("should update custom bot successfully", async () => {
       const updateConfig = {
         ...validConfig,
-        version: '1.1.0',
+        version: "1.1.0",
       };
 
       const mockUpdatedBot = {
-        id: 'bot-id',
-        name: 'test-bot',
-        version: '1.1.0',
+        id: "bot-id",
+        name: "test-bot",
+        version: "1.1.0",
         config: updateConfig,
         filePath:
-          'gs://test-bucket/user123/test-bot/1.1.0/test-bot_1.1.0_123456.zip',
-        userId: 'user123',
+          "gs://test-bucket/user123/test-bot/1.1.0/test-bot_1.1.0_123456.zip",
+        userId: "user123",
         createdAt: new Date(),
         updatedAt: new Date(),
       };
 
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.1.0/test-bot_1.1.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.1.0/test-bot_1.1.0_123456.zip";
       const body = { config: JSON.stringify(updateConfig), filePath };
 
       mockStorageService.fileExists.mockResolvedValue({
@@ -269,25 +269,25 @@ describe('CustomBotController', () => {
       mockService.updateCustomBot.mockResolvedValue(Ok(mockUpdatedBot));
 
       const result = await controller.updateCustomBot(
-        'test-bot',
+        "test-bot",
         body,
         mockRequest,
       );
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual(mockUpdatedBot);
-      expect(result.message).toBe('Custom bot updated successfully');
+      expect(result.message).toBe("Custom bot updated successfully");
       expect(mockService.updateCustomBot).toHaveBeenCalledWith(
-        'user123',
-        'test-bot',
+        "user123",
+        "test-bot",
         updateConfig,
         filePath,
       );
     });
 
-    it('should throw BadRequestException when service returns error', async () => {
+    it("should throw BadRequestException when service returns error", async () => {
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
       const body = { config: JSON.stringify(validConfig), filePath };
 
       mockStorageService.fileExists.mockResolvedValue({
@@ -296,41 +296,44 @@ describe('CustomBotController', () => {
         error: null,
       });
       mockService.updateCustomBot.mockResolvedValue(
-        Failure('Version must be newer'),
+        Failure("Version must be newer"),
       );
 
       await expect(
-        controller.updateCustomBot('test-bot', body, mockRequest),
+        controller.updateCustomBot("test-bot", body, mockRequest),
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('should throw BadRequestException when user ID is missing', async () => {
+    it("should throw BadRequestException when user ID is missing", async () => {
       const requestWithoutUser = {} as any;
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
       const body = { config: JSON.stringify(validConfig), filePath };
 
       await expect(
-        controller.updateCustomBot('test-bot', body, requestWithoutUser),
+        controller.updateCustomBot("test-bot", body, requestWithoutUser),
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('should throw BadRequestException when filePath is missing', async () => {
+    it("should throw BadRequestException when filePath is missing", async () => {
       const body = { config: JSON.stringify(validConfig) } as any;
 
       await expect(
-        controller.updateCustomBot('test-bot', body, mockRequest),
+        controller.updateCustomBot("test-bot", body, mockRequest),
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('should throw BadRequestException when config name mismatch', async () => {
+    it("should throw BadRequestException when config name mismatch", async () => {
       const configWithDifferentName = {
         ...validConfig,
-        name: 'different-bot',
+        name: "different-bot",
       };
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
-      const body = { config: JSON.stringify(configWithDifferentName), filePath };
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
+      const body = {
+        config: JSON.stringify(configWithDifferentName),
+        filePath,
+      };
 
       mockStorageService.fileExists.mockResolvedValue({
         success: true,
@@ -339,17 +342,17 @@ describe('CustomBotController', () => {
       });
 
       await expect(
-        controller.updateCustomBot('test-bot', body, mockRequest),
+        controller.updateCustomBot("test-bot", body, mockRequest),
       ).rejects.toThrow(BadRequestException);
     });
   });
 
-  describe('generateUploadUrl', () => {
-    it('should generate upload URL successfully', async () => {
+  describe("generateUploadUrl", () => {
+    it("should generate upload URL successfully", async () => {
       const mockUploadResponse = {
-        uploadUrl: 'https://storage.googleapis.com/signed-url',
+        uploadUrl: "https://storage.googleapis.com/signed-url",
         filePath:
-          'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip',
+          "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip",
         expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
       };
 
@@ -359,10 +362,10 @@ describe('CustomBotController', () => {
         error: null,
       });
 
-      const body = { version: '1.0.0' };
+      const body = { version: "1.0.0" };
 
       const result = await controller.generateUploadUrl(
-        'test-bot',
+        "test-bot",
         body,
         mockRequest,
       );
@@ -371,115 +374,115 @@ describe('CustomBotController', () => {
       expect(result.filePath).toBe(mockUploadResponse.filePath);
       expect(result.expiresAt).toBeDefined();
       expect(mockStorageService.generateSignedUploadUrl).toHaveBeenCalledWith(
-        'user123',
-        'test-bot',
-        '1.0.0',
+        "user123",
+        "test-bot",
+        "1.0.0",
       );
     });
 
-    it('should throw BadRequestException when user ID is missing', async () => {
+    it("should throw BadRequestException when user ID is missing", async () => {
       const requestWithoutUser = {} as any;
-      const body = { version: '1.0.0' };
+      const body = { version: "1.0.0" };
 
       await expect(
-        controller.generateUploadUrl('test-bot', body, requestWithoutUser),
+        controller.generateUploadUrl("test-bot", body, requestWithoutUser),
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('should throw BadRequestException when version is missing', async () => {
+    it("should throw BadRequestException when version is missing", async () => {
       const body = {};
 
       await expect(
-        controller.generateUploadUrl('test-bot', body as any, mockRequest),
+        controller.generateUploadUrl("test-bot", body as any, mockRequest),
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('should throw BadRequestException when GCS service fails', async () => {
+    it("should throw BadRequestException when GCS service fails", async () => {
       mockStorageService.generateSignedUploadUrl.mockResolvedValue({
         success: false,
         data: null,
-        error: 'Failed to generate signed URL',
+        error: "Failed to generate signed URL",
       });
 
-      const body = { version: '1.0.0' };
+      const body = { version: "1.0.0" };
 
       await expect(
-        controller.generateUploadUrl('test-bot', body, mockRequest),
+        controller.generateUploadUrl("test-bot", body, mockRequest),
       ).rejects.toThrow(BadRequestException);
     });
   });
 
   // NEW TEST SECTION
-  describe('getUserCustomBots', () => {
-    it('should get user custom bots successfully', async () => {
+  describe("getUserCustomBots", () => {
+    it("should get user custom bots successfully", async () => {
       const mockUserBots: CustomBotWithVersions[] = [
         {
-          id: 'bot-id-1',
-          name: 'my-arbitrage-bot',
-          userId: 'user123',
-          latestVersion: '1.2.0',
+          id: "bot-id-1",
+          name: "my-arbitrage-bot",
+          userId: "user123",
+          latestVersion: "1.2.0",
           versions: [
             {
-              version: '1.2.0',
+              version: "1.2.0",
               config: {
                 ...validConfig,
-                name: 'my-arbitrage-bot',
-                version: '1.2.0',
-                description: 'Advanced arbitrage trading bot',
+                name: "my-arbitrage-bot",
+                version: "1.2.0",
+                description: "Advanced arbitrage trading bot",
               },
-              status: 'approved',
+              status: "approved",
               marketplace: null,
-              userId: 'test-user-123',
-              id: 'bot-id',
-              filePath: 'gs://bucket/user123/my-arbitrage-bot/1.2.0/file.zip',
-              createdAt: new Date('2025-01-15T10:30:00.000Z'),
-              updatedAt: new Date('2025-01-15T10:30:00.000Z'),
+              userId: "test-user-123",
+              id: "bot-id",
+              filePath: "gs://bucket/user123/my-arbitrage-bot/1.2.0/file.zip",
+              createdAt: new Date("2025-01-15T10:30:00.000Z"),
+              updatedAt: new Date("2025-01-15T10:30:00.000Z"),
             },
             {
-              version: '1.1.0',
+              version: "1.1.0",
               config: {
                 ...validConfig,
-                name: 'my-arbitrage-bot',
-                version: '1.1.0',
-                description: 'Basic arbitrage trading bot',
+                name: "my-arbitrage-bot",
+                version: "1.1.0",
+                description: "Basic arbitrage trading bot",
               },
-              filePath: 'gs://bucket/user123/my-arbitrage-bot/1.1.0/file.zip',
-              createdAt: new Date('2025-01-10T09:15:00.000Z'),
-              updatedAt: new Date('2025-01-10T09:15:00.000Z'),
-              status: 'approved',
+              filePath: "gs://bucket/user123/my-arbitrage-bot/1.1.0/file.zip",
+              createdAt: new Date("2025-01-10T09:15:00.000Z"),
+              updatedAt: new Date("2025-01-10T09:15:00.000Z"),
+              status: "approved",
               marketplace: null,
-              userId: 'test-user-123',
-              id: 'bot-id',
+              userId: "test-user-123",
+              id: "bot-id",
             },
           ],
-          createdAt: new Date('2025-01-10T09:15:00.000Z'),
-          updatedAt: new Date('2025-01-15T10:30:00.000Z'),
+          createdAt: new Date("2025-01-10T09:15:00.000Z"),
+          updatedAt: new Date("2025-01-15T10:30:00.000Z"),
         },
         {
-          id: 'bot-id-2',
-          name: 'trend-follower',
-          userId: 'user123',
-          latestVersion: '2.0.0',
+          id: "bot-id-2",
+          name: "trend-follower",
+          userId: "user123",
+          latestVersion: "2.0.0",
           versions: [
             {
-              version: '2.0.0',
+              version: "2.0.0",
               config: {
                 ...validConfig,
-                name: 'trend-follower',
-                version: '2.0.0',
-                description: 'Trend following strategy',
+                name: "trend-follower",
+                version: "2.0.0",
+                description: "Trend following strategy",
               },
-              filePath: 'gs://bucket/user123/trend-follower/2.0.0/file.zip',
-              createdAt: new Date('2025-01-12T14:20:00.000Z'),
-              updatedAt: new Date('2025-01-12T14:20:00.000Z'),
-              status: 'approved',
+              filePath: "gs://bucket/user123/trend-follower/2.0.0/file.zip",
+              createdAt: new Date("2025-01-12T14:20:00.000Z"),
+              updatedAt: new Date("2025-01-12T14:20:00.000Z"),
+              status: "approved",
               marketplace: null,
-              userId: 'test-user-123',
-              id: 'bot-id',
+              userId: "test-user-123",
+              id: "bot-id",
             },
           ],
-          createdAt: new Date('2025-01-12T14:20:00.000Z'),
-          updatedAt: new Date('2025-01-12T14:20:00.000Z'),
+          createdAt: new Date("2025-01-12T14:20:00.000Z"),
+          updatedAt: new Date("2025-01-12T14:20:00.000Z"),
         },
       ];
 
@@ -489,22 +492,22 @@ describe('CustomBotController', () => {
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual(mockUserBots);
-      expect(result.message).toBe('User custom bots retrieved successfully');
-      expect(mockService.getUserCustomBots).toHaveBeenCalledWith('user123');
+      expect(result.message).toBe("User custom bots retrieved successfully");
+      expect(mockService.getUserCustomBots).toHaveBeenCalledWith("user123");
     });
 
-    it('should return empty array when user has no custom bots', async () => {
+    it("should return empty array when user has no custom bots", async () => {
       mockService.getUserCustomBots.mockResolvedValue(Ok([]));
 
       const result = await controller.getUserCustomBots(mockRequest);
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual([]);
-      expect(result.message).toBe('User custom bots retrieved successfully');
-      expect(mockService.getUserCustomBots).toHaveBeenCalledWith('user123');
+      expect(result.message).toBe("User custom bots retrieved successfully");
+      expect(mockService.getUserCustomBots).toHaveBeenCalledWith("user123");
     });
 
-    it('should throw BadRequestException when user ID is missing', async () => {
+    it("should throw BadRequestException when user ID is missing", async () => {
       const requestWithoutUser = {} as any;
 
       await expect(
@@ -514,19 +517,19 @@ describe('CustomBotController', () => {
       expect(mockService.getUserCustomBots).not.toHaveBeenCalled();
     });
 
-    it('should throw BadRequestException when service returns error', async () => {
+    it("should throw BadRequestException when service returns error", async () => {
       mockService.getUserCustomBots.mockResolvedValue(
-        Failure('Database connection failed'),
+        Failure("Database connection failed"),
       );
 
       await expect(controller.getUserCustomBots(mockRequest)).rejects.toThrow(
         BadRequestException,
       );
 
-      expect(mockService.getUserCustomBots).toHaveBeenCalledWith('user123');
+      expect(mockService.getUserCustomBots).toHaveBeenCalledWith("user123");
     });
 
-    it('should handle request with undefined user object', async () => {
+    it("should handle request with undefined user object", async () => {
       const requestWithUndefinedUser = { user: undefined } as any;
 
       await expect(
@@ -536,7 +539,7 @@ describe('CustomBotController', () => {
       expect(mockService.getUserCustomBots).not.toHaveBeenCalled();
     });
 
-    it('should handle request with null user object', async () => {
+    it("should handle request with null user object", async () => {
       const requestWithNullUser = { user: null } as any;
 
       await expect(
@@ -546,7 +549,7 @@ describe('CustomBotController', () => {
       expect(mockService.getUserCustomBots).not.toHaveBeenCalled();
     });
 
-    it('should handle request with user object missing uid', async () => {
+    it("should handle request with user object missing uid", async () => {
       const requestWithUserNoUid = { user: {} } as any;
 
       await expect(
@@ -557,64 +560,64 @@ describe('CustomBotController', () => {
     });
   });
 
-  describe('getAllVersions', () => {
-    it('should get all versions successfully', async () => {
+  describe("getAllVersions", () => {
+    it("should get all versions successfully", async () => {
       const mockVersions = {
-        id: 'bot-id',
-        name: 'test-bot',
-        userId: 'user123',
+        id: "bot-id",
+        name: "test-bot",
+        userId: "user123",
         versions: [
           {
-            version: '1.1.0',
+            version: "1.1.0",
             config: validConfig,
-            filePath: 'gs://bucket/v1.1.zip',
+            filePath: "gs://bucket/v1.1.zip",
             createdAt: new Date(),
             updatedAt: new Date(),
           },
           {
-            version: '1.0.0',
+            version: "1.0.0",
             config: validConfig,
-            filePath: 'gs://bucket/v1.0.zip',
+            filePath: "gs://bucket/v1.0.zip",
             createdAt: new Date(),
             updatedAt: new Date(),
           },
         ],
-        latestVersion: '1.1.0',
+        latestVersion: "1.1.0",
         createdAt: new Date(),
         updatedAt: new Date(),
       };
 
       mockService.getAllGlobalVersions.mockResolvedValue(Ok(mockVersions));
 
-      const result = await controller.getAllVersions('test-bot', mockRequest);
+      const result = await controller.getAllVersions("test-bot", mockRequest);
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual(mockVersions);
-      expect(result.message).toBe('Bot versions retrieved successfully');
-      expect(mockService.getAllGlobalVersions).toHaveBeenCalledWith('test-bot');
+      expect(result.message).toBe("Bot versions retrieved successfully");
+      expect(mockService.getAllGlobalVersions).toHaveBeenCalledWith("test-bot");
     });
 
-    it('should throw NotFoundException when bot not found', async () => {
+    it("should throw NotFoundException when bot not found", async () => {
       mockService.getAllGlobalVersions.mockResolvedValue(
-        Failure('Bot not found'),
+        Failure("Bot not found"),
       );
 
       await expect(
-        controller.getAllVersions('non-existent-bot', mockRequest),
+        controller.getAllVersions("non-existent-bot", mockRequest),
       ).rejects.toThrow(NotFoundException);
     });
   });
 
-  describe('getSpecificVersion', () => {
-    it('should get specific version successfully', async () => {
+  describe("getSpecificVersion", () => {
+    it("should get specific version successfully", async () => {
       const mockBot = {
-        id: 'bot-version-id',
-        name: 'test-bot',
-        version: '1.0.0',
+        id: "bot-version-id",
+        name: "test-bot",
+        version: "1.0.0",
         config: validConfig,
         filePath:
-          'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip',
-        userId: 'user123',
+          "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip",
+        userId: "user123",
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -622,27 +625,27 @@ describe('CustomBotController', () => {
       mockService.getGlobalSpecificVersion.mockResolvedValue(Ok(mockBot));
 
       const result = await controller.getSpecificVersion(
-        'test-bot',
-        '1.0.0',
+        "test-bot",
+        "1.0.0",
         mockRequest,
       );
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual(mockBot);
-      expect(result.message).toBe('Bot version retrieved successfully');
+      expect(result.message).toBe("Bot version retrieved successfully");
       expect(mockService.getGlobalSpecificVersion).toHaveBeenCalledWith(
-        'test-bot',
-        '1.0.0',
+        "test-bot",
+        "1.0.0",
       );
     });
 
-    it('should throw NotFoundException when version not found', async () => {
+    it("should throw NotFoundException when version not found", async () => {
       mockService.getGlobalSpecificVersion.mockResolvedValue(
-        Failure('Version not found'),
+        Failure("Version not found"),
       );
 
       await expect(
-        controller.getSpecificVersion('test-bot', '2.0.0', mockRequest),
+        controller.getSpecificVersion("test-bot", "2.0.0", mockRequest),
       ).rejects.toThrow(NotFoundException);
     });
   });

--- a/api/src/custom-bot/__tests__/custom-bot.integration.spec.ts
+++ b/api/src/custom-bot/__tests__/custom-bot.integration.spec.ts
@@ -1,59 +1,59 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
-import request from 'supertest';
-import { CustomBotModule } from '../custom-bot.module';
-import { CustomBotRepository } from '../custom-bot.repository';
-import { StorageService } from '../storage.service';
-import { Ok, Failure } from '@/common/result';
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication } from "@nestjs/common";
+import request from "supertest";
+import { CustomBotModule } from "../custom-bot.module";
+import { CustomBotRepository } from "../custom-bot.repository";
+import { StorageService } from "../storage.service";
+import { Ok, Failure } from "@/common/result";
 import {
   CustomBot,
   CustomBotConfig,
   CustomBotWithVersions,
-} from '@/custom-bot/custom-bot.types';
-import { AuthCombinedGuard } from '@/auth/auth-combined.guard';
-import { NatsService } from '@/nats/nats.service';
-import { CustomBotEventsService } from '../custom-bot-events.service';
+} from "@/custom-bot/custom-bot.types";
+import { AuthCombinedGuard } from "@/auth/auth-combined.guard";
+import { NatsService } from "@/nats/nats.service";
+import { CustomBotEventsService } from "../custom-bot-events.service";
 // Removed StripeConnectService - not needed in OSS version
 
 // Mock database and storage
-jest.mock('@/database/connection');
-jest.mock('../storage.service');
+jest.mock("@/database/connection");
+jest.mock("../storage.service");
 
-describe('Custom Bot API Integration Tests', () => {
+describe("Custom Bot API Integration Tests", () => {
   let app: INestApplication;
   let repository: jest.Mocked<CustomBotRepository>;
   let storageService: jest.Mocked<StorageService>;
   // Removed StripeConnectService - not needed in OSS version
 
   const validConfig: CustomBotConfig = {
-    name: 'integration-test-bot',
-    description: 'Integration test bot description',
-    version: '1.0.0',
-    author: 'Test Author',
-    type: 'scheduled',
-    runtime: 'python3.11',
+    name: "integration-test-bot",
+    description: "Integration test bot description",
+    version: "1.0.0",
+    author: "Test Author",
+    type: "scheduled",
+    runtime: "python3.11",
     entrypoints: {
-      bot: 'main.py',
-      backtest: 'backtest.py',
+      bot: "main.py",
+      backtest: "backtest.py",
     },
     schema: {
-      bot: { type: 'object' },
-      backtest: { type: 'object' },
+      bot: { type: "object" },
+      backtest: { type: "object" },
     },
     readme:
-      'This is a comprehensive readme for integration testing that meets all requirements.',
+      "This is a comprehensive readme for integration testing that meets all requirements.",
   };
 
   // Create a mock ZIP file buffer
   const createMockZipBuffer = (): Buffer => {
     // Simple ZIP file structure simulation
-    return Buffer.from('PK\x03\x04mock-zip-content');
+    return Buffer.from("PK\x03\x04mock-zip-content");
   };
 
   // Mock auth middleware
   const mockAuthMiddleware = (req: any, res: any, next: any) => {
-    req.userId = 'test-user-123';
-    req.user = { uid: 'test-user-123' };
+    req.userId = "test-user-123";
+    req.user = { uid: "test-user-123" };
     next();
   };
 
@@ -65,15 +65,17 @@ describe('Custom Bot API Integration Tests', () => {
       .useValue({
         globalBotExists: jest.fn().mockResolvedValue(Ok(false)),
         globalVersionExists: jest.fn().mockResolvedValue(Ok(false)),
-        createNewGlobalVersion: jest.fn().mockResolvedValue(Ok({
-          id: 'mock-bot-id',
-          name: 'mock-bot',
-          version: '1.0.0',
-          userId: 'test-user-123',
-          status: 'pending_review',
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        })),
+        createNewGlobalVersion: jest.fn().mockResolvedValue(
+          Ok({
+            id: "mock-bot-id",
+            name: "mock-bot",
+            version: "1.0.0",
+            userId: "test-user-123",
+            status: "pending_review",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          }),
+        ),
         getAllGlobalVersions: jest.fn().mockResolvedValue(Ok([])),
         getSpecificGlobalVersion: jest.fn().mockResolvedValue(Ok(null)),
         getGlobalLatestVersion: jest.fn().mockResolvedValue(Ok(null)),
@@ -88,14 +90,16 @@ describe('Custom Bot API Integration Tests', () => {
       })
       .overrideProvider(StorageService)
       .useValue({
-        generateSignedUploadUrl: jest.fn().mockResolvedValue(Ok({
-          uploadUrl: 'https://minio.test/upload-url',
-          filePath: 'test/path',
-          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
-        })),
+        generateSignedUploadUrl: jest.fn().mockResolvedValue(
+          Ok({
+            uploadUrl: "https://minio.test/upload-url",
+            filePath: "test/path",
+            expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+          }),
+        ),
         fileExists: jest.fn().mockResolvedValue(Ok(true)),
         validateZipStructure: jest.fn().mockResolvedValue(Ok(true)),
-        uploadBotFile: jest.fn().mockResolvedValue(Ok('test/path')),
+        uploadBotFile: jest.fn().mockResolvedValue(Ok("test/path")),
         deleteBotFile: jest.fn().mockResolvedValue(Ok(null)),
         getFileMetadata: jest.fn().mockResolvedValue(Ok({})),
         validateZipFile: jest.fn().mockResolvedValue(Ok(true)),
@@ -122,7 +126,7 @@ describe('Custom Bot API Integration Tests', () => {
     app = moduleFixture.createNestApplication();
 
     // Apply mock auth middleware
-    app.use('/custom-bots', mockAuthMiddleware);
+    app.use("/custom-bots", mockAuthMiddleware);
 
     await app.init();
 
@@ -138,19 +142,19 @@ describe('Custom Bot API Integration Tests', () => {
     jest.clearAllMocks();
   });
 
-  describe('POST /custom-bots/:name (Signed URL Deploy)', () => {
-    it('should create a new custom bot successfully with signed URL', async () => {
+  describe("POST /custom-bots/:name (Signed URL Deploy)", () => {
+    it("should create a new custom bot successfully with signed URL", async () => {
       const filePath =
-        'gs://test-bucket/user123/integration-test-bot/1.0.0/integration-test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/integration-test-bot/1.0.0/integration-test-bot_1.0.0_123456.zip";
 
       const mockCreatedBot: CustomBot = {
-        id: 'new-bot-id',
-        name: 'integration-test-bot',
-        version: '1.0.0',
+        id: "new-bot-id",
+        name: "integration-test-bot",
+        version: "1.0.0",
         config: validConfig,
         filePath,
-        userId: 'test-user-123',
-        status: 'pending_review',
+        userId: "test-user-123",
+        status: "pending_review",
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -163,7 +167,7 @@ describe('Custom Bot API Integration Tests', () => {
       repository.getSpecificGlobalVersion.mockResolvedValue(Ok(mockCreatedBot));
 
       const response = await request(app.getHttpServer())
-        .post('/custom-bots/integration-test-bot')
+        .post("/custom-bots/integration-test-bot")
         .send({
           config: JSON.stringify(validConfig),
           filePath: filePath,
@@ -171,36 +175,36 @@ describe('Custom Bot API Integration Tests', () => {
         .expect(201);
 
       expect(response.body.success).toBe(true);
-      expect(response.body.data.name).toBe('integration-test-bot');
-      expect(response.body.message).toBe('Custom bot created successfully');
+      expect(response.body.data.name).toBe("integration-test-bot");
+      expect(response.body.message).toBe("Custom bot created successfully");
 
       // Verify service calls
       expect(storageService.fileExists).toHaveBeenCalledWith(filePath);
       expect(storageService.validateZipStructure).toHaveBeenCalledWith(
         filePath,
-        ['main.py', 'backtest.py'],
+        ["main.py", "backtest.py"],
       );
     });
 
-    it('should return 400 when filePath is missing', async () => {
+    it("should return 400 when filePath is missing", async () => {
       const response = await request(app.getHttpServer())
-        .post('/custom-bots/integration-test-bot')
+        .post("/custom-bots/integration-test-bot")
         .send({
           config: JSON.stringify(validConfig),
         })
         .expect(400);
 
-      expect(response.body.message).toBe('file path is required');
+      expect(response.body.message).toBe("file path is required");
     });
 
-    it('should return 400 when file does not exist at filePath', async () => {
+    it("should return 400 when file does not exist at filePath", async () => {
       const filePath =
-        'gs://test-bucket/user123/integration-test-bot/1.0.0/nonexistent.zip';
+        "gs://test-bucket/user123/integration-test-bot/1.0.0/nonexistent.zip";
 
       storageService.fileExists.mockResolvedValue(Ok(false));
 
       const response = await request(app.getHttpServer())
-        .post('/custom-bots/integration-test-bot')
+        .post("/custom-bots/integration-test-bot")
         .send({
           config: JSON.stringify(validConfig),
           filePath: filePath,
@@ -208,55 +212,55 @@ describe('Custom Bot API Integration Tests', () => {
         .expect(400);
 
       expect(response.body.message).toBe(
-        'File not found at specified file path',
+        "File not found at specified file path",
       );
     });
 
-    it('should return 400 when config is missing', async () => {
+    it("should return 400 when config is missing", async () => {
       const filePath =
-        'gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip';
+        "gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip";
 
       storageService.fileExists.mockResolvedValue(Ok(true));
 
       const response = await request(app.getHttpServer())
-        .post('/custom-bots/integration-test-bot')
+        .post("/custom-bots/integration-test-bot")
         .send({
           filePath: filePath,
         })
         .expect(400);
 
-      expect(response.body.message).toBe('Config field is required');
+      expect(response.body.message).toBe("Config field is required");
     });
 
-    it('should return 400 when config is invalid JSON', async () => {
+    it("should return 400 when config is invalid JSON", async () => {
       const filePath =
-        'gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip';
+        "gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip";
 
       storageService.fileExists.mockResolvedValue(Ok(true));
 
       const response = await request(app.getHttpServer())
-        .post('/custom-bots/integration-test-bot')
+        .post("/custom-bots/integration-test-bot")
         .send({
-          config: 'invalid-json',
+          config: "invalid-json",
           filePath: filePath,
         })
         .expect(400);
 
-      expect(response.body.message).toBe('Config must be valid JSON');
+      expect(response.body.message).toBe("Config must be valid JSON");
     });
 
-    it('should return 400 when bot name in config doesnt match URL', async () => {
+    it("should return 400 when bot name in config doesnt match URL", async () => {
       const filePath =
-        'gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip';
+        "gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip";
       const configWithDifferentName = {
         ...validConfig,
-        name: 'different-name',
+        name: "different-name",
       };
 
       storageService.fileExists.mockResolvedValue(Ok(true));
 
       const response = await request(app.getHttpServer())
-        .post('/custom-bots/integration-test-bot')
+        .post("/custom-bots/integration-test-bot")
         .send({
           config: JSON.stringify(configWithDifferentName),
           filePath: filePath,
@@ -264,19 +268,19 @@ describe('Custom Bot API Integration Tests', () => {
         .expect(400);
 
       expect(response.body.message).toBe(
-        'Bot name in config must match URL parameter',
+        "Bot name in config must match URL parameter",
       );
     });
 
-    it('should return 400 when bot already exists', async () => {
+    it("should return 400 when bot already exists", async () => {
       const filePath =
-        'gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip';
+        "gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip";
 
       storageService.fileExists.mockResolvedValue(Ok(true));
       repository.globalBotExists.mockResolvedValue(Ok(true));
 
       const response = await request(app.getHttpServer())
-        .post('/custom-bots/integration-test-bot')
+        .post("/custom-bots/integration-test-bot")
         .send({
           config: JSON.stringify(validConfig),
           filePath: filePath,
@@ -284,79 +288,79 @@ describe('Custom Bot API Integration Tests', () => {
         .expect(400);
 
       expect(response.body.message).toContain(
-        'Custom bot with this name already exists',
+        "Custom bot with this name already exists",
       );
     });
 
-    it('should return 400 when ZIP validation fails', async () => {
+    it("should return 400 when ZIP validation fails", async () => {
       const filePath =
-        'gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip';
+        "gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip";
 
       storageService.fileExists.mockResolvedValue(Ok(true));
       repository.globalBotExists.mockResolvedValue(Ok(false));
       storageService.validateZipStructure.mockResolvedValue(
-        Failure('Required bot entrypoint main.py not found in ZIP'),
+        Failure("Required bot entrypoint main.py not found in ZIP"),
       );
 
       const response = await request(app.getHttpServer())
-        .post('/custom-bots/integration-test-bot')
+        .post("/custom-bots/integration-test-bot")
         .send({
           config: JSON.stringify(validConfig),
           filePath: filePath,
         })
         .expect(400);
 
-      expect(response.body.message).toContain('ZIP validation failed');
+      expect(response.body.message).toContain("ZIP validation failed");
     });
 
-    it('should return 400 when config validation fails', async () => {
+    it("should return 400 when config validation fails", async () => {
       const filePath =
-        'gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip';
+        "gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip";
       const invalidConfig = {
         ...validConfig,
-        version: 'invalid-version', // Invalid semver
+        version: "invalid-version", // Invalid semver
       };
 
       storageService.fileExists.mockResolvedValue(Ok(true));
 
       const response = await request(app.getHttpServer())
-        .post('/custom-bots/integration-test-bot')
+        .post("/custom-bots/integration-test-bot")
         .send({
           config: JSON.stringify(invalidConfig),
           filePath: filePath,
         })
         .expect(400);
 
-      expect(response.body.message).toContain('Validation failed');
+      expect(response.body.message).toContain("Validation failed");
     });
   });
 
-  describe('PUT /custom-bots/:name (Signed URL Deploy)', () => {
-    it('should update bot with new version successfully', async () => {
+  describe("PUT /custom-bots/:name (Signed URL Deploy)", () => {
+    it("should update bot with new version successfully", async () => {
       const filePath =
-        'gs://test-bucket/user123/integration-test-bot/1.1.0/integration-test-bot_1.1.0_123456.zip';
+        "gs://test-bucket/user123/integration-test-bot/1.1.0/integration-test-bot_1.1.0_123456.zip";
       const updateConfig = {
         ...validConfig,
-        version: '1.1.0',
-        description: 'Updated bot description',
+        version: "1.1.0",
+        description: "Updated bot description",
       };
 
       const mockExistingBot: CustomBot = {
-        id: 'existing-id',
-        name: 'integration-test-bot',
-        version: '1.0.0',
+        id: "existing-id",
+        name: "integration-test-bot",
+        version: "1.0.0",
         config: validConfig,
-        filePath: 'gs://test-bucket/old-file.zip',
-        userId: 'test-user-123',
-        status: 'approved',
+        filePath: "gs://test-bucket/old-file.zip",
+        userId: "test-user-123",
+        status: "approved",
         createdAt: new Date(),
         updatedAt: new Date(),
       };
 
       const mockUpdatedBot: CustomBot = {
         ...mockExistingBot,
-        id: 'new-version-id',
-        version: '1.1.0',
+        id: "new-version-id",
+        version: "1.1.0",
         config: updateConfig,
         filePath: filePath,
       };
@@ -371,7 +375,7 @@ describe('Custom Bot API Integration Tests', () => {
       repository.createNewGlobalVersion.mockResolvedValue(Ok(mockUpdatedBot));
 
       const response = await request(app.getHttpServer())
-        .put('/custom-bots/integration-test-bot')
+        .put("/custom-bots/integration-test-bot")
         .send({
           config: JSON.stringify(updateConfig),
           filePath: filePath,
@@ -379,62 +383,62 @@ describe('Custom Bot API Integration Tests', () => {
         .expect(200);
 
       expect(response.body.success).toBe(true);
-      expect(response.body.data.version).toBe('1.1.0');
-      expect(response.body.message).toBe('Custom bot updated successfully');
+      expect(response.body.data.version).toBe("1.1.0");
+      expect(response.body.message).toBe("Custom bot updated successfully");
     });
 
-    it('should return 400 when bot does not exist', async () => {
+    it("should return 400 when bot does not exist", async () => {
       const filePath =
-        'gs://test-bucket/user123/non-existent-bot/1.0.0/test-bot.zip';
+        "gs://test-bucket/user123/non-existent-bot/1.0.0/test-bot.zip";
 
       storageService.fileExists.mockResolvedValue(Ok(true));
       repository.globalBotExists.mockResolvedValue(Ok(false));
 
       const response = await request(app.getHttpServer())
-        .put('/custom-bots/non-existent-bot')
+        .put("/custom-bots/non-existent-bot")
         .send({
-          config: JSON.stringify({ ...validConfig, name: 'non-existent-bot' }),
+          config: JSON.stringify({ ...validConfig, name: "non-existent-bot" }),
           filePath: filePath,
         })
         .expect(400);
 
       expect(response.body.message).toBe(
-        'Custom bot does not exist. Create it first using POST.',
+        "Custom bot does not exist. Create it first using POST.",
       );
     });
 
-    it('should return 400 when user is not the owner', async () => {
+    it("should return 400 when user is not the owner", async () => {
       const filePath =
-        'gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip';
+        "gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip";
 
       storageService.fileExists.mockResolvedValue(Ok(true));
       repository.globalBotExists.mockResolvedValue(Ok(true));
       repository.checkUserOwnership.mockResolvedValue(
-        Failure('Insufficient permissions'),
+        Failure("Insufficient permissions"),
       );
 
       const response = await request(app.getHttpServer())
-        .put('/custom-bots/integration-test-bot')
+        .put("/custom-bots/integration-test-bot")
         .send({
           config: JSON.stringify(validConfig),
           filePath: filePath,
         })
         .expect(400);
 
-      expect(response.body.message).toBe('Insufficient permissions');
+      expect(response.body.message).toBe("Insufficient permissions");
     });
 
-    it('should return 400 when version is not newer', async () => {
+    it("should return 400 when version is not newer", async () => {
       const filePath =
-        'gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip';
+        "gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip";
       const mockExistingBot: CustomBot = {
-        id: 'existing-id',
-        name: 'integration-test-bot',
-        version: '2.0.0', // Higher than payload version
+        id: "existing-id",
+        name: "integration-test-bot",
+        version: "2.0.0", // Higher than payload version
         config: validConfig,
-        filePath: 'gs://test-bucket/old-file.zip',
-        userId: 'test-user-123',
-        status: 'approved',
+        filePath: "gs://test-bucket/old-file.zip",
+        userId: "test-user-123",
+        status: "approved",
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -446,7 +450,7 @@ describe('Custom Bot API Integration Tests', () => {
       repository.isVersionNewer.mockReturnValue(false);
 
       const response = await request(app.getHttpServer())
-        .put('/custom-bots/integration-test-bot')
+        .put("/custom-bots/integration-test-bot")
         .send({
           config: JSON.stringify(validConfig),
           filePath: filePath,
@@ -454,21 +458,21 @@ describe('Custom Bot API Integration Tests', () => {
         .expect(400);
 
       expect(response.body.message).toContain(
-        'must be greater than current version',
+        "must be greater than current version",
       );
     });
 
-    it('should return 400 when version already exists', async () => {
+    it("should return 400 when version already exists", async () => {
       const filePath =
-        'gs://test-bucket/user123/integration-test-bot/1.1.0/test-bot.zip';
+        "gs://test-bucket/user123/integration-test-bot/1.1.0/test-bot.zip";
       const mockExistingBot: CustomBot = {
-        id: 'existing-id',
-        name: 'integration-test-bot',
-        version: '1.0.0',
+        id: "existing-id",
+        name: "integration-test-bot",
+        version: "1.0.0",
         config: validConfig,
-        filePath: 'gs://test-bucket/old-file.zip',
-        userId: 'test-user-123',
-        status: 'approved',
+        filePath: "gs://test-bucket/old-file.zip",
+        userId: "test-user-123",
+        status: "approved",
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -481,24 +485,24 @@ describe('Custom Bot API Integration Tests', () => {
       repository.globalVersionExists.mockResolvedValue(Ok(true)); // Version exists
 
       const response = await request(app.getHttpServer())
-        .put('/custom-bots/integration-test-bot')
+        .put("/custom-bots/integration-test-bot")
         .send({
-          config: JSON.stringify({ ...validConfig, version: '1.1.0' }),
+          config: JSON.stringify({ ...validConfig, version: "1.1.0" }),
           filePath: filePath,
         })
         .expect(400);
 
-      expect(response.body.message).toContain('already exists for this bot');
+      expect(response.body.message).toContain("already exists for this bot");
     });
   });
 
-  describe('POST /custom-bots/:name/upload-url', () => {
-    it('should generate upload URL successfully', async () => {
+  describe("POST /custom-bots/:name/upload-url", () => {
+    it("should generate upload URL successfully", async () => {
       const mockUploadResponse = {
         uploadUrl:
-          'https://storage.googleapis.com/bucket/path?signature=abc123',
+          "https://storage.googleapis.com/bucket/path?signature=abc123",
         filePath:
-          'gs://test-bucket/user123/integration-test-bot/1.0.0/integration-test-bot_1.0.0_123456.zip',
+          "gs://test-bucket/user123/integration-test-bot/1.0.0/integration-test-bot_1.0.0_123456.zip",
         expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
       };
 
@@ -507,8 +511,8 @@ describe('Custom Bot API Integration Tests', () => {
       );
 
       const response = await request(app.getHttpServer())
-        .post('/custom-bots/integration-test-bot/upload-url')
-        .send({ version: '1.0.0' })
+        .post("/custom-bots/integration-test-bot/upload-url")
+        .send({ version: "1.0.0" })
         .expect(200);
 
       expect(response.body.uploadUrl).toBe(mockUploadResponse.uploadUrl);
@@ -516,60 +520,60 @@ describe('Custom Bot API Integration Tests', () => {
       expect(response.body.expiresAt).toBeDefined();
     });
 
-    it('should return 400 when version is missing', async () => {
+    it("should return 400 when version is missing", async () => {
       const response = await request(app.getHttpServer())
-        .post('/custom-bots/integration-test-bot/upload-url')
+        .post("/custom-bots/integration-test-bot/upload-url")
         .send({})
         .expect(400);
 
-      expect(response.body.message).toBe('Version is required');
+      expect(response.body.message).toBe("Version is required");
     });
 
-    it('should return 400 when GCS service fails', async () => {
+    it("should return 400 when GCS service fails", async () => {
       storageService.generateSignedUploadUrl.mockResolvedValue(
-        Failure('Failed to generate signed URL'),
+        Failure("Failed to generate signed URL"),
       );
 
       const response = await request(app.getHttpServer())
-        .post('/custom-bots/integration-test-bot/upload-url')
-        .send({ version: '1.0.0' })
+        .post("/custom-bots/integration-test-bot/upload-url")
+        .send({ version: "1.0.0" })
         .expect(400);
 
-      expect(response.body.message).toContain('Failed to generate upload URL');
+      expect(response.body.message).toContain("Failed to generate upload URL");
     });
   });
 
-  describe('GET /custom-bots/:name', () => {
-    it('should get all versions successfully', async () => {
+  describe("GET /custom-bots/:name", () => {
+    it("should get all versions successfully", async () => {
       const mockVersionsData = {
-        id: 'bot-id',
-        name: 'integration-test-bot',
-        userId: 'test-user-123',
+        id: "bot-id",
+        name: "integration-test-bot",
+        userId: "test-user-123",
         versions: [
           {
-            version: '1.1.0',
-            config: { ...validConfig, version: '1.1.0' },
-            filePath: 'gs://bucket/v1.1.zip',
+            version: "1.1.0",
+            config: { ...validConfig, version: "1.1.0" },
+            filePath: "gs://bucket/v1.1.zip",
             createdAt: new Date(),
             updatedAt: new Date(),
-            status: 'approved',
+            status: "approved",
             marketplace: null,
-            userId: 'test-user-123',
-            id: 'bot-id',
+            userId: "test-user-123",
+            id: "bot-id",
           },
           {
-            version: '1.0.0',
+            version: "1.0.0",
             config: validConfig,
-            filePath: 'gs://bucket/v1.0.zip',
+            filePath: "gs://bucket/v1.0.zip",
             createdAt: new Date(),
             updatedAt: new Date(),
-            status: 'approved',
+            status: "approved",
             marketplace: null,
-            userId: 'test-user-123',
-            id: 'bot-id',
+            userId: "test-user-123",
+            id: "bot-id",
           },
         ],
-        latestVersion: '1.1.0',
+        latestVersion: "1.1.0",
         createdAt: new Date(),
         updatedAt: new Date(),
       } as unknown as CustomBotWithVersions;
@@ -577,38 +581,38 @@ describe('Custom Bot API Integration Tests', () => {
       repository.getAllGlobalVersions.mockResolvedValue(Ok(mockVersionsData));
 
       const response = await request(app.getHttpServer())
-        .get('/custom-bots/integration-test-bot')
+        .get("/custom-bots/integration-test-bot")
         .expect(200);
 
       expect(response.body.success).toBe(true);
       expect(response.body.data.versions).toHaveLength(2);
-      expect(response.body.data.latestVersion).toBe('1.1.0');
-      expect(response.body.message).toBe('Bot versions retrieved successfully');
+      expect(response.body.data.latestVersion).toBe("1.1.0");
+      expect(response.body.message).toBe("Bot versions retrieved successfully");
     });
 
-    it('should return 404 when bot not found', async () => {
+    it("should return 404 when bot not found", async () => {
       repository.getAllGlobalVersions.mockResolvedValue(
-        Failure('Bot not found'),
+        Failure("Bot not found"),
       );
 
       const response = await request(app.getHttpServer())
-        .get('/custom-bots/non-existent-bot')
+        .get("/custom-bots/non-existent-bot")
         .expect(404);
 
-      expect(response.body.message).toBe('Bot not found');
+      expect(response.body.message).toBe("Bot not found");
     });
   });
 
-  describe('GET /custom-bots/:name/:version', () => {
-    it('should get specific version successfully', async () => {
+  describe("GET /custom-bots/:name/:version", () => {
+    it("should get specific version successfully", async () => {
       const mockBot: CustomBot = {
-        id: 'specific-version-id',
-        name: 'integration-test-bot',
-        version: '1.0.0',
+        id: "specific-version-id",
+        name: "integration-test-bot",
+        version: "1.0.0",
         config: validConfig,
-        filePath: 'gs://test-bucket/file.zip',
-        status: 'approved',
-        userId: 'test-user-123',
+        filePath: "gs://test-bucket/file.zip",
+        status: "approved",
+        userId: "test-user-123",
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -616,58 +620,56 @@ describe('Custom Bot API Integration Tests', () => {
       repository.getSpecificGlobalVersion.mockResolvedValue(Ok(mockBot));
 
       const response = await request(app.getHttpServer())
-        .get('/custom-bots/integration-test-bot/1.0.0')
+        .get("/custom-bots/integration-test-bot/1.0.0")
         .expect(200);
 
       expect(response.body.success).toBe(true);
-      expect(response.body.data.version).toBe('1.0.0');
-      expect(response.body.message).toBe('Bot version retrieved successfully');
+      expect(response.body.data.version).toBe("1.0.0");
+      expect(response.body.message).toBe("Bot version retrieved successfully");
     });
 
-    it('should return 404 when specific version not found', async () => {
+    it("should return 404 when specific version not found", async () => {
       repository.getSpecificGlobalVersion.mockResolvedValue(
-        Failure('Version not found'),
+        Failure("Version not found"),
       );
 
       const response = await request(app.getHttpServer())
-        .get('/custom-bots/integration-test-bot/2.0.0')
+        .get("/custom-bots/integration-test-bot/2.0.0")
         .expect(404);
 
-      expect(response.body.message).toBe('Version not found');
+      expect(response.body.message).toBe("Version not found");
     });
   });
 
-  describe('End-to-end workflow with file uploads', () => {
-    it('should complete full bot lifecycle: create -> update -> retrieve', async () => {
-      const botName = 'e2e-test-bot';
+  describe("End-to-end workflow with file uploads", () => {
+    it("should complete full bot lifecycle: create -> update -> retrieve", async () => {
+      const botName = "e2e-test-bot";
 
       // Step 1: Create initial bot
       const createConfig: CustomBotConfig = {
         name: botName,
-        description: 'End-to-end test bot',
-        version: '1.0.0',
-        type: 'scheduled',
-        runtime: 'python3.11',
-        author: 'E2E Test',
-        entrypoints: { bot: 'main.py', backtest: 'backtest.py' },
+        description: "End-to-end test bot",
+        version: "1.0.0",
+        type: "scheduled",
+        runtime: "python3.11",
+        author: "E2E Test",
+        entrypoints: { bot: "main.py", backtest: "backtest.py" },
         schema: { bot: {}, backtest: {} },
         readme:
-          'E2E test bot readme with sufficient length for validation requirements.',
+          "E2E test bot readme with sufficient length for validation requirements.",
       };
 
       storageService.fileExists.mockResolvedValueOnce(Ok(true));
-      storageService.validateZipStructure.mockResolvedValueOnce(
-        Ok(true),
-      );
+      storageService.validateZipStructure.mockResolvedValueOnce(Ok(true));
       repository.globalBotExists.mockResolvedValueOnce(Ok(false));
       const mockCreatedBot = {
-        id: 'e2e-v1-id',
+        id: "e2e-v1-id",
         name: botName,
-        version: '1.0.0',
+        version: "1.0.0",
         config: createConfig,
-        status: 'pending_review',
-        filePath: 'gs://test-bucket/e2e-v1.zip',
-        userId: 'test-user-123',
+        status: "pending_review",
+        filePath: "gs://test-bucket/e2e-v1.zip",
+        userId: "test-user-123",
         createdAt: new Date(),
         updatedAt: new Date(),
       } as unknown as CustomBot;
@@ -682,34 +684,32 @@ describe('Custom Bot API Integration Tests', () => {
         .post(`/custom-bots/${botName}`)
         .send({
           config: JSON.stringify(createConfig),
-          filePath: 'gs://test-bucket/e2e-v1.zip',
+          filePath: "gs://test-bucket/e2e-v1.zip",
         })
         .expect(201);
 
-      expect(createResponse.body.data.version).toBe('1.0.0');
+      expect(createResponse.body.data.version).toBe("1.0.0");
 
       // Step 2: Update with new version
       const updateConfig = {
         ...createConfig,
-        version: '1.1.0',
-        description: 'Updated E2E test bot',
+        version: "1.1.0",
+        description: "Updated E2E test bot",
       };
 
       storageService.fileExists.mockResolvedValueOnce(Ok(true));
-      storageService.validateZipStructure.mockResolvedValueOnce(
-        Ok(true),
-      );
+      storageService.validateZipStructure.mockResolvedValueOnce(Ok(true));
       repository.globalBotExists.mockResolvedValueOnce(Ok(true));
       repository.checkUserOwnership.mockResolvedValueOnce(Ok(true));
       repository.getGlobalLatestVersion.mockResolvedValueOnce(
         Ok({
-          id: 'e2e-v1-id',
+          id: "e2e-v1-id",
           name: botName,
-          version: '1.0.0',
+          version: "1.0.0",
           config: createConfig,
-          status: 'approved',
-          filePath: 'gs://test-bucket/e2e-v1.zip',
-          userId: 'test-user-123',
+          status: "approved",
+          filePath: "gs://test-bucket/e2e-v1.zip",
+          userId: "test-user-123",
           createdAt: new Date(),
           updatedAt: new Date(),
         }),
@@ -718,13 +718,13 @@ describe('Custom Bot API Integration Tests', () => {
       repository.globalVersionExists.mockResolvedValueOnce(Ok(false));
       repository.createNewGlobalVersion.mockResolvedValueOnce(
         Ok({
-          id: 'e2e-v1.1-id',
+          id: "e2e-v1.1-id",
           name: botName,
-          version: '1.1.0',
+          version: "1.1.0",
           config: updateConfig,
-          status: 'pending_review',
-          filePath: 'gs://test-bucket/e2e-v1.1.zip',
-          userId: 'test-user-123',
+          status: "pending_review",
+          filePath: "gs://test-bucket/e2e-v1.1.zip",
+          userId: "test-user-123",
           createdAt: new Date(),
           updatedAt: new Date(),
         }),
@@ -734,43 +734,43 @@ describe('Custom Bot API Integration Tests', () => {
         .put(`/custom-bots/${botName}`)
         .send({
           config: JSON.stringify(updateConfig),
-          filePath: 'gs://test-bucket/e2e-v1.1.zip',
+          filePath: "gs://test-bucket/e2e-v1.1.zip",
         })
         .expect(200);
 
-      expect(updateResponse.body.data.version).toBe('1.1.0');
+      expect(updateResponse.body.data.version).toBe("1.1.0");
 
       // Step 3: Retrieve all versions
       repository.getAllGlobalVersions.mockResolvedValueOnce(
         Ok({
-          id: 'e2e-bot-id',
+          id: "e2e-bot-id",
           name: botName,
-          userId: 'test-user-123',
+          userId: "test-user-123",
           versions: [
             {
-              version: '1.1.0',
+              version: "1.1.0",
               config: updateConfig,
-              filePath: 'gs://test-bucket/e2e-v1.1.zip',
+              filePath: "gs://test-bucket/e2e-v1.1.zip",
               createdAt: new Date(),
               updatedAt: new Date(),
-              status: 'approved',
+              status: "approved",
               marketplace: null,
-              userId: 'test-user-123',
-              id: 'bot-id',
+              userId: "test-user-123",
+              id: "bot-id",
             },
             {
-              version: '1.0.0',
+              version: "1.0.0",
               config: createConfig,
-              filePath: 'gs://test-bucket/e2e-v1.zip',
+              filePath: "gs://test-bucket/e2e-v1.zip",
               createdAt: new Date(),
               updatedAt: new Date(),
-              status: 'approved',
+              status: "approved",
               marketplace: null,
-              userId: 'test-user-123',
-              id: 'bot-id',
+              userId: "test-user-123",
+              id: "bot-id",
             },
           ],
-          latestVersion: '1.1.0',
+          latestVersion: "1.1.0",
           createdAt: new Date(),
           updatedAt: new Date(),
         }),
@@ -781,18 +781,18 @@ describe('Custom Bot API Integration Tests', () => {
         .expect(200);
 
       expect(getAllResponse.body.data.versions).toHaveLength(2);
-      expect(getAllResponse.body.data.latestVersion).toBe('1.1.0');
+      expect(getAllResponse.body.data.latestVersion).toBe("1.1.0");
 
       // Step 4: Retrieve specific version
       repository.getSpecificGlobalVersion.mockResolvedValueOnce(
         Ok({
-          id: 'e2e-v1-id',
+          id: "e2e-v1-id",
           name: botName,
-          version: '1.0.0',
+          version: "1.0.0",
           config: createConfig,
-          status: 'approved',
-          filePath: 'gs://test-bucket/e2e-v1.zip',
-          userId: 'test-user-123',
+          status: "approved",
+          filePath: "gs://test-bucket/e2e-v1.zip",
+          userId: "test-user-123",
           createdAt: new Date(),
           updatedAt: new Date(),
         }),
@@ -802,64 +802,64 @@ describe('Custom Bot API Integration Tests', () => {
         .get(`/custom-bots/${botName}/1.0.0`)
         .expect(200);
 
-      expect(getSpecificResponse.body.data.version).toBe('1.0.0');
+      expect(getSpecificResponse.body.data.version).toBe("1.0.0");
     });
   });
 
-  describe('Error handling and edge cases', () => {
-    it('should handle repository errors gracefully', async () => {
+  describe("Error handling and edge cases", () => {
+    it("should handle repository errors gracefully", async () => {
       const filePath =
-        'gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip';
+        "gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip";
 
       storageService.fileExists.mockResolvedValue(Ok(true));
       repository.globalBotExists.mockResolvedValue(
-        Failure('Database connection failed'),
+        Failure("Database connection failed"),
       );
 
       const response = await request(app.getHttpServer())
-        .post('/custom-bots/integration-test-bot')
+        .post("/custom-bots/integration-test-bot")
         .send({
           config: JSON.stringify(validConfig),
           filePath: filePath,
         })
         .expect(400);
 
-      expect(response.body.message).toContain('Database connection failed');
+      expect(response.body.message).toContain("Database connection failed");
     });
 
-    it('should handle GCS service errors gracefully', async () => {
+    it("should handle GCS service errors gracefully", async () => {
       const filePath =
-        'gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip';
+        "gs://test-bucket/user123/integration-test-bot/1.0.0/test-bot.zip";
 
       storageService.fileExists.mockResolvedValue(Ok(true));
       repository.globalBotExists.mockResolvedValue(Ok(false));
       storageService.validateZipStructure.mockResolvedValue(
-        Failure('GCS service unavailable'),
+        Failure("GCS service unavailable"),
       );
 
       const response = await request(app.getHttpServer())
-        .post('/custom-bots/integration-test-bot')
+        .post("/custom-bots/integration-test-bot")
         .send({
           config: JSON.stringify(validConfig),
           filePath: filePath,
         })
         .expect(400);
 
-      expect(response.body.message).toContain('ZIP validation failed');
+      expect(response.body.message).toContain("ZIP validation failed");
     });
 
-    it('should handle large file uploads properly', async () => {
+    it("should handle large file uploads properly", async () => {
       const filePath =
-        'gs://test-bucket/user123/integration-test-bot/1.0.0/large-bot.zip';
+        "gs://test-bucket/user123/integration-test-bot/1.0.0/large-bot.zip";
 
       storageService.fileExists.mockResolvedValue(Ok(true));
       repository.globalBotExists.mockResolvedValue(Ok(false));
       storageService.validateZipStructure.mockResolvedValue(
-        Failure('ZIP file size exceeds 200MB limit'),
+        Failure("ZIP file size exceeds 200MB limit"),
       );
 
       const response = await request(app.getHttpServer())
-        .post('/custom-bots/integration-test-bot')
+        .post("/custom-bots/integration-test-bot")
         .send({
           config: JSON.stringify(validConfig),
           filePath: filePath,
@@ -867,51 +867,51 @@ describe('Custom Bot API Integration Tests', () => {
         .expect(400);
 
       expect(response.body.message).toContain(
-        'ZIP validation failed: ZIP file size exceeds 200MB limit',
+        "ZIP validation failed: ZIP file size exceeds 200MB limit",
       );
     });
 
-    it('should handle missing user authentication', async () => {
+    it("should handle missing user authentication", async () => {
       // Create a request without the auth middleware
       const response = await request(app.getHttpServer())
-        .post('/custom-bots/no-auth-bot')
+        .post("/custom-bots/no-auth-bot")
         .send({
           config: JSON.stringify(validConfig),
-          filePath: 'gs://test-bucket/user123/no-auth-bot/1.0.0/test-bot.zip',
+          filePath: "gs://test-bucket/user123/no-auth-bot/1.0.0/test-bot.zip",
         });
 
       // This should fail because there's no auth middleware applied to this specific route
       expect(response.status).toBeGreaterThanOrEqual(400);
     });
 
-    it('should validate file content type properly', async () => {
+    it("should validate file content type properly", async () => {
       const filePath =
-        'gs://test-bucket/user123/integration-test-bot/1.0.0/fake.zip';
+        "gs://test-bucket/user123/integration-test-bot/1.0.0/fake.zip";
 
       storageService.fileExists.mockResolvedValue(Ok(true));
       repository.globalBotExists.mockResolvedValue(Ok(false));
       storageService.validateZipStructure.mockResolvedValue(
-        Failure('Failed to validate ZIP structure: not a valid ZIP file'),
+        Failure("Failed to validate ZIP structure: not a valid ZIP file"),
       );
 
       const response = await request(app.getHttpServer())
-        .post('/custom-bots/integration-test-bot')
+        .post("/custom-bots/integration-test-bot")
         .send({
           config: JSON.stringify(validConfig),
           filePath: filePath,
         })
         .expect(400);
 
-      expect(response.body.message).toContain('ZIP validation failed');
+      expect(response.body.message).toContain("ZIP validation failed");
     });
 
-    it('should handle malformed requests', async () => {
+    it("should handle malformed requests", async () => {
       const response = await request(app.getHttpServer())
-        .post('/custom-bots/malformed-request')
-        .send({ invalid: 'data' })
+        .post("/custom-bots/malformed-request")
+        .send({ invalid: "data" })
         .expect(400);
 
-      expect(response.body.message).toBe('file path is required');
+      expect(response.body.message).toBe("file path is required");
     });
   });
 });

--- a/api/src/custom-bot/__tests__/custom-bot.repository.spec.ts
+++ b/api/src/custom-bot/__tests__/custom-bot.repository.spec.ts
@@ -1,25 +1,29 @@
-import { CustomBotRepository } from '../custom-bot.repository';
-import { CustomBot, CustomBotConfig, MarketplaceMetadata } from '../custom-bot.types';
-import { Result } from '@/common';
+import { CustomBotRepository } from "../custom-bot.repository";
+import {
+  CustomBot,
+  CustomBotConfig,
+  MarketplaceMetadata,
+} from "../custom-bot.types";
+import { Result } from "@/common";
 
 // Mock Drizzle database and dependencies
-jest.mock('@/database/connection', () => ({
+jest.mock("@/database/connection", () => ({
   getDatabase: jest.fn(),
   getTables: jest.fn(),
 }));
 
-jest.mock('drizzle-orm', () => ({
+jest.mock("drizzle-orm", () => ({
   eq: jest.fn(),
   and: jest.fn(),
   desc: jest.fn(),
   asc: jest.fn(),
 }));
 
-jest.mock('@paralleldrive/cuid2', () => ({
-  createId: jest.fn(() => 'mock-id'),
+jest.mock("@paralleldrive/cuid2", () => ({
+  createId: jest.fn(() => "mock-id"),
 }));
 
-describe('CustomBotRepository', () => {
+describe("CustomBotRepository", () => {
   let repository: CustomBotRepository;
   let mockDb: any;
   let mockTables: any;
@@ -28,12 +32,12 @@ describe('CustomBotRepository', () => {
   beforeEach(() => {
     // Mock table operations
     mockTable = {
-      userId: { name: 'userId' },
-      id: { name: 'id' },
-      name: { name: 'name' },
-      version: { name: 'version' },
-      createdAt: { name: 'createdAt' },
-      updatedAt: { name: 'updatedAt' },
+      userId: { name: "userId" },
+      id: { name: "id" },
+      name: { name: "name" },
+      version: { name: "version" },
+      createdAt: { name: "createdAt" },
+      updatedAt: { name: "updatedAt" },
     };
 
     mockTables = {
@@ -52,11 +56,11 @@ describe('CustomBotRepository', () => {
       limit: jest.fn().mockReturnThis(),
       values: jest.fn().mockReturnThis(),
       set: jest.fn().mockReturnThis(),
-      returning: jest.fn().mockResolvedValue([{ id: 'test-id' }]),
+      returning: jest.fn().mockResolvedValue([{ id: "test-id" }]),
     };
 
     // Mock the database connection
-    const { getDatabase, getTables } = require('@/database/connection');
+    const { getDatabase, getTables } = require("@/database/connection");
     getDatabase.mockReturnValue(mockDb);
     getTables.mockReturnValue(mockTables);
 
@@ -67,16 +71,16 @@ describe('CustomBotRepository', () => {
     jest.clearAllMocks();
   });
 
-  describe('userBotExists', () => {
-    it('should return true when bot exists', async () => {
+  describe("userBotExists", () => {
+    it("should return true when bot exists", async () => {
       // Mock the findByKey method directly
       const originalFindByKey = repository.findByKey;
       repository.findByKey = jest.fn().mockResolvedValue({
         success: true,
-        data: [{ id: 'test-id', name: 'test-bot', userId: 'user123' }],
+        data: [{ id: "test-id", name: "test-bot", userId: "user123" }],
       });
 
-      const result = await repository.userBotExists('user123', 'test-bot');
+      const result = await repository.userBotExists("user123", "test-bot");
 
       expect(result.success).toBe(true);
       expect(result.data).toBe(true);
@@ -85,7 +89,7 @@ describe('CustomBotRepository', () => {
       repository.findByKey = originalFindByKey;
     });
 
-    it('should return false when bot does not exist', async () => {
+    it("should return false when bot does not exist", async () => {
       // Mock the findByKey method to return empty array
       const originalFindByKey = repository.findByKey;
       repository.findByKey = jest.fn().mockResolvedValue({
@@ -94,8 +98,8 @@ describe('CustomBotRepository', () => {
       });
 
       const result = await repository.userBotExists(
-        'user123',
-        'non-existent-bot',
+        "user123",
+        "non-existent-bot",
       );
 
       expect(result.success).toBe(true);
@@ -106,16 +110,16 @@ describe('CustomBotRepository', () => {
     });
   });
 
-  describe('globalBotExists', () => {
-    it('should return true when global bot exists', async () => {
+  describe("globalBotExists", () => {
+    it("should return true when global bot exists", async () => {
       // Mock the findGlobalByKey method directly
       const originalFindGlobalByKey = repository.findGlobalByKey;
       repository.findGlobalByKey = jest.fn().mockResolvedValue({
         success: true,
-        data: [{ id: 'test-id', name: 'test-bot', userId: 'user123' }],
+        data: [{ id: "test-id", name: "test-bot", userId: "user123" }],
       });
 
-      const result = await repository.globalBotExists('test-bot');
+      const result = await repository.globalBotExists("test-bot");
 
       expect(result.success).toBe(true);
       expect(result.data).toBe(true);
@@ -124,7 +128,7 @@ describe('CustomBotRepository', () => {
       repository.findGlobalByKey = originalFindGlobalByKey;
     });
 
-    it('should return false when global bot does not exist', async () => {
+    it("should return false when global bot does not exist", async () => {
       // Mock the findGlobalByKey method to return empty array
       const originalFindGlobalByKey = repository.findGlobalByKey;
       repository.findGlobalByKey = jest.fn().mockResolvedValue({
@@ -132,7 +136,7 @@ describe('CustomBotRepository', () => {
         data: [],
       });
 
-      const result = await repository.globalBotExists('non-existent-bot');
+      const result = await repository.globalBotExists("non-existent-bot");
 
       expect(result.success).toBe(true);
       expect(result.data).toBe(false);
@@ -142,13 +146,13 @@ describe('CustomBotRepository', () => {
     });
   });
 
-  describe('userVersionExists', () => {
-    it('should return true when specific version exists', async () => {
+  describe("userVersionExists", () => {
+    it("should return true when specific version exists", async () => {
       const mockBotData = {
-        id: 'test-id',
-        name: 'test-bot',
-        version: '1.0.0',
-        userId: 'user123',
+        id: "test-id",
+        name: "test-bot",
+        version: "1.0.0",
+        userId: "user123",
       };
 
       // Mock the specific findByKeyAndVersion method call
@@ -159,9 +163,9 @@ describe('CustomBotRepository', () => {
       });
 
       const result = await repository.userVersionExists(
-        'user123',
-        'test-bot',
-        '1.0.0',
+        "user123",
+        "test-bot",
+        "1.0.0",
       );
 
       expect(result.success).toBe(true);
@@ -171,18 +175,18 @@ describe('CustomBotRepository', () => {
       repository.findByKeyAndVersion = originalFindByKeyAndVersion;
     });
 
-    it('should return false when version does not exist', async () => {
+    it("should return false when version does not exist", async () => {
       // Mock the specific findByKeyAndVersion method call to return not found
       const originalFindByKeyAndVersion = repository.findByKeyAndVersion;
       repository.findByKeyAndVersion = jest.fn().mockResolvedValue({
         success: false,
-        error: 'Not found',
+        error: "Not found",
       });
 
       const result = await repository.userVersionExists(
-        'user123',
-        'test-bot',
-        '2.0.0',
+        "user123",
+        "test-bot",
+        "2.0.0",
       );
 
       expect(result.success).toBe(true);
@@ -193,23 +197,24 @@ describe('CustomBotRepository', () => {
     });
   });
 
-  describe('globalVersionExists', () => {
-    it('should return true when global version exists', async () => {
+  describe("globalVersionExists", () => {
+    it("should return true when global version exists", async () => {
       const mockBotData = {
-        id: 'test-id',
-        name: 'test-bot',
-        version: '1.0.0',
-        userId: 'user123',
+        id: "test-id",
+        name: "test-bot",
+        version: "1.0.0",
+        userId: "user123",
       };
 
       // Mock the specific findGlobalByKeyAndVersion method call
-      const originalFindGlobalByKeyAndVersion = repository.findGlobalByKeyAndVersion;
+      const originalFindGlobalByKeyAndVersion =
+        repository.findGlobalByKeyAndVersion;
       repository.findGlobalByKeyAndVersion = jest.fn().mockResolvedValue({
         success: true,
         data: mockBotData,
       });
 
-      const result = await repository.globalVersionExists('test-bot', '1.0.0');
+      const result = await repository.globalVersionExists("test-bot", "1.0.0");
 
       expect(result.success).toBe(true);
       expect(result.data).toBe(true);
@@ -218,15 +223,16 @@ describe('CustomBotRepository', () => {
       repository.findGlobalByKeyAndVersion = originalFindGlobalByKeyAndVersion;
     });
 
-    it('should return false when global version does not exist', async () => {
+    it("should return false when global version does not exist", async () => {
       // Mock the specific findGlobalByKeyAndVersion method call to return not found
-      const originalFindGlobalByKeyAndVersion = repository.findGlobalByKeyAndVersion;
+      const originalFindGlobalByKeyAndVersion =
+        repository.findGlobalByKeyAndVersion;
       repository.findGlobalByKeyAndVersion = jest.fn().mockResolvedValue({
         success: false,
-        error: 'Not found',
+        error: "Not found",
       });
 
-      const result = await repository.globalVersionExists('test-bot', '2.0.0');
+      const result = await repository.globalVersionExists("test-bot", "2.0.0");
 
       expect(result.success).toBe(true);
       expect(result.data).toBe(false);
@@ -236,8 +242,8 @@ describe('CustomBotRepository', () => {
     });
   });
 
-  describe('getUserCustomBots', () => {
-    it('should return empty array when user has no bots', async () => {
+  describe("getUserCustomBots", () => {
+    it("should return empty array when user has no bots", async () => {
       // Mock the findAll method to return empty array
       const originalFindAll = repository.findAll;
       repository.findAll = jest.fn().mockResolvedValue({
@@ -245,7 +251,7 @@ describe('CustomBotRepository', () => {
         data: [],
       });
 
-      const result = await repository.getUserCustomBots('user123');
+      const result = await repository.getUserCustomBots("user123");
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual([]);
@@ -254,51 +260,51 @@ describe('CustomBotRepository', () => {
       repository.findAll = originalFindAll;
     });
 
-    it('should return single bot with multiple versions grouped correctly', async () => {
+    it("should return single bot with multiple versions grouped correctly", async () => {
       const mockBots: CustomBot[] = [
         {
-          id: 'v2-id',
-          name: 'arbitrage-bot',
-          version: '2.0.0',
+          id: "v2-id",
+          name: "arbitrage-bot",
+          version: "2.0.0",
           config: {
-            name: 'arbitrage-bot',
-            version: '2.0.0',
-            description: 'Advanced arbitrage bot',
-            type: 'realtime',
-            runtime: 'python3.11',
-            author: 'user@example.com',
-            entrypoints: { bot: 'main.py', backtest: 'backtest.py' },
+            name: "arbitrage-bot",
+            version: "2.0.0",
+            description: "Advanced arbitrage bot",
+            type: "realtime",
+            runtime: "python3.11",
+            author: "user@example.com",
+            entrypoints: { bot: "main.py", backtest: "backtest.py" },
             schema: { bot: {}, backtest: {} },
-            readme: 'Advanced bot with multiple features',
+            readme: "Advanced bot with multiple features",
           },
-          status: 'approved',
-          filePath: '/local/path/arbitrage-bot/2.0.0/file.zip',
-          userId: 'user123',
+          status: "approved",
+          filePath: "/local/path/arbitrage-bot/2.0.0/file.zip",
+          userId: "user123",
           marketplace: null,
-          createdAt: new Date('2023-02-01T10:00:00Z'),
-          updatedAt: new Date('2023-02-01T10:00:00Z'),
+          createdAt: new Date("2023-02-01T10:00:00Z"),
+          updatedAt: new Date("2023-02-01T10:00:00Z"),
         },
         {
-          id: 'v1-id',
-          name: 'arbitrage-bot',
-          version: '1.0.0',
+          id: "v1-id",
+          name: "arbitrage-bot",
+          version: "1.0.0",
           config: {
-            name: 'arbitrage-bot',
-            version: '1.0.0',
-            description: 'Basic arbitrage bot',
-            type: 'realtime',
-            runtime: 'python3.11',
-            author: 'user@example.com',
-            entrypoints: { bot: 'main.py', backtest: 'backtest.py' },
+            name: "arbitrage-bot",
+            version: "1.0.0",
+            description: "Basic arbitrage bot",
+            type: "realtime",
+            runtime: "python3.11",
+            author: "user@example.com",
+            entrypoints: { bot: "main.py", backtest: "backtest.py" },
             schema: { bot: {}, backtest: {} },
-            readme: 'Advanced bot with multiple features',
+            readme: "Advanced bot with multiple features",
           },
-          status: 'approved',
-          filePath: '/local/path/arbitrage-bot/1.0.0/file.zip',
-          userId: 'user123',
+          status: "approved",
+          filePath: "/local/path/arbitrage-bot/1.0.0/file.zip",
+          userId: "user123",
           marketplace: null,
-          createdAt: new Date('2023-01-01T10:00:00Z'),
-          updatedAt: new Date('2023-01-01T10:00:00Z'),
+          createdAt: new Date("2023-01-01T10:00:00Z"),
+          updatedAt: new Date("2023-01-01T10:00:00Z"),
         },
       ] as CustomBot[];
 
@@ -309,7 +315,7 @@ describe('CustomBotRepository', () => {
         data: mockBots,
       });
 
-      const result = await repository.getUserCustomBots('user123');
+      const result = await repository.getUserCustomBots("user123");
 
       // Restore original method
       repository.findAll = originalFindAll;
@@ -318,83 +324,87 @@ describe('CustomBotRepository', () => {
       expect(result.data).toHaveLength(1);
 
       const botWithVersions = result.data![0];
-      expect(botWithVersions.name).toBe('arbitrage-bot');
-      expect(botWithVersions.latestVersion).toBe('2.0.0');
+      expect(botWithVersions.name).toBe("arbitrage-bot");
+      expect(botWithVersions.latestVersion).toBe("2.0.0");
       expect(botWithVersions.versions).toHaveLength(2);
-      expect(botWithVersions.versions[0].version).toBe('2.0.0');
-      expect(botWithVersions.versions[1].version).toBe('1.0.0');
-      expect(botWithVersions.createdAt).toEqual(new Date('2023-01-01T10:00:00Z')); // First created
-      expect(botWithVersions.updatedAt).toEqual(new Date('2023-02-01T10:00:00Z')); // Latest updated
+      expect(botWithVersions.versions[0].version).toBe("2.0.0");
+      expect(botWithVersions.versions[1].version).toBe("1.0.0");
+      expect(botWithVersions.createdAt).toEqual(
+        new Date("2023-01-01T10:00:00Z"),
+      ); // First created
+      expect(botWithVersions.updatedAt).toEqual(
+        new Date("2023-02-01T10:00:00Z"),
+      ); // Latest updated
     });
 
-    it('should return multiple bots with correct grouping and sorting', async () => {
+    it("should return multiple bots with correct grouping and sorting", async () => {
       const mockBots: CustomBot[] = [
         // Trading Bot (newer updates)
         {
-          id: 'trading-v2-id',
-          name: 'trading-bot',
-          version: '2.1.0',
+          id: "trading-v2-id",
+          name: "trading-bot",
+          version: "2.1.0",
           config: {
-            name: 'trading-bot',
-            version: '2.1.0',
-            description: 'Advanced trading bot',
-            type: 'scheduled',
-            runtime: 'python3.11',
-            author: 'user@example.com',
-            entrypoints: { bot: 'trade.py', backtest: 'backtest.py' },
+            name: "trading-bot",
+            version: "2.1.0",
+            description: "Advanced trading bot",
+            type: "scheduled",
+            runtime: "python3.11",
+            author: "user@example.com",
+            entrypoints: { bot: "trade.py", backtest: "backtest.py" },
             schema: { bot: {}, backtest: {} },
-            readme: 'Advanced trading bot with multiple features',
+            readme: "Advanced trading bot with multiple features",
           },
-          status: 'approved',
-          filePath: '/local/path/trading-bot/2.1.0/file.zip',
-          userId: 'user123',
+          status: "approved",
+          filePath: "/local/path/trading-bot/2.1.0/file.zip",
+          userId: "user123",
           marketplace: null,
-          createdAt: new Date('2023-03-15T10:00:00Z'),
-          updatedAt: new Date('2023-03-15T10:00:00Z'),
+          createdAt: new Date("2023-03-15T10:00:00Z"),
+          updatedAt: new Date("2023-03-15T10:00:00Z"),
         },
         {
-          id: 'trading-v1-id',
-          name: 'trading-bot',
-          version: '2.0.0',
+          id: "trading-v1-id",
+          name: "trading-bot",
+          version: "2.0.0",
           config: {
-            name: 'trading-bot',
-            version: '2.0.0',
-            description: 'Basic trading bot',
-            type: 'scheduled',
-            runtime: 'python3.11',
-            author: 'user@example.com',
-            entrypoints: { bot: 'trade.py', backtest: 'backtest.py' },
+            name: "trading-bot",
+            version: "2.0.0",
+            description: "Basic trading bot",
+            type: "scheduled",
+            runtime: "python3.11",
+            author: "user@example.com",
+            entrypoints: { bot: "trade.py", backtest: "backtest.py" },
             schema: { bot: {}, backtest: {} },
-            readme: 'Basic trading bot with minimal features',
+            readme: "Basic trading bot with minimal features",
           },
-          status: 'approved',
-          filePath: '/local/path/trading-bot/2.0.0/file.zip',
-          userId: 'user123',
+          status: "approved",
+          filePath: "/local/path/trading-bot/2.0.0/file.zip",
+          userId: "user123",
           marketplace: null,
-          createdAt: new Date('2023-01-15T10:00:00Z'),
-          updatedAt: new Date('2023-01-15T10:00:00Z'),
+          createdAt: new Date("2023-01-15T10:00:00Z"),
+          updatedAt: new Date("2023-01-15T10:00:00Z"),
         },
         // Arbitrage Bot (older updates)
         {
-          id: 'arb-v1-id',
-          name: 'arbitrage-bot',
-          version: '1.0.0',
+          id: "arb-v1-id",
+          name: "arbitrage-bot",
+          version: "1.0.0",
           config: {
-            name: 'arbitrage-bot',
-            version: '1.0.0',
-            description: 'Arbitrage bot',
-            type: 'realtime',
-            runtime: 'python3.11',
-            author: 'user@example.com',
-            entrypoints: { bot: 'arbitrage.py', backtest: 'backtest.py' },
+            name: "arbitrage-bot",
+            version: "1.0.0",
+            description: "Arbitrage bot",
+            type: "realtime",
+            runtime: "python3.11",
+            author: "user@example.com",
+            entrypoints: { bot: "arbitrage.py", backtest: "backtest.py" },
             schema: { bot: {}, backtest: {} },
-            readme: 'Basic arbitrage bot with minimal features',
+            readme: "Basic arbitrage bot with minimal features",
           },
-          status: 'approved',
-          filePath: '/local/path/arbitrage-bot/1.0.0/file.zip',
-          userId: 'user123',
-          createdAt: new Date('2023-02-01T10:00:00Z'),
-          updatedAt: new Date('2023-02-01T10:00:00Z'),
+          status: "approved",
+          filePath: "/local/path/arbitrage-bot/1.0.0/file.zip",
+          userId: "user123",
+          createdAt: new Date("2023-02-01T10:00:00Z"),
+          updatedAt: new Date("2023-02-01T10:00:00Z"),
         },
       ] as CustomBot[];
 
@@ -405,7 +415,7 @@ describe('CustomBotRepository', () => {
         data: mockBots,
       });
 
-      const result = await repository.getUserCustomBots('user123');
+      const result = await repository.getUserCustomBots("user123");
 
       // Restore original method
       repository.findAll = originalFindAll;
@@ -414,78 +424,78 @@ describe('CustomBotRepository', () => {
       expect(result.data).toHaveLength(2);
 
       // Should be sorted by latest update time descending
-      expect(result.data![0].name).toBe('trading-bot'); // More recent update
-      expect(result.data![1].name).toBe('arbitrage-bot'); // Older update
+      expect(result.data![0].name).toBe("trading-bot"); // More recent update
+      expect(result.data![1].name).toBe("arbitrage-bot"); // Older update
 
       // Check trading bot details
       const tradingBot = result.data![0];
-      expect(tradingBot.latestVersion).toBe('2.1.0');
+      expect(tradingBot.latestVersion).toBe("2.1.0");
       expect(tradingBot.versions).toHaveLength(2);
-      expect(tradingBot.versions[0].version).toBe('2.1.0'); // Latest first
-      expect(tradingBot.versions[1].version).toBe('2.0.0');
+      expect(tradingBot.versions[0].version).toBe("2.1.0"); // Latest first
+      expect(tradingBot.versions[1].version).toBe("2.0.0");
 
       // Check arbitrage bot details
       const arbitrageBot = result.data![1];
-      expect(arbitrageBot.latestVersion).toBe('1.0.0');
+      expect(arbitrageBot.latestVersion).toBe("1.0.0");
       expect(arbitrageBot.versions).toHaveLength(1);
     });
 
-    it('should handle repository errors gracefully', async () => {
+    it("should handle repository errors gracefully", async () => {
       // Mock findAll to return an error
       const originalFindAll = repository.findAll;
       repository.findAll = jest.fn().mockResolvedValue({
         success: false,
-        error: 'Database connection failed',
+        error: "Database connection failed",
       });
 
-      const result = await repository.getUserCustomBots('user123');
+      const result = await repository.getUserCustomBots("user123");
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Database connection failed');
+      expect(result.error).toBe("Database connection failed");
 
       // Restore original method
       repository.findAll = originalFindAll;
     });
 
-    it('should handle unexpected errors gracefully', async () => {
+    it("should handle unexpected errors gracefully", async () => {
       // Mock findAll to throw an exception
       const originalFindAll = repository.findAll;
       repository.findAll = jest
         .fn()
-        .mockRejectedValue(new Error('Unexpected error'));
+        .mockRejectedValue(new Error("Unexpected error"));
 
-      const result = await repository.getUserCustomBots('user123');
+      const result = await repository.getUserCustomBots("user123");
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Unexpected error');
+      expect(result.error).toBe("Unexpected error");
 
       // Restore original method
       repository.findAll = originalFindAll;
     });
   });
 
-  describe('getAllUserVersions', () => {
-    it('should return all versions with proper structure', async () => {
+  describe("getAllUserVersions", () => {
+    it("should return all versions with proper structure", async () => {
       const mockBots = [
         {
-          id: 'v2-id',
-          name: 'test-bot',
-          version: '2.0.0',
-          config: { name: 'test-bot', version: '2.0.0' },
-          filePath: '/local/path/v2.zip',
-          userId: 'user123',
-          createdAt: new Date('2023-02-01'),
-          updatedAt: new Date('2023-02-01'),
+          id: "v2-id",
+          name: "test-bot",
+          version: "2.0.0",
+          config: { name: "test-bot", version: "2.0.0" },
+          filePath: "/local/path/v2.zip",
+          userId: "user123",
+          createdAt: new Date("2023-02-01"),
+          updatedAt: new Date("2023-02-01"),
         },
         {
-          id: 'v1-id',
-          name: 'test-bot',
-          version: '1.0.0',
-          config: { name: 'test-bot', version: '1.0.0' },
-          filePath: '/local/path/v1.zip',
-          userId: 'user123',
-          createdAt: new Date('2023-01-01'),
-          updatedAt: new Date('2023-01-01'),
+          id: "v1-id",
+          name: "test-bot",
+          version: "1.0.0",
+          config: { name: "test-bot", version: "1.0.0" },
+          filePath: "/local/path/v1.zip",
+          userId: "user123",
+          createdAt: new Date("2023-01-01"),
+          updatedAt: new Date("2023-01-01"),
         },
       ];
 
@@ -496,21 +506,21 @@ describe('CustomBotRepository', () => {
         data: mockBots,
       });
 
-      const result = await repository.getAllUserVersions('user123', 'test-bot');
+      const result = await repository.getAllUserVersions("user123", "test-bot");
 
       // Restore original method
       repository.findByKey = originalFindByKey;
 
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.data!.name).toBe('test-bot');
-      expect(result.data!.latestVersion).toBe('2.0.0');
+      expect(result.data!.name).toBe("test-bot");
+      expect(result.data!.latestVersion).toBe("2.0.0");
       expect(result.data!.versions).toHaveLength(2);
-      expect(result.data!.versions[0].version).toBe('2.0.0');
-      expect(result.data!.versions[1].version).toBe('1.0.0');
+      expect(result.data!.versions[0].version).toBe("2.0.0");
+      expect(result.data!.versions[1].version).toBe("1.0.0");
     });
 
-    it('should return error when bot not found', async () => {
+    it("should return error when bot not found", async () => {
       // Mock the findByKey method to return empty array
       const originalFindByKey = repository.findByKey;
       repository.findByKey = jest.fn().mockResolvedValue({
@@ -519,40 +529,40 @@ describe('CustomBotRepository', () => {
       });
 
       const result = await repository.getAllUserVersions(
-        'user123',
-        'non-existent',
+        "user123",
+        "non-existent",
       );
 
       // Restore original method
       repository.findByKey = originalFindByKey;
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Bot not found');
+      expect(result.error).toBe("Bot not found");
     });
   });
 
-  describe('getAllGlobalVersions', () => {
-    it('should return all global versions with proper structure', async () => {
+  describe("getAllGlobalVersions", () => {
+    it("should return all global versions with proper structure", async () => {
       const mockBots = [
         {
-          id: 'global-v2-id',
-          name: 'global-bot',
-          version: '2.0.0',
-          config: { name: 'global-bot', version: '2.0.0' },
-          filePath: '/local/path/global-v2.zip',
-          userId: 'user456',
-          createdAt: new Date('2023-02-01'),
-          updatedAt: new Date('2023-02-01'),
+          id: "global-v2-id",
+          name: "global-bot",
+          version: "2.0.0",
+          config: { name: "global-bot", version: "2.0.0" },
+          filePath: "/local/path/global-v2.zip",
+          userId: "user456",
+          createdAt: new Date("2023-02-01"),
+          updatedAt: new Date("2023-02-01"),
         },
         {
-          id: 'global-v1-id',
-          name: 'global-bot',
-          version: '1.0.0',
-          config: { name: 'global-bot', version: '1.0.0' },
-          filePath: '/local/path/global-v1.zip',
-          userId: 'user456',
-          createdAt: new Date('2023-01-01'),
-          updatedAt: new Date('2023-01-01'),
+          id: "global-v1-id",
+          name: "global-bot",
+          version: "1.0.0",
+          config: { name: "global-bot", version: "1.0.0" },
+          filePath: "/local/path/global-v1.zip",
+          userId: "user456",
+          createdAt: new Date("2023-01-01"),
+          updatedAt: new Date("2023-01-01"),
         },
       ];
 
@@ -563,19 +573,19 @@ describe('CustomBotRepository', () => {
         data: mockBots,
       });
 
-      const result = await repository.getAllGlobalVersions('global-bot');
+      const result = await repository.getAllGlobalVersions("global-bot");
 
       // Restore original method
       repository.findGlobalByKey = originalFindGlobalByKey;
 
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.data!.name).toBe('global-bot');
-      expect(result.data!.latestVersion).toBe('2.0.0');
+      expect(result.data!.name).toBe("global-bot");
+      expect(result.data!.latestVersion).toBe("2.0.0");
       expect(result.data!.versions).toHaveLength(2);
     });
 
-    it('should return error when global bot not found', async () => {
+    it("should return error when global bot not found", async () => {
       // Mock the findGlobalByKey method to return empty array
       const originalFindGlobalByKey = repository.findGlobalByKey;
       repository.findGlobalByKey = jest.fn().mockResolvedValue({
@@ -583,27 +593,27 @@ describe('CustomBotRepository', () => {
         data: [],
       });
 
-      const result = await repository.getAllGlobalVersions('non-existent');
+      const result = await repository.getAllGlobalVersions("non-existent");
 
       // Restore original method
       repository.findGlobalByKey = originalFindGlobalByKey;
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Bot not found');
+      expect(result.error).toBe("Bot not found");
     });
   });
 
-  describe('getSpecificUserVersion', () => {
-    it('should return specific user version', async () => {
+  describe("getSpecificUserVersion", () => {
+    it("should return specific user version", async () => {
       const mockBotData = {
-        id: 'test-id',
-        name: 'test-bot',
-        version: '1.0.0',
-        userId: 'user123',
-        config: { name: 'test-bot', version: '1.0.0' },
-        filePath: '/local/path/test.zip',
-        createdAt: new Date('2023-01-01'),
-        updatedAt: new Date('2023-01-01'),
+        id: "test-id",
+        name: "test-bot",
+        version: "1.0.0",
+        userId: "user123",
+        config: { name: "test-bot", version: "1.0.0" },
+        filePath: "/local/path/test.zip",
+        createdAt: new Date("2023-01-01"),
+        updatedAt: new Date("2023-01-01"),
       };
 
       // Mock the specific findByKeyAndVersion method call
@@ -614,109 +624,110 @@ describe('CustomBotRepository', () => {
       });
 
       const result = await repository.getSpecificUserVersion(
-        'user123',
-        'test-bot',
-        '1.0.0',
+        "user123",
+        "test-bot",
+        "1.0.0",
       );
 
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.data!.version).toBe('1.0.0');
+      expect(result.data!.version).toBe("1.0.0");
 
       // Restore original method
       repository.findByKeyAndVersion = originalFindByKeyAndVersion;
     });
   });
 
-  describe('getSpecificGlobalVersion', () => {
-    it('should return specific global version', async () => {
+  describe("getSpecificGlobalVersion", () => {
+    it("should return specific global version", async () => {
       const mockBotData = {
-        id: 'global-test-id',
-        name: 'global-bot',
-        version: '1.0.0',
-        userId: 'user456',
-        config: { name: 'global-bot', version: '1.0.0' },
-        filePath: '/local/path/global-test.zip',
-        createdAt: new Date('2023-01-01'),
-        updatedAt: new Date('2023-01-01'),
+        id: "global-test-id",
+        name: "global-bot",
+        version: "1.0.0",
+        userId: "user456",
+        config: { name: "global-bot", version: "1.0.0" },
+        filePath: "/local/path/global-test.zip",
+        createdAt: new Date("2023-01-01"),
+        updatedAt: new Date("2023-01-01"),
       };
 
       // Mock the specific findGlobalByKeyAndVersion method call
-      const originalFindGlobalByKeyAndVersion = repository.findGlobalByKeyAndVersion;
+      const originalFindGlobalByKeyAndVersion =
+        repository.findGlobalByKeyAndVersion;
       repository.findGlobalByKeyAndVersion = jest.fn().mockResolvedValue({
         success: true,
         data: mockBotData,
       });
 
       const result = await repository.getSpecificGlobalVersion(
-        'global-bot',
-        '1.0.0',
+        "global-bot",
+        "1.0.0",
       );
 
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.data!.version).toBe('1.0.0');
+      expect(result.data!.version).toBe("1.0.0");
 
       // Restore original method
       repository.findGlobalByKeyAndVersion = originalFindGlobalByKeyAndVersion;
     });
   });
 
-  describe('isVersionNewer', () => {
-    it('should return true for newer major version', () => {
-      const result = repository.isVersionNewer('1.0.0', '2.0.0');
+  describe("isVersionNewer", () => {
+    it("should return true for newer major version", () => {
+      const result = repository.isVersionNewer("1.0.0", "2.0.0");
       expect(result).toBe(true);
     });
 
-    it('should return true for newer minor version', () => {
-      const result = repository.isVersionNewer('1.0.0', '1.1.0');
+    it("should return true for newer minor version", () => {
+      const result = repository.isVersionNewer("1.0.0", "1.1.0");
       expect(result).toBe(true);
     });
 
-    it('should return true for newer patch version', () => {
-      const result = repository.isVersionNewer('1.0.0', '1.0.1');
+    it("should return true for newer patch version", () => {
+      const result = repository.isVersionNewer("1.0.0", "1.0.1");
       expect(result).toBe(true);
     });
 
-    it('should return false for same version', () => {
-      const result = repository.isVersionNewer('1.0.0', '1.0.0');
+    it("should return false for same version", () => {
+      const result = repository.isVersionNewer("1.0.0", "1.0.0");
       expect(result).toBe(false);
     });
 
-    it('should return false for older version', () => {
-      const result = repository.isVersionNewer('2.0.0', '1.0.0');
+    it("should return false for older version", () => {
+      const result = repository.isVersionNewer("2.0.0", "1.0.0");
       expect(result).toBe(false);
     });
   });
 
-  describe('createNewGlobalVersion', () => {
-    it('should create new version successfully', async () => {
+  describe("createNewGlobalVersion", () => {
+    it("should create new version successfully", async () => {
       const config: CustomBotConfig = {
-        name: 'test-bot',
-        version: '1.0.0',
-        description: 'Test bot',
-        author: 'Test Author',
-        type: 'scheduled',
-        runtime: 'python3.11',
-        entrypoints: { bot: 'main.py', backtest: 'backtest.py' },
+        name: "test-bot",
+        version: "1.0.0",
+        description: "Test bot",
+        author: "Test Author",
+        type: "scheduled",
+        runtime: "python3.11",
+        entrypoints: { bot: "main.py", backtest: "backtest.py" },
         schema: { bot: {}, backtest: {} },
-        readme: 'Test readme',
-        metadata: { tags: ['test'], license: 'MIT' },
+        readme: "Test readme",
+        metadata: { tags: ["test"], license: "MIT" },
       };
       const botData = {
-        name: 'test-bot',
-        version: '1.0.0',
+        name: "test-bot",
+        version: "1.0.0",
         config: config,
-        userId: 'user123',
-        filePath: '/local/path/test.zip',
+        userId: "user123",
+        filePath: "/local/path/test.zip",
       };
 
       // Mock successful database operations
       mockDb.from.mockReturnValue(mockDb);
-      mockDb.orderBy.mockResolvedValue([{ ...botData, id: 'new-id' }]);
+      mockDb.orderBy.mockResolvedValue([{ ...botData, id: "new-id" }]);
 
       const result = await repository.createNewGlobalVersion(
-        'user123',
+        "user123",
         botData,
       );
 
@@ -726,12 +737,12 @@ describe('CustomBotRepository', () => {
     });
   });
 
-  describe('checkUserOwnership', () => {
-    it('should return true if user owns the bot', async () => {
+  describe("checkUserOwnership", () => {
+    it("should return true if user owns the bot", async () => {
       const mockBotData = {
-        id: 'test-id',
-        name: 'test-bot',
-        userId: 'user123',
+        id: "test-id",
+        name: "test-bot",
+        userId: "user123",
       };
 
       // Mock the findGlobalByKey method directly
@@ -741,7 +752,7 @@ describe('CustomBotRepository', () => {
         data: [mockBotData],
       });
 
-      const result = await repository.checkUserOwnership('user123', 'test-bot');
+      const result = await repository.checkUserOwnership("user123", "test-bot");
 
       // Restore original method
       repository.findGlobalByKey = originalFindGlobalByKey;
@@ -750,11 +761,11 @@ describe('CustomBotRepository', () => {
       expect(result.data).toBe(true);
     });
 
-    it('should return error if user does not own the bot', async () => {
+    it("should return error if user does not own the bot", async () => {
       const mockBotData = {
-        id: 'test-id',
-        name: 'test-bot',
-        userId: 'otherUser',
+        id: "test-id",
+        name: "test-bot",
+        userId: "otherUser",
       };
 
       // Mock the findGlobalByKey method with different user
@@ -764,16 +775,16 @@ describe('CustomBotRepository', () => {
         data: [mockBotData],
       });
 
-      const result = await repository.checkUserOwnership('user123', 'test-bot');
+      const result = await repository.checkUserOwnership("user123", "test-bot");
 
       // Restore original method
       repository.findGlobalByKey = originalFindGlobalByKey;
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Insufficient permissions');
+      expect(result.error).toBe("Insufficient permissions");
     });
 
-    it('should return error if bot is not found', async () => {
+    it("should return error if bot is not found", async () => {
       // Mock the findGlobalByKey method to return empty array
       const originalFindGlobalByKey = repository.findGlobalByKey;
       repository.findGlobalByKey = jest.fn().mockResolvedValue({
@@ -782,15 +793,15 @@ describe('CustomBotRepository', () => {
       });
 
       const result = await repository.checkUserOwnership(
-        'user123',
-        'non-existent-bot',
+        "user123",
+        "non-existent-bot",
       );
 
       // Restore original method
       repository.findGlobalByKey = originalFindGlobalByKey;
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Bot not found');
+      expect(result.error).toBe("Bot not found");
     });
   });
 });

--- a/api/src/custom-bot/__tests__/custom-bot.service.spec.ts
+++ b/api/src/custom-bot/__tests__/custom-bot.service.spec.ts
@@ -1,25 +1,25 @@
-import { CustomBotService } from '../custom-bot.service';
-import { CustomBotRepository } from '../custom-bot.repository';
-import { StorageService } from '../storage.service';
+import { CustomBotService } from "../custom-bot.service";
+import { CustomBotRepository } from "../custom-bot.repository";
+import { StorageService } from "../storage.service";
 import {
   CustomBot,
   CustomBotConfig,
   CustomBotWithVersions,
-} from '../custom-bot.types';
-import { Ok, Failure } from '@/common/result';
-import { validateCustomBotConfigPayload } from '../custom-bot.schema';
-import { NatsService } from '@/nats/nats.service';
-import { ConfigService } from '@nestjs/config';
+} from "../custom-bot.types";
+import { Ok, Failure } from "@/common/result";
+import { validateCustomBotConfigPayload } from "../custom-bot.schema";
+import { NatsService } from "@/nats/nats.service";
+import { ConfigService } from "@nestjs/config";
 // Removed StripeConnectService - not needed in OSS version
 
 // Mock dependencies
-jest.mock('../custom-bot.repository');
-jest.mock('../storage.service');
-jest.mock('../custom-bot.schema', () => ({
+jest.mock("../custom-bot.repository");
+jest.mock("../storage.service");
+jest.mock("../custom-bot.schema", () => ({
   validateCustomBotConfigPayload: jest.fn(),
 }));
 
-describe('CustomBotService', () => {
+describe("CustomBotService", () => {
   let service: CustomBotService;
   let mockRepository: jest.Mocked<CustomBotRepository>;
   let mockStorageService: jest.Mocked<StorageService>;
@@ -31,39 +31,39 @@ describe('CustomBotService', () => {
   >;
 
   const validConfig: CustomBotConfig = {
-    name: 'test-bot',
-    description: 'Test bot description',
-    version: '1.0.0',
-    author: 'Test Author',
-    type: 'scheduled',
-    runtime: 'python3.11',
+    name: "test-bot",
+    description: "Test bot description",
+    version: "1.0.0",
+    author: "Test Author",
+    type: "scheduled",
+    runtime: "python3.11",
     entrypoints: {
-      bot: 'main.py',
-      backtest: 'backtest.py',
+      bot: "main.py",
+      backtest: "backtest.py",
     },
     schema: {
-      bot: { type: 'object' },
-      backtest: { type: 'object' },
+      bot: { type: "object" },
+      backtest: { type: "object" },
     },
     readme:
-      'This is a test bot with enough content to pass validation requirements for the readme field.',
+      "This is a test bot with enough content to pass validation requirements for the readme field.",
   };
 
   const createMockFile = (
-    originalname = 'test-bot.zip',
-    mimetype = 'application/zip',
+    originalname = "test-bot.zip",
+    mimetype = "application/zip",
     size = 1024,
-    buffer: Buffer = Buffer.from('test zip content'),
+    buffer: Buffer = Buffer.from("test zip content"),
   ): Express.Multer.File => ({
-    fieldname: 'file',
+    fieldname: "file",
     originalname,
-    encoding: '7bit',
+    encoding: "7bit",
     mimetype,
     size,
     buffer,
-    destination: '',
-    filename: '',
-    path: '',
+    destination: "",
+    filename: "",
+    path: "",
     stream: null as any,
   });
 
@@ -120,26 +120,24 @@ describe('CustomBotService', () => {
     jest.clearAllMocks();
   });
 
-  describe('createCustomBot', () => {
-    it('should create a custom bot successfully', async () => {
-      const userId = 'user123';
+  describe("createCustomBot", () => {
+    it("should create a custom bot successfully", async () => {
+      const userId = "user123";
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
 
       // Setup mocks
       mockValidateConfig.mockReturnValue({ valid: true });
       mockRepository.globalBotExists.mockResolvedValue(Ok(false));
-      mockStorageService.validateZipStructure.mockResolvedValue(
-        Ok(true),
-      );
+      mockStorageService.validateZipStructure.mockResolvedValue(Ok(true));
       const mockResult = {
-        id: 'new-bot-id',
-        name: 'test-bot',
-        version: '1.0.0',
+        id: "new-bot-id",
+        name: "test-bot",
+        version: "1.0.0",
         config: validConfig,
-        status: 'pending_review',
+        status: "pending_review",
         filePath:
-          'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip',
+          "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip",
         userId,
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -155,21 +153,22 @@ describe('CustomBotService', () => {
 
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.data!.name).toBe('test-bot');
-      expect(mockRepository.globalBotExists).toHaveBeenCalledWith('test-bot');
-      expect(
-        mockStorageService.validateZipStructure,
-      ).toHaveBeenCalledWith(filePath, Object.values(validConfig.entrypoints).filter(Boolean));
+      expect(result.data!.name).toBe("test-bot");
+      expect(mockRepository.globalBotExists).toHaveBeenCalledWith("test-bot");
+      expect(mockStorageService.validateZipStructure).toHaveBeenCalledWith(
+        filePath,
+        Object.values(validConfig.entrypoints).filter(Boolean),
+      );
     });
 
-    it('should fail validation with invalid config', async () => {
-      const userId = 'user123';
+    it("should fail validation with invalid config", async () => {
+      const userId = "user123";
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
 
       mockValidateConfig.mockReturnValue({
         valid: false,
-        errors: ['name is required', 'version format invalid'],
+        errors: ["name is required", "version format invalid"],
       });
 
       const result = await service.createCustomBot(
@@ -179,14 +178,14 @@ describe('CustomBotService', () => {
       );
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Validation failed');
-      expect(result.error).toContain('name is required');
+      expect(result.error).toContain("Validation failed");
+      expect(result.error).toContain("name is required");
     });
 
-    it('should fail when bot already exists', async () => {
-      const userId = 'user123';
+    it("should fail when bot already exists", async () => {
+      const userId = "user123";
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
 
       mockValidateConfig.mockReturnValue({ valid: true });
       mockRepository.globalBotExists.mockResolvedValue(Ok(true));
@@ -198,18 +197,18 @@ describe('CustomBotService', () => {
       );
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Custom bot with this name already exists');
+      expect(result.error).toBe("Custom bot with this name already exists");
     });
 
-    it('should fail when ZIP validation fails', async () => {
-      const userId = 'user123';
+    it("should fail when ZIP validation fails", async () => {
+      const userId = "user123";
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
 
       mockValidateConfig.mockReturnValue({ valid: true });
       mockRepository.globalBotExists.mockResolvedValue(Ok(false));
       mockStorageService.validateZipStructure.mockResolvedValue(
-        Failure('Required entrypoint not found'),
+        Failure("Required entrypoint not found"),
       );
 
       const result = await service.createCustomBot(
@@ -219,18 +218,18 @@ describe('CustomBotService', () => {
       );
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('ZIP validation failed');
+      expect(result.error).toContain("ZIP validation failed");
     });
 
-    it('should fail when ZIP validation fails', async () => {
-      const userId = 'user123';
+    it("should fail when ZIP validation fails", async () => {
+      const userId = "user123";
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
 
       mockValidateConfig.mockReturnValue({ valid: true });
       mockRepository.globalBotExists.mockResolvedValue(Ok(false));
       mockStorageService.validateZipStructure.mockResolvedValue(
-        Failure('Required entrypoint not found'),
+        Failure("Required entrypoint not found"),
       );
 
       const result = await service.createCustomBot(
@@ -240,21 +239,19 @@ describe('CustomBotService', () => {
       );
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('ZIP validation failed');
+      expect(result.error).toContain("ZIP validation failed");
     });
 
-    it('should handle repository errors', async () => {
-      const userId = 'user123';
+    it("should handle repository errors", async () => {
+      const userId = "user123";
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
 
       mockValidateConfig.mockReturnValue({ valid: true });
       mockRepository.globalBotExists.mockResolvedValue(Ok(false));
-      mockStorageService.validateZipStructure.mockResolvedValue(
-        Ok(true),
-      );
+      mockStorageService.validateZipStructure.mockResolvedValue(Ok(true));
       mockRepository.createNewGlobalVersion.mockResolvedValue(
-        Failure('Database error'),
+        Failure("Database error"),
       );
 
       const result = await service.createCustomBot(
@@ -264,17 +261,17 @@ describe('CustomBotService', () => {
       );
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Database error');
+      expect(result.error).toBe("Database error");
     });
 
-    it('should handle unexpected errors gracefully', async () => {
-      const userId = 'user123';
+    it("should handle unexpected errors gracefully", async () => {
+      const userId = "user123";
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
 
       mockValidateConfig.mockReturnValue({ valid: true });
       mockRepository.globalBotExists.mockRejectedValue(
-        new Error('Unexpected error'),
+        new Error("Unexpected error"),
       );
 
       const result = await service.createCustomBot(
@@ -284,34 +281,32 @@ describe('CustomBotService', () => {
       );
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Failed to create custom bot');
-      expect(result.error).toContain('Unexpected error');
+      expect(result.error).toContain("Failed to create custom bot");
+      expect(result.error).toContain("Unexpected error");
     });
 
-    it('should fail when realtime bot does not specify runtime', async () => {
-      const userId = 'user123';
+    it("should fail when realtime bot does not specify runtime", async () => {
+      const userId = "user123";
       const realtimeConfig = {
         ...validConfig,
-        type: 'realtime' as const,
+        type: "realtime" as const,
         runtime: undefined as any, // Realtime bot without runtime
       };
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
 
       mockValidateConfig.mockReturnValue({ valid: true });
       mockRepository.globalBotExists.mockResolvedValue(Ok(false));
-      mockStorageService.validateZipStructure.mockResolvedValue(
-        Ok(true),
-      );
+      mockStorageService.validateZipStructure.mockResolvedValue(Ok(true));
 
       const mockResult = {
-        id: 'new-bot-id',
-        name: 'test-bot',
-        version: '1.0.0',
+        id: "new-bot-id",
+        name: "test-bot",
+        version: "1.0.0",
         config: validConfig,
-        status: 'pending_review',
+        status: "pending_review",
         filePath:
-          'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip',
+          "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip",
         userId,
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -327,22 +322,20 @@ describe('CustomBotService', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe(
-        'Realtime bots must specify a valid runtime (python3.11 or nodejs20)',
+        "Realtime bots must specify a valid runtime (python3.11 or nodejs20)",
       );
-      expect(
-        mockStorageService.validateZipStructure,
-      ).not.toHaveBeenCalled();
+      expect(mockStorageService.validateZipStructure).not.toHaveBeenCalled();
     });
 
-    it('should fail when scheduled bot uses nodejs20 runtime', async () => {
-      const userId = 'user123';
+    it("should fail when scheduled bot uses nodejs20 runtime", async () => {
+      const userId = "user123";
       const scheduledNodeConfig = {
         ...validConfig,
-        type: 'scheduled' as const,
-        runtime: 'nodejs20' as const, // Invalid for scheduled bots
+        type: "scheduled" as const,
+        runtime: "nodejs20" as const, // Invalid for scheduled bots
       };
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
 
       mockValidateConfig.mockReturnValue({ valid: true });
       mockRepository.globalBotExists.mockResolvedValue(Ok(false));
@@ -355,36 +348,34 @@ describe('CustomBotService', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe(
-        'Scheduled bots must use python3.11 runtime (nodejs20 is not supported for scheduled bots)',
+        "Scheduled bots must use python3.11 runtime (nodejs20 is not supported for scheduled bots)",
       );
-      expect(
-        mockStorageService.validateZipStructure,
-      ).not.toHaveBeenCalled();
+      expect(mockStorageService.validateZipStructure).not.toHaveBeenCalled();
     });
   });
 
-  describe('updateCustomBot', () => {
-    it('should update custom bot with new version successfully', async () => {
-      const userId = 'user123';
-      const botName = 'test-bot';
+  describe("updateCustomBot", () => {
+    it("should update custom bot with new version successfully", async () => {
+      const userId = "user123";
+      const botName = "test-bot";
       const updateConfig = {
         ...validConfig,
-        version: '1.1.0',
+        version: "1.1.0",
       };
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
 
       mockValidateConfig.mockReturnValue({ valid: true });
       mockRepository.globalBotExists.mockResolvedValue(Ok(true));
       mockRepository.checkUserOwnership.mockResolvedValue(Ok(true));
       mockRepository.getGlobalLatestVersion.mockResolvedValue(
         Ok({
-          id: 'existing-id',
-          name: 'test-bot',
-          version: '1.0.0',
+          id: "existing-id",
+          name: "test-bot",
+          version: "1.0.0",
           config: validConfig,
-          filePath: 'gs://old-path.zip',
-          status: 'approved',
+          filePath: "gs://old-path.zip",
+          status: "approved",
           userId,
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -392,18 +383,16 @@ describe('CustomBotService', () => {
       );
       mockRepository.isVersionNewer.mockReturnValue(true);
       mockRepository.globalVersionExists.mockResolvedValue(Ok(false));
-      mockStorageService.validateZipStructure.mockResolvedValue(
-        Ok(true),
-      );
+      mockStorageService.validateZipStructure.mockResolvedValue(Ok(true));
       mockRepository.createNewGlobalVersion.mockResolvedValue(
         Ok({
-          id: 'new-version-id',
-          name: 'test-bot',
-          version: '1.1.0',
+          id: "new-version-id",
+          name: "test-bot",
+          version: "1.1.0",
           config: updateConfig,
-          status: 'pending_review',
+          status: "pending_review",
           filePath:
-            'gs://test-bucket/user123/test-bot/1.1.0/test-bot_1.1.0_123456.zip',
+            "gs://test-bucket/user123/test-bot/1.1.0/test-bot_1.1.0_123456.zip",
           userId,
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -418,20 +407,20 @@ describe('CustomBotService', () => {
       );
 
       expect(result.success).toBe(true);
-      expect(result.data!.version).toBe('1.1.0');
+      expect(result.data!.version).toBe("1.1.0");
     });
 
-    it('should fail when the realtime bot does not specify runtime', async () => {
-      const userId = 'user123';
-      const botName = 'test-bot';
+    it("should fail when the realtime bot does not specify runtime", async () => {
+      const userId = "user123";
+      const botName = "test-bot";
       const realtimeConfig = {
         ...validConfig,
         name: botName,
-        type: 'realtime' as const,
+        type: "realtime" as const,
         runtime: undefined as any, // Invalid runtime for realtime bot
       };
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
 
       mockValidateConfig.mockReturnValue({ valid: true });
 
@@ -444,24 +433,22 @@ describe('CustomBotService', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe(
-        'Realtime bots must specify a valid runtime (python3.11 or nodejs20)',
+        "Realtime bots must specify a valid runtime (python3.11 or nodejs20)",
       );
-      expect(
-        mockStorageService.validateZipStructure,
-      ).not.toHaveBeenCalled();
+      expect(mockStorageService.validateZipStructure).not.toHaveBeenCalled();
     });
 
-    it('should fail when scheduled bot uses nodejs20 runtime', async () => {
-      const userId = 'user123';
-      const botName = 'test-bot';
+    it("should fail when scheduled bot uses nodejs20 runtime", async () => {
+      const userId = "user123";
+      const botName = "test-bot";
       const scheduledNodeConfig = {
         ...validConfig,
         name: botName,
-        type: 'scheduled' as const,
-        runtime: 'nodejs20' as const, // Invalid for scheduled bots
+        type: "scheduled" as const,
+        runtime: "nodejs20" as const, // Invalid for scheduled bots
       };
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
 
       mockValidateConfig.mockReturnValue({ valid: true });
 
@@ -474,18 +461,16 @@ describe('CustomBotService', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe(
-        'Scheduled bots must use python3.11 runtime (nodejs20 is not supported for scheduled bots)',
+        "Scheduled bots must use python3.11 runtime (nodejs20 is not supported for scheduled bots)",
       );
-      expect(
-        mockStorageService.validateZipStructure,
-      ).not.toHaveBeenCalled();
+      expect(mockStorageService.validateZipStructure).not.toHaveBeenCalled();
     });
 
-    it('should fail when bot name in config does not match URL parameter', async () => {
-      const userId = 'user123';
-      const botName = 'different-bot';
+    it("should fail when bot name in config does not match URL parameter", async () => {
+      const userId = "user123";
+      const botName = "different-bot";
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
 
       mockValidateConfig.mockReturnValue({ valid: true });
 
@@ -498,15 +483,15 @@ describe('CustomBotService', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe(
-        'Bot name in config must match the URL parameter',
+        "Bot name in config must match the URL parameter",
       );
     });
 
-    it('should fail when bot does not exist', async () => {
-      const userId = 'user123';
-      const botName = 'test-bot';
+    it("should fail when bot does not exist", async () => {
+      const userId = "user123";
+      const botName = "test-bot";
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
 
       mockValidateConfig.mockReturnValue({ valid: true });
       mockRepository.globalBotExists.mockResolvedValue(Ok(false));
@@ -520,20 +505,20 @@ describe('CustomBotService', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe(
-        'Custom bot does not exist. Create it first using POST.',
+        "Custom bot does not exist. Create it first using POST.",
       );
     });
 
-    it('should fail when user does not own the bot', async () => {
-      const userId = 'user123';
-      const botName = 'test-bot';
+    it("should fail when user does not own the bot", async () => {
+      const userId = "user123";
+      const botName = "test-bot";
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
 
       mockValidateConfig.mockReturnValue({ valid: true });
       mockRepository.globalBotExists.mockResolvedValue(Ok(true));
       mockRepository.checkUserOwnership.mockResolvedValue(
-        Failure('Insufficient permissions'),
+        Failure("Insufficient permissions"),
       );
 
       const result = await service.updateCustomBot(
@@ -544,26 +529,26 @@ describe('CustomBotService', () => {
       );
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Insufficient permissions');
+      expect(result.error).toBe("Insufficient permissions");
     });
 
-    it('should fail when new version is not newer', async () => {
-      const userId = 'user123';
-      const botName = 'test-bot';
+    it("should fail when new version is not newer", async () => {
+      const userId = "user123";
+      const botName = "test-bot";
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
 
       mockValidateConfig.mockReturnValue({ valid: true });
       mockRepository.globalBotExists.mockResolvedValue(Ok(true));
       mockRepository.checkUserOwnership.mockResolvedValue(Ok(true));
       mockRepository.getGlobalLatestVersion.mockResolvedValue(
         Ok({
-          id: 'existing-id',
-          name: 'test-bot',
-          version: '2.0.0', // Higher than payload version
+          id: "existing-id",
+          name: "test-bot",
+          version: "2.0.0", // Higher than payload version
           config: validConfig,
-          status: 'approved',
-          filePath: 'gs://old-path.zip',
+          status: "approved",
+          filePath: "gs://old-path.zip",
           userId,
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -579,26 +564,26 @@ describe('CustomBotService', () => {
       );
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('must be greater than current version');
+      expect(result.error).toContain("must be greater than current version");
     });
 
-    it('should fail when version already exists', async () => {
-      const userId = 'user123';
-      const botName = 'test-bot';
+    it("should fail when version already exists", async () => {
+      const userId = "user123";
+      const botName = "test-bot";
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
 
       mockValidateConfig.mockReturnValue({ valid: true });
       mockRepository.globalBotExists.mockResolvedValue(Ok(true));
       mockRepository.checkUserOwnership.mockResolvedValue(Ok(true));
       mockRepository.getGlobalLatestVersion.mockResolvedValue(
         Ok({
-          id: 'existing-id',
-          name: 'test-bot',
-          version: '0.9.0',
+          id: "existing-id",
+          name: "test-bot",
+          version: "0.9.0",
           config: validConfig,
-          status: 'approved',
-          filePath: 'gs://old-path.zip',
+          status: "approved",
+          filePath: "gs://old-path.zip",
           userId,
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -615,26 +600,26 @@ describe('CustomBotService', () => {
       );
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('already exists for this bot');
+      expect(result.error).toContain("already exists for this bot");
     });
 
-    it('should fail when ZIP validation fails', async () => {
-      const userId = 'user123';
-      const botName = 'test-bot';
+    it("should fail when ZIP validation fails", async () => {
+      const userId = "user123";
+      const botName = "test-bot";
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
 
       mockValidateConfig.mockReturnValue({ valid: true });
       mockRepository.globalBotExists.mockResolvedValue(Ok(true));
       mockRepository.checkUserOwnership.mockResolvedValue(Ok(true));
       mockRepository.getGlobalLatestVersion.mockResolvedValue(
         Ok({
-          id: 'existing-id',
-          name: 'test-bot',
-          version: '0.9.0',
+          id: "existing-id",
+          name: "test-bot",
+          version: "0.9.0",
           config: validConfig,
-          status: 'approved',
-          filePath: 'gs://old-path.zip',
+          status: "approved",
+          filePath: "gs://old-path.zip",
           userId,
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -643,7 +628,7 @@ describe('CustomBotService', () => {
       mockRepository.isVersionNewer.mockReturnValue(true);
       mockRepository.globalVersionExists.mockResolvedValue(Ok(false));
       mockStorageService.validateZipStructure.mockResolvedValue(
-        Failure('Invalid ZIP structure'),
+        Failure("Invalid ZIP structure"),
       );
 
       const result = await service.updateCustomBot(
@@ -654,18 +639,18 @@ describe('CustomBotService', () => {
       );
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('ZIP validation failed');
+      expect(result.error).toContain("ZIP validation failed");
     });
 
-    it('should handle unexpected errors gracefully', async () => {
-      const userId = 'user123';
-      const botName = 'test-bot';
+    it("should handle unexpected errors gracefully", async () => {
+      const userId = "user123";
+      const botName = "test-bot";
       const filePath =
-        'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip';
+        "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip";
 
       mockValidateConfig.mockReturnValue({ valid: true });
       mockRepository.globalBotExists.mockRejectedValue(
-        new Error('Database connection failed'),
+        new Error("Database connection failed"),
       );
 
       const result = await service.updateCustomBot(
@@ -676,79 +661,79 @@ describe('CustomBotService', () => {
       );
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Failed to update custom bot');
-      expect(result.error).toContain('Database connection failed');
+      expect(result.error).toContain("Failed to update custom bot");
+      expect(result.error).toContain("Database connection failed");
     });
   });
 
-  describe('getUserCustomBots', () => {
-    it('should return user custom bots successfully', async () => {
-      const userId = 'user123';
+  describe("getUserCustomBots", () => {
+    it("should return user custom bots successfully", async () => {
+      const userId = "user123";
       const mockBotsWithVersions: CustomBotWithVersions[] = [
         {
-          id: 'bot-1',
-          name: 'arbitrage-bot',
+          id: "bot-1",
+          name: "arbitrage-bot",
           userId,
-          latestVersion: '1.2.0',
+          latestVersion: "1.2.0",
           versions: [
             {
-              version: '1.2.0',
+              version: "1.2.0",
               config: {
                 ...validConfig,
-                name: 'arbitrage-bot',
-                version: '1.2.0',
+                name: "arbitrage-bot",
+                version: "1.2.0",
               },
               marketplace: null,
-              status: 'approved',
-              id: 'bot-1',
+              status: "approved",
+              id: "bot-1",
               userId,
-              filePath: 'gs://bucket/arbitrage-bot/1.2.0/file.zip',
-              createdAt: new Date('2025-01-15T10:30:00.000Z'),
-              updatedAt: new Date('2025-01-15T10:30:00.000Z'),
+              filePath: "gs://bucket/arbitrage-bot/1.2.0/file.zip",
+              createdAt: new Date("2025-01-15T10:30:00.000Z"),
+              updatedAt: new Date("2025-01-15T10:30:00.000Z"),
             },
             {
-              version: '1.1.0',
+              version: "1.1.0",
               config: {
                 ...validConfig,
-                name: 'arbitrage-bot',
-                version: '1.1.0',
+                name: "arbitrage-bot",
+                version: "1.1.0",
               },
               marketplace: null,
-              status: 'approved',
-              id: 'bot-1',
+              status: "approved",
+              id: "bot-1",
               userId,
-              filePath: 'gs://bucket/arbitrage-bot/1.1.0/file.zip',
-              createdAt: new Date('2025-01-10T09:15:00.000Z'),
-              updatedAt: new Date('2025-01-10T09:15:00.000Z'),
+              filePath: "gs://bucket/arbitrage-bot/1.1.0/file.zip",
+              createdAt: new Date("2025-01-10T09:15:00.000Z"),
+              updatedAt: new Date("2025-01-10T09:15:00.000Z"),
             },
           ],
-          createdAt: new Date('2025-01-10T09:15:00.000Z'),
-          updatedAt: new Date('2025-01-15T10:30:00.000Z'),
+          createdAt: new Date("2025-01-10T09:15:00.000Z"),
+          updatedAt: new Date("2025-01-15T10:30:00.000Z"),
         },
         {
-          id: 'bot-2',
-          name: 'trend-following-bot',
+          id: "bot-2",
+          name: "trend-following-bot",
           userId,
-          latestVersion: '2.0.0',
+          latestVersion: "2.0.0",
           versions: [
             {
-              version: '2.0.0',
+              version: "2.0.0",
               config: {
                 ...validConfig,
-                name: 'trend-following-bot',
-                version: '2.0.0',
+                name: "trend-following-bot",
+                version: "2.0.0",
               },
               marketplace: null,
-              status: 'approved',
-              id: 'bot-1',
+              status: "approved",
+              id: "bot-1",
               userId,
-              filePath: 'gs://bucket/trend-following-bot/2.0.0/file.zip',
-              createdAt: new Date('2025-01-12T14:20:00.000Z'),
-              updatedAt: new Date('2025-01-12T14:20:00.000Z'),
+              filePath: "gs://bucket/trend-following-bot/2.0.0/file.zip",
+              createdAt: new Date("2025-01-12T14:20:00.000Z"),
+              updatedAt: new Date("2025-01-12T14:20:00.000Z"),
             },
           ],
-          createdAt: new Date('2025-01-12T14:20:00.000Z'),
-          updatedAt: new Date('2025-01-12T14:20:00.000Z'),
+          createdAt: new Date("2025-01-12T14:20:00.000Z"),
+          updatedAt: new Date("2025-01-12T14:20:00.000Z"),
         },
       ];
 
@@ -761,15 +746,15 @@ describe('CustomBotService', () => {
       expect(result.success).toBe(true);
       expect(result.data).toEqual(mockBotsWithVersions);
       expect(result.data!.length).toBe(2);
-      expect(result.data![0].name).toBe('arbitrage-bot');
+      expect(result.data![0].name).toBe("arbitrage-bot");
       expect(result.data![0].versions.length).toBe(2);
-      expect(result.data![1].name).toBe('trend-following-bot');
+      expect(result.data![1].name).toBe("trend-following-bot");
       expect(result.data![1].versions.length).toBe(1);
       expect(mockRepository.getUserCustomBots).toHaveBeenCalledWith(userId);
     });
 
-    it('should return empty array when user has no custom bots', async () => {
-      const userId = 'user123';
+    it("should return empty array when user has no custom bots", async () => {
+      const userId = "user123";
 
       mockRepository.getUserCustomBots.mockResolvedValue(Ok([]));
 
@@ -780,91 +765,91 @@ describe('CustomBotService', () => {
       expect(mockRepository.getUserCustomBots).toHaveBeenCalledWith(userId);
     });
 
-    it('should handle repository errors', async () => {
-      const userId = 'user123';
+    it("should handle repository errors", async () => {
+      const userId = "user123";
 
       mockRepository.getUserCustomBots.mockResolvedValue(
-        Failure('Database connection failed'),
+        Failure("Database connection failed"),
       );
 
       const result = await service.getUserCustomBots(userId);
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Database connection failed');
+      expect(result.error).toBe("Database connection failed");
       expect(mockRepository.getUserCustomBots).toHaveBeenCalledWith(userId);
     });
 
-    it('should handle unexpected errors gracefully', async () => {
-      const userId = 'user123';
+    it("should handle unexpected errors gracefully", async () => {
+      const userId = "user123";
 
       mockRepository.getUserCustomBots.mockRejectedValue(
-        new Error('Network timeout'),
+        new Error("Network timeout"),
       );
 
       const result = await service.getUserCustomBots(userId);
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Failed to get user custom bots');
-      expect(result.error).toContain('Network timeout');
+      expect(result.error).toContain("Failed to get user custom bots");
+      expect(result.error).toContain("Network timeout");
     });
 
-    it('should maintain correct data structure for grouped bots', async () => {
-      const userId = 'user123';
+    it("should maintain correct data structure for grouped bots", async () => {
+      const userId = "user123";
       const mockBotWithMultipleVersions: CustomBotWithVersions[] = [
         {
-          id: 'bot-complex',
-          name: 'multi-version-bot',
+          id: "bot-complex",
+          name: "multi-version-bot",
           userId,
-          latestVersion: '3.0.0',
+          latestVersion: "3.0.0",
           versions: [
             {
-              version: '3.0.0',
+              version: "3.0.0",
               config: {
                 ...validConfig,
-                name: 'multi-version-bot',
-                version: '3.0.0',
+                name: "multi-version-bot",
+                version: "3.0.0",
               },
               marketplace: null,
-              status: 'approved',
-              id: 'bot-1',
+              status: "approved",
+              id: "bot-1",
               userId,
-              filePath: 'gs://bucket/multi-version-bot/3.0.0/file.zip',
-              createdAt: new Date('2025-01-15T10:30:00.000Z'),
-              updatedAt: new Date('2025-01-15T10:30:00.000Z'),
+              filePath: "gs://bucket/multi-version-bot/3.0.0/file.zip",
+              createdAt: new Date("2025-01-15T10:30:00.000Z"),
+              updatedAt: new Date("2025-01-15T10:30:00.000Z"),
             },
             {
-              version: '2.1.0',
+              version: "2.1.0",
               config: {
                 ...validConfig,
-                name: 'multi-version-bot',
-                version: '2.1.0',
+                name: "multi-version-bot",
+                version: "2.1.0",
               },
               marketplace: null,
-              status: 'approved',
-              id: 'bot-1',
+              status: "approved",
+              id: "bot-1",
               userId,
-              filePath: 'gs://bucket/multi-version-bot/2.1.0/file.zip',
-              createdAt: new Date('2025-01-12T10:30:00.000Z'),
-              updatedAt: new Date('2025-01-12T10:30:00.000Z'),
+              filePath: "gs://bucket/multi-version-bot/2.1.0/file.zip",
+              createdAt: new Date("2025-01-12T10:30:00.000Z"),
+              updatedAt: new Date("2025-01-12T10:30:00.000Z"),
             },
             {
-              version: '1.0.0',
+              version: "1.0.0",
               config: {
                 ...validConfig,
-                name: 'multi-version-bot',
-                version: '1.0.0',
+                name: "multi-version-bot",
+                version: "1.0.0",
               },
               marketplace: null,
-              status: 'approved',
-              id: 'bot-1',
+              status: "approved",
+              id: "bot-1",
               userId,
-              filePath: 'gs://bucket/multi-version-bot/1.0.0/file.zip',
-              createdAt: new Date('2025-01-10T10:30:00.000Z'),
-              updatedAt: new Date('2025-01-10T10:30:00.000Z'),
+              filePath: "gs://bucket/multi-version-bot/1.0.0/file.zip",
+              createdAt: new Date("2025-01-10T10:30:00.000Z"),
+              updatedAt: new Date("2025-01-10T10:30:00.000Z"),
             },
           ],
-          createdAt: new Date('2025-01-10T10:30:00.000Z'), // First created
-          updatedAt: new Date('2025-01-15T10:30:00.000Z'), // Latest updated
+          createdAt: new Date("2025-01-10T10:30:00.000Z"), // First created
+          updatedAt: new Date("2025-01-15T10:30:00.000Z"), // Latest updated
         },
       ];
 
@@ -875,46 +860,46 @@ describe('CustomBotService', () => {
       const result = await service.getUserCustomBots(userId);
 
       expect(result.success).toBe(true);
-      expect(result.data![0].latestVersion).toBe('3.0.0');
+      expect(result.data![0].latestVersion).toBe("3.0.0");
       expect(result.data![0].versions).toHaveLength(3);
-      expect(result.data![0].versions[0].version).toBe('3.0.0'); // Latest first
-      expect(result.data![0].versions[2].version).toBe('1.0.0'); // Oldest last
+      expect(result.data![0].versions[0].version).toBe("3.0.0"); // Latest first
+      expect(result.data![0].versions[2].version).toBe("1.0.0"); // Oldest last
     });
   });
 
-  describe('getAllUserVersions', () => {
-    it('should return all versions for a specific bot successfully', async () => {
-      const userId = 'user123';
-      const botName = 'test-bot';
+  describe("getAllUserVersions", () => {
+    it("should return all versions for a specific bot successfully", async () => {
+      const userId = "user123";
+      const botName = "test-bot";
       const mockVersions: CustomBotWithVersions = {
-        id: 'bot-id',
-        name: 'test-bot',
+        id: "bot-id",
+        name: "test-bot",
         userId,
         versions: [
           {
-            version: '1.1.0',
-            config: { ...validConfig, version: '1.1.0' },
-            filePath: 'path1',
+            version: "1.1.0",
+            config: { ...validConfig, version: "1.1.0" },
+            filePath: "path1",
             createdAt: new Date(),
             updatedAt: new Date(),
             marketplace: null,
-            status: 'approved',
-            id: 'bot-1',
+            status: "approved",
+            id: "bot-1",
             userId,
           },
           {
-            version: '1.0.0',
+            version: "1.0.0",
             config: validConfig,
-            filePath: 'path2',
+            filePath: "path2",
             createdAt: new Date(),
             updatedAt: new Date(),
             marketplace: null,
-            status: 'approved',
-            id: 'bot-1',
+            status: "approved",
+            id: "bot-1",
             userId,
           },
         ],
-        latestVersion: '1.1.0',
+        latestVersion: "1.1.0",
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -931,42 +916,42 @@ describe('CustomBotService', () => {
       );
     });
 
-    it('should handle repository errors', async () => {
-      const userId = 'user123';
-      const botName = 'test-bot';
+    it("should handle repository errors", async () => {
+      const userId = "user123";
+      const botName = "test-bot";
 
       mockRepository.getAllUserVersions.mockResolvedValue(
-        Failure('Bot not found'),
+        Failure("Bot not found"),
       );
 
       const result = await service.getAllUserVersions(userId, botName);
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Bot not found');
+      expect(result.error).toBe("Bot not found");
     });
   });
 
-  describe('getAllGlobalVersions', () => {
-    it('should return all global versions for a bot successfully', async () => {
-      const botName = 'test-bot';
+  describe("getAllGlobalVersions", () => {
+    it("should return all global versions for a bot successfully", async () => {
+      const botName = "test-bot";
       const mockVersions: CustomBotWithVersions = {
-        id: 'bot-id',
-        name: 'test-bot',
-        userId: 'any-user',
+        id: "bot-id",
+        name: "test-bot",
+        userId: "any-user",
         versions: [
           {
-            version: '2.0.0',
-            config: { ...validConfig, version: '2.0.0' },
-            filePath: 'path1',
+            version: "2.0.0",
+            config: { ...validConfig, version: "2.0.0" },
+            filePath: "path1",
             createdAt: new Date(),
             updatedAt: new Date(),
             marketplace: null,
-            status: 'approved',
-            id: 'bot-1',
-            userId: 'any-user',
+            status: "approved",
+            id: "bot-1",
+            userId: "any-user",
           },
         ],
-        latestVersion: '2.0.0',
+        latestVersion: "2.0.0",
         createdAt: new Date(),
         updatedAt: new Date(),
       };
@@ -981,19 +966,19 @@ describe('CustomBotService', () => {
     });
   });
 
-  describe('getUserSpecificVersion', () => {
-    it('should return specific version successfully', async () => {
-      const userId = 'user123';
-      const botName = 'test-bot';
-      const version = '1.0.0';
+  describe("getUserSpecificVersion", () => {
+    it("should return specific version successfully", async () => {
+      const userId = "user123";
+      const botName = "test-bot";
+      const version = "1.0.0";
       const mockBot = {
-        id: 'bot-id',
-        name: 'test-bot',
-        version: '1.0.0',
+        id: "bot-id",
+        name: "test-bot",
+        version: "1.0.0",
         config: validConfig,
-        status: 'approved',
+        status: "approved",
         filePath:
-          'gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip',
+          "gs://test-bucket/user123/test-bot/1.0.0/test-bot_1.0.0_123456.zip",
         userId,
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -1016,13 +1001,13 @@ describe('CustomBotService', () => {
       );
     });
 
-    it('should handle version not found', async () => {
-      const userId = 'user123';
-      const botName = 'test-bot';
-      const version = '1.0.0';
+    it("should handle version not found", async () => {
+      const userId = "user123";
+      const botName = "test-bot";
+      const version = "1.0.0";
 
       mockRepository.getSpecificUserVersion.mockResolvedValue(
-        Failure('Version not found'),
+        Failure("Version not found"),
       );
 
       const result = await service.getUserSpecificVersion(
@@ -1032,22 +1017,22 @@ describe('CustomBotService', () => {
       );
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Version not found');
+      expect(result.error).toBe("Version not found");
     });
   });
 
-  describe('getGlobalSpecificVersion', () => {
-    it('should return global specific version successfully', async () => {
-      const botName = 'test-bot';
-      const version = '1.0.0';
+  describe("getGlobalSpecificVersion", () => {
+    it("should return global specific version successfully", async () => {
+      const botName = "test-bot";
+      const version = "1.0.0";
       const mockBot = {
-        id: 'bot-id',
-        name: 'test-bot',
-        version: '1.0.0',
+        id: "bot-id",
+        name: "test-bot",
+        version: "1.0.0",
         config: validConfig,
-        filePath: 'gs://test-bucket/test-bot/1.0.0/file.zip',
-        userId: 'any-user',
-        status: 'approved',
+        filePath: "gs://test-bucket/test-bot/1.0.0/file.zip",
+        userId: "any-user",
+        status: "approved",
         createdAt: new Date(),
         updatedAt: new Date(),
       } as CustomBot;
@@ -1064,5 +1049,4 @@ describe('CustomBotService', () => {
       );
     });
   });
-
 });

--- a/api/src/custom-bot/__tests__/schema.validation.spec.ts
+++ b/api/src/custom-bot/__tests__/schema.validation.spec.ts
@@ -2,53 +2,53 @@ import {
   validateCustomBotConfig,
   validateCustomBotConfigPayload,
   validateCustomBotPayload,
-} from '../custom-bot.schema';
-import { CustomBotConfig } from '../custom-bot.types';
+} from "../custom-bot.schema";
+import { CustomBotConfig } from "../custom-bot.types";
 
-describe('Custom Bot Schema Validation', () => {
+describe("Custom Bot Schema Validation", () => {
   const validConfig: CustomBotConfig = {
-    name: 'test-bot',
-    description: 'A valid test bot description',
-    version: '1.0.0',
-    author: 'Test Author',
-    type: 'scheduled',
-    runtime: 'python3.11',
+    name: "test-bot",
+    description: "A valid test bot description",
+    version: "1.0.0",
+    author: "Test Author",
+    type: "scheduled",
+    runtime: "python3.11",
     entrypoints: {
-      bot: 'main.py',
-      backtest: 'backtest.py',
+      bot: "main.py",
+      backtest: "backtest.py",
     },
     schema: {
       bot: {
-        type: 'object',
+        type: "object",
         properties: {
-          apiKey: { type: 'string' },
+          apiKey: { type: "string" },
         },
       },
       backtest: {
-        type: 'object',
+        type: "object",
         properties: {
-          symbol: { type: 'string' },
+          symbol: { type: "string" },
         },
       },
     },
     readme:
-      'This is a comprehensive readme that meets the minimum length requirement for bot documentation and provides useful information.',
+      "This is a comprehensive readme that meets the minimum length requirement for bot documentation and provides useful information.",
   };
 
-  describe('validateCustomBotConfig', () => {
-    it('should validate a complete valid config', () => {
+  describe("validateCustomBotConfig", () => {
+    it("should validate a complete valid config", () => {
       const result = validateCustomBotConfig(validConfig);
       expect(result).toBe(true);
     });
 
-    it('should validate config with optional metadata', () => {
+    it("should validate config with optional metadata", () => {
       const configWithMetadata = {
         ...validConfig,
         metadata: {
-          categories: ['trading', 'crypto'],
-          instruments: ['bitcoin', 'ethereum'],
-          exchanges: ['binance', 'coinbase'],
-          tags: ['test', 'demo'],
+          categories: ["trading", "crypto"],
+          instruments: ["bitcoin", "ethereum"],
+          exchanges: ["binance", "coinbase"],
+          tags: ["test", "demo"],
         },
       };
 
@@ -56,12 +56,12 @@ describe('Custom Bot Schema Validation', () => {
       expect(result).toBe(true);
     });
 
-    it('should validate with JavaScript entrypoints', () => {
+    it("should validate with JavaScript entrypoints", () => {
       const jsConfig = {
         ...validConfig,
         entrypoints: {
-          bot: 'main.js',
-          backtest: 'backtest.js',
+          bot: "main.js",
+          backtest: "backtest.js",
         },
       };
 
@@ -69,8 +69,8 @@ describe('Custom Bot Schema Validation', () => {
       expect(result).toBe(true);
     });
 
-    it('should validate all bot types', () => {
-      const types = ['scheduled', 'realtime', 'event'] as const;
+    it("should validate all bot types", () => {
+      const types = ["scheduled", "realtime", "event"] as const;
 
       types.forEach((type) => {
         const configWithType = { ...validConfig, type };
@@ -79,22 +79,22 @@ describe('Custom Bot Schema Validation', () => {
       });
     });
 
-    it('should validate realtime bot with nodejs20 runtime', () => {
+    it("should validate realtime bot with nodejs20 runtime", () => {
       const realtimeConfig = {
         ...validConfig,
-        type: 'realtime' as const,
-        runtime: 'nodejs20' as const,
+        type: "realtime" as const,
+        runtime: "nodejs20" as const,
       };
 
       const result = validateCustomBotConfig(realtimeConfig);
       expect(result).toBe(true);
     });
 
-    it('should validate realtime bot with python3.11 runtime', () => {
+    it("should validate realtime bot with python3.11 runtime", () => {
       const realtimeConfig = {
         ...validConfig,
-        type: 'realtime' as const,
-        runtime: 'python3.11' as const,
+        type: "realtime" as const,
+        runtime: "python3.11" as const,
       };
 
       const result = validateCustomBotConfig(realtimeConfig);
@@ -102,22 +102,22 @@ describe('Custom Bot Schema Validation', () => {
     });
   });
 
-  describe('validateCustomBotConfigPayload', () => {
-    it('should validate a complete valid config payload', () => {
+  describe("validateCustomBotConfigPayload", () => {
+    it("should validate a complete valid config payload", () => {
       const result = validateCustomBotConfigPayload(validConfig);
       expect(result.valid).toBe(true);
       expect(result.errors).toBeUndefined();
     });
 
-    it('should validate payload with optional metadata', () => {
+    it("should validate payload with optional metadata", () => {
       const configWithMetadata = {
         ...validConfig,
         metadata: {
-          categories: ['trading', 'crypto'],
-          instruments: ['bitcoin', 'ethereum'],
-          exchanges: ['binance', 'coinbase'],
-          tags: ['test', 'demo'],
-          customField: 'allowed',
+          categories: ["trading", "crypto"],
+          instruments: ["bitcoin", "ethereum"],
+          exchanges: ["binance", "coinbase"],
+          tags: ["test", "demo"],
+          customField: "allowed",
         },
       };
 
@@ -125,7 +125,7 @@ describe('Custom Bot Schema Validation', () => {
       expect(result.valid).toBe(true);
     });
 
-    it('should fail when name is missing', () => {
+    it("should fail when name is missing", () => {
       const invalidConfig = { ...validConfig };
       delete (invalidConfig as any).name;
 
@@ -138,7 +138,7 @@ describe('Custom Bot Schema Validation', () => {
       ).toBe(true);
     });
 
-    it('should fail when version is missing', () => {
+    it("should fail when version is missing", () => {
       const invalidConfig = { ...validConfig };
       delete (invalidConfig as any).version;
 
@@ -151,7 +151,7 @@ describe('Custom Bot Schema Validation', () => {
       ).toBe(true);
     });
 
-    it('should fail when entrypoints are missing', () => {
+    it("should fail when entrypoints are missing", () => {
       const invalidConfig = { ...validConfig };
       delete (invalidConfig as any).entrypoints;
 
@@ -164,7 +164,7 @@ describe('Custom Bot Schema Validation', () => {
       ).toBe(true);
     });
 
-    it('should fail when schema is missing', () => {
+    it("should fail when schema is missing", () => {
       const invalidConfig = { ...validConfig };
       delete (invalidConfig as any).schema;
 
@@ -177,7 +177,7 @@ describe('Custom Bot Schema Validation', () => {
       ).toBe(true);
     });
 
-    it('should fail when readme is missing', () => {
+    it("should fail when readme is missing", () => {
       const invalidConfig = { ...validConfig };
       delete (invalidConfig as any).readme;
 
@@ -190,7 +190,7 @@ describe('Custom Bot Schema Validation', () => {
       ).toBe(true);
     });
 
-    it('should fail when type is missing', () => {
+    it("should fail when type is missing", () => {
       const invalidConfig = { ...validConfig };
       delete (invalidConfig as any).type;
 
@@ -203,7 +203,7 @@ describe('Custom Bot Schema Validation', () => {
       ).toBe(true);
     });
 
-    it('should fail when runtime is missing', () => {
+    it("should fail when runtime is missing", () => {
       const invalidConfig = { ...validConfig };
       delete (invalidConfig as any).runtime;
 
@@ -217,85 +217,85 @@ describe('Custom Bot Schema Validation', () => {
     });
   });
 
-  describe('validateCustomBotPayload (backward compatibility)', () => {
-    it('should validate config directly', () => {
+  describe("validateCustomBotPayload (backward compatibility)", () => {
+    it("should validate config directly", () => {
       const result = validateCustomBotPayload(validConfig);
       expect(result.valid).toBe(true);
     });
 
-    it('should validate payload with config property', () => {
+    it("should validate payload with config property", () => {
       const payload = { config: validConfig };
       const result = validateCustomBotPayload(payload);
       expect(result.valid).toBe(true);
     });
 
-    it('should handle invalid payload gracefully', () => {
+    it("should handle invalid payload gracefully", () => {
       const result = validateCustomBotPayload(null);
       expect(result.valid).toBe(false);
     });
   });
 
-  describe('runtime validation rules', () => {
-    it('should validate scheduled bot with python3.11 runtime', () => {
+  describe("runtime validation rules", () => {
+    it("should validate scheduled bot with python3.11 runtime", () => {
       const scheduledConfig = {
         ...validConfig,
-        type: 'scheduled' as const,
-        runtime: 'python3.11' as const,
+        type: "scheduled" as const,
+        runtime: "python3.11" as const,
       };
 
       const result = validateCustomBotConfigPayload(scheduledConfig);
       expect(result.valid).toBe(true);
     });
 
-    it('should fail scheduled bot with nodejs20 runtime', () => {
+    it("should fail scheduled bot with nodejs20 runtime", () => {
       const scheduledConfig = {
         ...validConfig,
-        type: 'scheduled' as const,
-        runtime: 'nodejs20' as const,
+        type: "scheduled" as const,
+        runtime: "nodejs20" as const,
       };
 
       const result = validateCustomBotConfigPayload(scheduledConfig);
       expect(result.valid).toBe(false);
       expect(
         result.errors?.some((err) =>
-          err.includes('must be equal to one of the allowed values'),
+          err.includes("must be equal to one of the allowed values"),
         ),
       ).toBe(true);
     });
 
-    it('should validate realtime bot with python3.11 runtime', () => {
+    it("should validate realtime bot with python3.11 runtime", () => {
       const realtimeConfig = {
         ...validConfig,
-        type: 'realtime' as const,
-        runtime: 'python3.11' as const,
+        type: "realtime" as const,
+        runtime: "python3.11" as const,
       };
 
       const result = validateCustomBotConfigPayload(realtimeConfig);
       expect(result.valid).toBe(true);
     });
 
-    it('should validate realtime bot with nodejs20 runtime', () => {
+    it("should validate realtime bot with nodejs20 runtime", () => {
       const realtimeConfig = {
         ...validConfig,
-        type: 'realtime' as const,
-        runtime: 'nodejs20' as const,
+        type: "realtime" as const,
+        runtime: "nodejs20" as const,
       };
 
       const result = validateCustomBotConfigPayload(realtimeConfig);
       expect(result.valid).toBe(true);
     });
 
-    it('should validate event bot with either runtime', () => {
+    it("should validate event bot with either runtime", () => {
       const eventConfigPython = {
         ...validConfig,
-        type: 'event' as const,
-        runtime: 'python3.11' as const,
+        type: "event" as const,
+        runtime: "python3.11" as const,
       };
 
       const eventConfigNode = {
         ...validConfig,
-        type: 'event' as const,
-        runtime: 'nodejs20' as const,
+        type: "event" as const,
+        runtime: "nodejs20" as const,
       };
 
       expect(validateCustomBotConfigPayload(eventConfigPython).valid).toBe(
@@ -305,250 +305,163 @@ describe('Custom Bot Schema Validation', () => {
     });
   });
 
-  describe('invalid configs - format validation', () => {
-    it('should fail with invalid bot name format', () => {
+  describe("invalid configs - format validation", () => {
+    it("should fail with invalid bot name format", () => {
       const invalidConfig = {
         ...validConfig,
-        name: 'Invalid_Name_With_Underscores!',
+        name: "Invalid_Name_With_Underscores!",
       };
 
       const result = validateCustomBotConfigPayload(invalidConfig);
       expect(result.valid).toBe(false);
       expect(
-        result.errors?.some((err) => err.includes('must match pattern')),
+        result.errors?.some((err) => err.includes("must match pattern")),
       ).toBe(true);
     });
 
-    it('should fail with invalid version format', () => {
+    it("should fail with invalid version format", () => {
       const invalidConfig = {
         ...validConfig,
-        version: '1.0', // Missing patch version
+        version: "1.0", // Missing patch version
       };
 
       const result = validateCustomBotConfigPayload(invalidConfig);
       expect(result.valid).toBe(false);
       expect(
-        result.errors?.some((err) => err.includes('must match pattern')),
+        result.errors?.some((err) => err.includes("must match pattern")),
       ).toBe(true);
     });
 
-    it('should fail with invalid entrypoint file extension', () => {
-      const invalidConfig = {
-        ...validConfig,
-        entrypoints: {
-          bot: 'main.txt', // Invalid extension
-          backtest: 'backtest.py',
-        },
-      };
-
-      const result = validateCustomBotConfigPayload(invalidConfig);
-      expect(result.valid).toBe(false);
-      expect(
-        result.errors?.some((err) => err.includes('must match pattern')),
-      ).toBe(true);
-    });
-
-    it('should fail with invalid bot type', () => {
-      const invalidConfig = {
-        ...validConfig,
-        type: 'invalid-type' as any,
-      };
-
-      const result = validateCustomBotConfigPayload(invalidConfig);
-      expect(result.valid).toBe(false);
-      expect(
-        result.errors?.some((err) =>
-          err.includes('must be equal to one of the allowed values'),
-        ),
-      ).toBe(true);
-    });
-  });
-
-  describe('invalid configs - length validation', () => {
-    it('should fail with name too short', () => {
-      const invalidConfig = {
-        ...validConfig,
-        name: 'ab', // Too short
-      };
-
-      const result = validateCustomBotConfigPayload(invalidConfig);
-      expect(result.valid).toBe(false);
-      expect(
-        result.errors?.some((err) =>
-          err.includes('must NOT have fewer than 3 characters'),
-        ),
-      ).toBe(true);
-    });
-
-    it('should fail with name too long', () => {
-      const invalidConfig = {
-        ...validConfig,
-        name: 'a'.repeat(51), // Too long
-      };
-
-      const result = validateCustomBotConfigPayload(invalidConfig);
-      expect(result.valid).toBe(false);
-      expect(
-        result.errors?.some((err) =>
-          err.includes('must NOT have more than 50 characters'),
-        ),
-      ).toBe(true);
-    });
-
-    it('should fail with readme too short', () => {
-      const invalidConfig = {
-        ...validConfig,
-        readme: 'Too short', // Less than 50 characters
-      };
-
-      const result = validateCustomBotConfigPayload(invalidConfig);
-      expect(result.valid).toBe(false);
-      expect(
-        result.errors?.some((err) =>
-          err.includes('must NOT have fewer than 50 characters'),
-        ),
-      ).toBe(true);
-    });
-
-    it('should fail with readme too long', () => {
-      const invalidConfig = {
-        ...validConfig,
-        readme: 'a'.repeat(10001), // Too long
-      };
-
-      const result = validateCustomBotConfigPayload(invalidConfig);
-      expect(result.valid).toBe(false);
-      expect(
-        result.errors?.some((err) =>
-          err.includes('must NOT have more than 10000 characters'),
-        ),
-      ).toBe(true);
-    });
-
-    it('should fail with description too long', () => {
-      const invalidConfig = {
-        ...validConfig,
-        description: 'a'.repeat(501), // Too long
-      };
-
-      const result = validateCustomBotConfigPayload(invalidConfig);
-      expect(result.valid).toBe(false);
-      expect(
-        result.errors?.some((err) =>
-          err.includes('must NOT have more than 500 characters'),
-        ),
-      ).toBe(true);
-    });
-
-    it('should fail with author too long', () => {
-      const invalidConfig = {
-        ...validConfig,
-        author: 'a'.repeat(101), // Too long
-      };
-
-      const result = validateCustomBotConfigPayload(invalidConfig);
-      expect(result.valid).toBe(false);
-      expect(
-        result.errors?.some((err) =>
-          err.includes('must NOT have more than 100 characters'),
-        ),
-      ).toBe(true);
-    });
-  });
-
-  describe('invalid configs - array limits', () => {
-    it('should fail with too many categories', () => {
-      const invalidConfig = {
-        ...validConfig,
-        metadata: {
-          categories: Array(11).fill('category'), // Too many
-        },
-      };
-
-      const result = validateCustomBotConfigPayload(invalidConfig);
-      expect(result.valid).toBe(false);
-      expect(
-        result.errors?.some((err) =>
-          err.includes('must NOT have more than 10 items'),
-        ),
-      ).toBe(true);
-    });
-
-    it('should fail with too many tags', () => {
-      const invalidConfig = {
-        ...validConfig,
-        metadata: {
-          tags: Array(21).fill('tag'), // Too many
-        },
-      };
-
-      const result = validateCustomBotConfigPayload(invalidConfig);
-      expect(result.valid).toBe(false);
-      expect(
-        result.errors?.some((err) =>
-          err.includes('must NOT have more than 20 items'),
-        ),
-      ).toBe(true);
-    });
-
-    it('should fail with too many instruments', () => {
-      const invalidConfig = {
-        ...validConfig,
-        metadata: {
-          instruments: Array(21).fill('instrument'), // Too many
-        },
-      };
-
-      const result = validateCustomBotConfigPayload(invalidConfig);
-      expect(result.valid).toBe(false);
-      expect(
-        result.errors?.some((err) =>
-          err.includes('must NOT have more than 20 items'),
-        ),
-      ).toBe(true);
-    });
-
-    it('should fail with too many exchanges', () => {
-      const invalidConfig = {
-        ...validConfig,
-        metadata: {
-          exchanges: Array(21).fill('exchange'), // Too many
-        },
-      };
-
-      const result = validateCustomBotConfigPayload(invalidConfig);
-      expect(result.valid).toBe(false);
-      expect(
-        result.errors?.some((err) =>
-          err.includes('must NOT have more than 20 items'),
-        ),
-      ).toBe(true);
-    });
-  });
-
-  describe('schema validation edge cases', () => {
-    it('should fail with additional properties in config root', () => {
-      const invalidConfig = {
-        ...validConfig,
-        extraProperty: 'not allowed',
-      };
-
-      const result = validateCustomBotConfigPayload(invalidConfig);
-      expect(result.valid).toBe(false);
-      expect(
-        result.errors?.some((err) =>
-          err.includes('must NOT have additional properties'),
-        ),
-      ).toBe(true);
-    });
-
-    it('should fail with additional properties in entrypoints', () => {
+    it("should fail with invalid entrypoint file extension", () => {
       const invalidConfig = {
         ...validConfig,
         entrypoints: {
-          bot: 'main.py',
-          backtest: 'backtest.py',
-          extraEntry: 'extra.py', // Not allowed
+          bot: "main.txt", // Invalid extension
+          backtest: "backtest.py",
+        },
+      };
+
+      const result = validateCustomBotConfigPayload(invalidConfig);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors?.some((err) => err.includes("must match pattern")),
+      ).toBe(true);
+    });
+
+    it("should fail with invalid bot type", () => {
+      const invalidConfig = {
+        ...validConfig,
+        type: "invalid-type" as any,
+      };
+
+      const result = validateCustomBotConfigPayload(invalidConfig);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors?.some((err) =>
+          err.includes("must be equal to one of the allowed values"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("invalid configs - length validation", () => {
+    it("should fail with name too short", () => {
+      const invalidConfig = {
+        ...validConfig,
+        name: "ab", // Too short
+      };
+
+      const result = validateCustomBotConfigPayload(invalidConfig);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors?.some((err) =>
+          err.includes("must NOT have fewer than 3 characters"),
+        ),
+      ).toBe(true);
+    });
+
+    it("should fail with name too long", () => {
+      const invalidConfig = {
+        ...validConfig,
+        name: "a".repeat(51), // Too long
+      };
+
+      const result = validateCustomBotConfigPayload(invalidConfig);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors?.some((err) =>
+          err.includes("must NOT have more than 50 characters"),
+        ),
+      ).toBe(true);
+    });
+
+    it("should fail with readme too short", () => {
+      const invalidConfig = {
+        ...validConfig,
+        readme: "Too short", // Less than 50 characters
+      };
+
+      const result = validateCustomBotConfigPayload(invalidConfig);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors?.some((err) =>
+          err.includes("must NOT have fewer than 50 characters"),
+        ),
+      ).toBe(true);
+    });
+
+    it("should fail with readme too long", () => {
+      const invalidConfig = {
+        ...validConfig,
+        readme: "a".repeat(10001), // Too long
+      };
+
+      const result = validateCustomBotConfigPayload(invalidConfig);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors?.some((err) =>
+          err.includes("must NOT have more than 10000 characters"),
+        ),
+      ).toBe(true);
+    });
+
+    it("should fail with description too long", () => {
+      const invalidConfig = {
+        ...validConfig,
+        description: "a".repeat(501), // Too long
+      };
+
+      const result = validateCustomBotConfigPayload(invalidConfig);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors?.some((err) =>
+          err.includes("must NOT have more than 500 characters"),
+        ),
+      ).toBe(true);
+    });
+
+    it("should fail with author too long", () => {
+      const invalidConfig = {
+        ...validConfig,
+        author: "a".repeat(101), // Too long
+      };
+
+      const result = validateCustomBotConfigPayload(invalidConfig);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors?.some((err) =>
+          err.includes("must NOT have more than 100 characters"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("invalid configs - array limits", () => {
+    it("should fail with too many categories", () => {
+      const invalidConfig = {
+        ...validConfig,
+        metadata: {
+          categories: Array(11).fill("category"), // Too many
         },
       };
 
@@ -556,12 +469,99 @@ describe('Custom Bot Schema Validation', () => {
       expect(result.valid).toBe(false);
       expect(
         result.errors?.some((err) =>
-          err.includes('must NOT have additional properties'),
+          err.includes("must NOT have more than 10 items"),
         ),
       ).toBe(true);
     });
 
-    it('should fail with additional properties in schema', () => {
+    it("should fail with too many tags", () => {
+      const invalidConfig = {
+        ...validConfig,
+        metadata: {
+          tags: Array(21).fill("tag"), // Too many
+        },
+      };
+
+      const result = validateCustomBotConfigPayload(invalidConfig);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors?.some((err) =>
+          err.includes("must NOT have more than 20 items"),
+        ),
+      ).toBe(true);
+    });
+
+    it("should fail with too many instruments", () => {
+      const invalidConfig = {
+        ...validConfig,
+        metadata: {
+          instruments: Array(21).fill("instrument"), // Too many
+        },
+      };
+
+      const result = validateCustomBotConfigPayload(invalidConfig);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors?.some((err) =>
+          err.includes("must NOT have more than 20 items"),
+        ),
+      ).toBe(true);
+    });
+
+    it("should fail with too many exchanges", () => {
+      const invalidConfig = {
+        ...validConfig,
+        metadata: {
+          exchanges: Array(21).fill("exchange"), // Too many
+        },
+      };
+
+      const result = validateCustomBotConfigPayload(invalidConfig);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors?.some((err) =>
+          err.includes("must NOT have more than 20 items"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("schema validation edge cases", () => {
+    it("should fail with additional properties in config root", () => {
+      const invalidConfig = {
+        ...validConfig,
+        extraProperty: "not allowed",
+      };
+
+      const result = validateCustomBotConfigPayload(invalidConfig);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors?.some((err) =>
+          err.includes("must NOT have additional properties"),
+        ),
+      ).toBe(true);
+    });
+
+    it("should fail with additional properties in entrypoints", () => {
+      const invalidConfig = {
+        ...validConfig,
+        entrypoints: {
+          bot: "main.py",
+          backtest: "backtest.py",
+          extraEntry: "extra.py", // Not allowed
+        },
+      };
+
+      const result = validateCustomBotConfigPayload(invalidConfig);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors?.some((err) =>
+          err.includes("must NOT have additional properties"),
+        ),
+      ).toBe(true);
+    });
+
+    it("should fail with additional properties in schema", () => {
       const invalidConfig = {
         ...validConfig,
         schema: {
@@ -575,18 +575,18 @@ describe('Custom Bot Schema Validation', () => {
       expect(result.valid).toBe(false);
       expect(
         result.errors?.some((err) =>
-          err.includes('must NOT have additional properties'),
+          err.includes("must NOT have additional properties"),
         ),
       ).toBe(true);
     });
 
-    it('should allow additional properties in metadata', () => {
+    it("should allow additional properties in metadata", () => {
       const configWithExtraMetadata = {
         ...validConfig,
         metadata: {
-          categories: ['trading'],
-          customField: 'allowed',
-          anotherField: { nested: 'also allowed' },
+          categories: ["trading"],
+          customField: "allowed",
+          anotherField: { nested: "also allowed" },
         },
       };
 
@@ -594,33 +594,33 @@ describe('Custom Bot Schema Validation', () => {
       expect(result.valid).toBe(true);
     });
 
-    it('should validate missing optional fields', () => {
+    it("should validate missing optional fields", () => {
       const minimalConfig = {
-        name: 'minimal-bot',
-        version: '1.0.0',
-        type: 'scheduled',
-        runtime: 'python3.11',
+        name: "minimal-bot",
+        version: "1.0.0",
+        type: "scheduled",
+        runtime: "python3.11",
         entrypoints: {
-          bot: 'main.py',
-          backtest: 'backtest.py',
+          bot: "main.py",
+          backtest: "backtest.py",
         },
         schema: {
           bot: {},
           backtest: {},
         },
         readme:
-          'This is a minimal but valid readme that meets the length requirement for validation.',
+          "This is a minimal but valid readme that meets the length requirement for validation.",
       };
 
       const result = validateCustomBotConfigPayload(minimalConfig);
       expect(result.valid).toBe(true);
     });
 
-    it('should validate with missing optional backtest entrypoint', () => {
+    it("should validate with missing optional backtest entrypoint", () => {
       const configWithoutBacktest = {
         ...validConfig,
         entrypoints: {
-          bot: 'main.py',
+          bot: "main.py",
           // Missing backtest - should be allowed now
         },
         schema: {
@@ -633,11 +633,11 @@ describe('Custom Bot Schema Validation', () => {
       expect(result.valid).toBe(true);
     });
 
-    it('should validate with missing optional backtest schema', () => {
+    it("should validate with missing optional backtest schema", () => {
       const configWithoutBacktestSchema = {
         ...validConfig,
         entrypoints: {
-          bot: 'main.py',
+          bot: "main.py",
           // No backtest entrypoint
         },
         schema: {
@@ -652,12 +652,12 @@ describe('Custom Bot Schema Validation', () => {
       expect(result.valid).toBe(true);
     });
 
-    it('should fail if backtest entrypoint is provided without backtest schema', () => {
+    it("should fail if backtest entrypoint is provided without backtest schema", () => {
       const configWithBacktestButNoSchema = {
         ...validConfig,
         entrypoints: {
-          bot: 'main.py',
-          backtest: 'backtest.py', // Has backtest entrypoint
+          bot: "main.py",
+          backtest: "backtest.py", // Has backtest entrypoint
         },
         schema: {
           bot: {},
@@ -676,7 +676,7 @@ describe('Custom Bot Schema Validation', () => {
       ).toBe(true);
     });
 
-    it('should validate with empty schemas', () => {
+    it("should validate with empty schemas", () => {
       const configWithEmptySchemas = {
         ...validConfig,
         schema: {
@@ -689,38 +689,38 @@ describe('Custom Bot Schema Validation', () => {
       expect(result.valid).toBe(true);
     });
 
-    it('should validate with complex schemas', () => {
+    it("should validate with complex schemas", () => {
       const configWithComplexSchemas = {
         ...validConfig,
         schema: {
           bot: {
-            type: 'object',
+            type: "object",
             properties: {
-              apiKey: { type: 'string', minLength: 1 },
+              apiKey: { type: "string", minLength: 1 },
               exchanges: {
-                type: 'array',
-                items: { type: 'string' },
+                type: "array",
+                items: { type: "string" },
                 minItems: 1,
               },
               riskSettings: {
-                type: 'object',
+                type: "object",
                 properties: {
-                  maxLoss: { type: 'number', minimum: 0 },
-                  stopLoss: { type: 'boolean' },
+                  maxLoss: { type: "number", minimum: 0 },
+                  stopLoss: { type: "boolean" },
                 },
               },
             },
-            required: ['apiKey'],
+            required: ["apiKey"],
           },
           backtest: {
-            type: 'object',
+            type: "object",
             properties: {
-              symbol: { type: 'string' },
-              timeframe: { type: 'string', enum: ['1m', '5m', '1h', '1d'] },
-              startDate: { type: 'string', format: 'date' },
-              endDate: { type: 'string', format: 'date' },
+              symbol: { type: "string" },
+              timeframe: { type: "string", enum: ["1m", "5m", "1h", "1d"] },
+              startDate: { type: "string", format: "date" },
+              endDate: { type: "string", format: "date" },
             },
-            required: ['symbol', 'timeframe'],
+            required: ["symbol", "timeframe"],
           },
         },
       };
@@ -730,43 +730,43 @@ describe('Custom Bot Schema Validation', () => {
     });
   });
 
-  describe('real-world validation scenarios', () => {
-    it('should validate a realistic trading bot config', () => {
+  describe("real-world validation scenarios", () => {
+    it("should validate a realistic trading bot config", () => {
       const tradingBotConfig = {
-        name: 'arbitrage-scanner',
+        name: "arbitrage-scanner",
         description:
-          'Multi-exchange arbitrage opportunity scanner with automated execution',
-        version: '2.1.3',
-        author: 'Trading Team',
-        type: 'realtime' as const,
-        runtime: 'python3.11' as const,
+          "Multi-exchange arbitrage opportunity scanner with automated execution",
+        version: "2.1.3",
+        author: "Trading Team",
+        type: "realtime" as const,
+        runtime: "python3.11" as const,
         entrypoints: {
-          bot: 'src/arbitrage_bot.py',
-          backtest: 'tests/backtest_arbitrage.py',
+          bot: "src/arbitrage_bot.py",
+          backtest: "tests/backtest_arbitrage.py",
         },
         schema: {
           bot: {
-            type: 'object',
+            type: "object",
             properties: {
-              exchanges: { type: 'array', items: { type: 'string' } },
-              minProfitThreshold: { type: 'number', minimum: 0.001 },
-              maxTradeAmount: { type: 'number', minimum: 0 },
+              exchanges: { type: "array", items: { type: "string" } },
+              minProfitThreshold: { type: "number", minimum: 0.001 },
+              maxTradeAmount: { type: "number", minimum: 0 },
               apiCredentials: {
-                type: 'object',
+                type: "object",
                 properties: {
-                  binance: { type: 'object' },
-                  coinbase: { type: 'object' },
+                  binance: { type: "object" },
+                  coinbase: { type: "object" },
                 },
               },
             },
-            required: ['exchanges', 'minProfitThreshold'],
+            required: ["exchanges", "minProfitThreshold"],
           },
           backtest: {
-            type: 'object',
+            type: "object",
             properties: {
-              historicalDataSource: { type: 'string' },
-              testPeriod: { type: 'string' },
-              initialBalance: { type: 'number', minimum: 0 },
+              historicalDataSource: { type: "string" },
+              testPeriod: { type: "string" },
+              initialBalance: { type: "number", minimum: 0 },
             },
           },
         },
@@ -783,11 +783,11 @@ This bot scans multiple cryptocurrency exchanges for arbitrage opportunities and
 ## Configuration
 The bot requires API credentials for supported exchanges and allows customization of profit thresholds and trade limits.`,
         metadata: {
-          categories: ['arbitrage', 'multi-exchange'],
-          instruments: ['BTC', 'ETH', 'USDT'],
-          exchanges: ['binance', 'coinbase', 'kraken'],
-          tags: ['automated', 'real-time', 'profitable'],
-          license: 'MIT',
+          categories: ["arbitrage", "multi-exchange"],
+          instruments: ["BTC", "ETH", "USDT"],
+          exchanges: ["binance", "coinbase", "kraken"],
+          tags: ["automated", "real-time", "profitable"],
+          license: "MIT",
           minimumBalance: 1000,
         },
       };
@@ -796,43 +796,43 @@ The bot requires API credentials for supported exchanges and allows customizatio
       expect(result.valid).toBe(true);
     });
 
-    it('should validate a scheduled analytics bot config', () => {
+    it("should validate a scheduled analytics bot config", () => {
       const analyticsBotConfig = {
-        name: 'market-analytics',
-        description: 'Daily market analysis and reporting bot',
-        version: '1.0.0',
-        author: 'Analytics Team',
-        type: 'scheduled' as const,
-        runtime: 'python3.11' as const,
+        name: "market-analytics",
+        description: "Daily market analysis and reporting bot",
+        version: "1.0.0",
+        author: "Analytics Team",
+        type: "scheduled" as const,
+        runtime: "python3.11" as const,
         entrypoints: {
-          bot: 'analytics/daily_report.py',
-          backtest: 'analytics/historical_analysis.py',
+          bot: "analytics/daily_report.py",
+          backtest: "analytics/historical_analysis.py",
         },
         schema: {
           bot: {
-            type: 'object',
+            type: "object",
             properties: {
-              reportEmail: { type: 'string', format: 'email' },
-              markets: { type: 'array', items: { type: 'string' } },
+              reportEmail: { type: "string", format: "email" },
+              markets: { type: "array", items: { type: "string" } },
               analysisDepth: {
-                type: 'string',
-                enum: ['basic', 'detailed', 'comprehensive'],
+                type: "string",
+                enum: ["basic", "detailed", "comprehensive"],
               },
             },
           },
           backtest: {
-            type: 'object',
+            type: "object",
             properties: {
-              analysisWindow: { type: 'string' },
-              includeCorrelations: { type: 'boolean' },
+              analysisWindow: { type: "string" },
+              includeCorrelations: { type: "boolean" },
             },
           },
         },
         readme:
-          'Market analytics bot that generates daily reports on cryptocurrency market trends and provides insights for trading decisions. Supports email delivery and customizable analysis depth.',
+          "Market analytics bot that generates daily reports on cryptocurrency market trends and provides insights for trading decisions. Supports email delivery and customizable analysis depth.",
         metadata: {
-          categories: ['analytics', 'reporting'],
-          tags: ['daily', 'email', 'trends'],
+          categories: ["analytics", "reporting"],
+          tags: ["daily", "email", "trends"],
         },
       };
 
@@ -840,36 +840,36 @@ The bot requires API credentials for supported exchanges and allows customizatio
       expect(result.valid).toBe(true);
     });
 
-    it('should validate a bot without backtest functionality', () => {
+    it("should validate a bot without backtest functionality", () => {
       const nonBacktestBotConfig = {
-        name: 'notification-bot',
-        description: 'Real-time price alert and notification bot',
-        version: '1.0.0',
-        author: 'Notification Team',
-        type: 'realtime' as const,
-        runtime: 'nodejs20' as const,
+        name: "notification-bot",
+        description: "Real-time price alert and notification bot",
+        version: "1.0.0",
+        author: "Notification Team",
+        type: "realtime" as const,
+        runtime: "nodejs20" as const,
         entrypoints: {
-          bot: 'src/notification_bot.js',
+          bot: "src/notification_bot.js",
           // No backtest entrypoint - this bot doesn't support backtesting
         },
         schema: {
           bot: {
-            type: 'object',
+            type: "object",
             properties: {
-              webhookUrl: { type: 'string', format: 'uri' },
+              webhookUrl: { type: "string", format: "uri" },
               priceThresholds: {
-                type: 'object',
+                type: "object",
                 properties: {
-                  BTC: { type: 'number', minimum: 0 },
-                  ETH: { type: 'number', minimum: 0 },
+                  BTC: { type: "number", minimum: 0 },
+                  ETH: { type: "number", minimum: 0 },
                 },
               },
               notificationChannels: {
-                type: 'array',
-                items: { type: 'string', enum: ['email', 'slack', 'webhook'] },
+                type: "array",
+                items: { type: "string", enum: ["email", "slack", "webhook"] },
               },
             },
-            required: ['webhookUrl'],
+            required: ["webhookUrl"],
           },
           // No backtest schema - this bot doesn't support backtesting
         },
@@ -886,8 +886,8 @@ This bot monitors cryptocurrency prices and sends notifications when certain thr
 ## Note
 This bot does not support backtesting as it's designed for real-time notifications only.`,
         metadata: {
-          categories: ['notification', 'alerts'],
-          tags: ['real-time', 'webhook', 'alerts'],
+          categories: ["notification", "alerts"],
+          tags: ["real-time", "webhook", "alerts"],
         },
       };
 

--- a/api/src/custom-bot/__tests__/storage.service.spec.ts
+++ b/api/src/custom-bot/__tests__/storage.service.spec.ts
@@ -1,15 +1,15 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { ConfigService } from '@nestjs/config';
-import { StorageService } from '../storage.service';
-import { Ok, Failure } from '@/common/result';
-import * as Minio from 'minio';
-import { EventEmitter } from 'events';
-import AdmZip from 'adm-zip';
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigService } from "@nestjs/config";
+import { StorageService } from "../storage.service";
+import { Ok, Failure } from "@/common/result";
+import * as Minio from "minio";
+import { EventEmitter } from "events";
+import AdmZip from "adm-zip";
 
 // Mock the minio module
-jest.mock('minio');
+jest.mock("minio");
 
-describe('StorageService', () => {
+describe("StorageService", () => {
   let service: StorageService;
   let configService: jest.Mocked<ConfigService>;
   let mockMinioClient: jest.Mocked<Minio.Client>;
@@ -19,9 +19,9 @@ describe('StorageService', () => {
     const stream = new EventEmitter();
     setTimeout(() => {
       if (content) {
-        stream.emit('data', content);
+        stream.emit("data", content);
       }
-      stream.emit('end');
+      stream.emit("end");
     }, 0);
     return stream;
   };
@@ -30,8 +30,8 @@ describe('StorageService', () => {
   const createSampleZipBuffer = () => {
     // Create a real ZIP file using AdmZip for testing
     const zip = new AdmZip();
-    zip.addFile('main.js', Buffer.from('console.log("hello world");'));
-    zip.addFile('config.yaml', Buffer.from('name: test-bot\nversion: 1.0.0'));
+    zip.addFile("main.js", Buffer.from('console.log("hello world");'));
+    zip.addFile("config.yaml", Buffer.from("name: test-bot\nversion: 1.0.0"));
     return zip.toBuffer();
   };
 
@@ -58,11 +58,11 @@ describe('StorageService', () => {
           useValue: {
             get: jest.fn((key: string) => {
               const config = {
-                MINIO_ENDPOINT: 'localhost:9000',
-                MINIO_USE_SSL: 'false',
-                MINIO_ACCESS_KEY: 'testkey',
-                MINIO_SECRET_KEY: 'testsecret',
-                CUSTOM_BOTS_BUCKET: 'custom-bots',
+                MINIO_ENDPOINT: "localhost:9000",
+                MINIO_USE_SSL: "false",
+                MINIO_ACCESS_KEY: "testkey",
+                MINIO_SECRET_KEY: "testsecret",
+                CUSTOM_BOTS_BUCKET: "custom-bots",
               };
               return config[key];
             }),
@@ -79,35 +79,35 @@ describe('StorageService', () => {
     jest.clearAllMocks();
   });
 
-  describe('constructor', () => {
-    it('should initialize MinIO client with correct configuration', () => {
+  describe("constructor", () => {
+    it("should initialize MinIO client with correct configuration", () => {
       expect(Minio.Client).toHaveBeenCalledWith({
-        endPoint: 'localhost',
+        endPoint: "localhost",
         port: 9000,
         useSSL: false,
-        accessKey: 'testkey',
-        secretKey: 'testsecret',
+        accessKey: "testkey",
+        secretKey: "testsecret",
       });
     });
 
-    it('should set the correct bucket name', () => {
-      expect(configService.get).toHaveBeenCalledWith('CUSTOM_BOTS_BUCKET');
+    it("should set the correct bucket name", () => {
+      expect(configService.get).toHaveBeenCalledWith("CUSTOM_BOTS_BUCKET");
     });
   });
 
-  describe('ensureBucket', () => {
-    it('should create bucket if it does not exist', async () => {
+  describe("ensureBucket", () => {
+    it("should create bucket if it does not exist", async () => {
       mockMinioClient.bucketExists.mockResolvedValue(false);
       mockMinioClient.makeBucket.mockResolvedValue(undefined);
 
       const result = await service.ensureBucket();
 
       expect(result.success).toBe(true);
-      expect(mockMinioClient.bucketExists).toHaveBeenCalledWith('custom-bots');
-      expect(mockMinioClient.makeBucket).toHaveBeenCalledWith('custom-bots');
+      expect(mockMinioClient.bucketExists).toHaveBeenCalledWith("custom-bots");
+      expect(mockMinioClient.makeBucket).toHaveBeenCalledWith("custom-bots");
     });
 
-    it('should not create bucket if it already exists', async () => {
+    it("should not create bucket if it already exists", async () => {
       // Clear any previous calls from constructor
       jest.clearAllMocks();
       mockMinioClient.bucketExists.mockResolvedValue(true);
@@ -115,253 +115,280 @@ describe('StorageService', () => {
       const result = await service.ensureBucket();
 
       expect(result.success).toBe(true);
-      expect(mockMinioClient.bucketExists).toHaveBeenCalledWith('custom-bots');
+      expect(mockMinioClient.bucketExists).toHaveBeenCalledWith("custom-bots");
       expect(mockMinioClient.makeBucket).not.toHaveBeenCalled();
     });
 
-    it('should handle bucket creation errors', async () => {
+    it("should handle bucket creation errors", async () => {
       mockMinioClient.bucketExists.mockResolvedValue(false);
-      mockMinioClient.makeBucket.mockRejectedValue(new Error('Bucket creation failed'));
+      mockMinioClient.makeBucket.mockRejectedValue(
+        new Error("Bucket creation failed"),
+      );
 
       const result = await service.ensureBucket();
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Bucket creation failed');
+      expect(result.error).toContain("Bucket creation failed");
     });
   });
 
-  describe('fileExists', () => {
-    it('should return true if file exists', async () => {
+  describe("fileExists", () => {
+    it("should return true if file exists", async () => {
       mockMinioClient.statObject.mockResolvedValue({
         size: 1024,
         lastModified: new Date(),
       } as any);
 
-      const result = await service.fileExists('test/file.zip');
+      const result = await service.fileExists("test/file.zip");
 
       expect(result.success).toBe(true);
       expect(result.data).toBe(true);
-      expect(mockMinioClient.statObject).toHaveBeenCalledWith('custom-bots', 'test/file.zip');
+      expect(mockMinioClient.statObject).toHaveBeenCalledWith(
+        "custom-bots",
+        "test/file.zip",
+      );
     });
 
-    it('should return false if file does not exist', async () => {
-      const error = new Error('The specified key does not exist.') as any;
-      error.code = 'NoSuchKey';
+    it("should return false if file does not exist", async () => {
+      const error = new Error("The specified key does not exist.") as any;
+      error.code = "NoSuchKey";
       mockMinioClient.statObject.mockRejectedValue(error);
 
-      const result = await service.fileExists('test/nonexistent.zip');
+      const result = await service.fileExists("test/nonexistent.zip");
 
       expect(result.success).toBe(true);
       expect(result.data).toBe(false);
     });
 
-    it('should handle other errors', async () => {
-      mockMinioClient.statObject.mockRejectedValue(new Error('Network error'));
+    it("should handle other errors", async () => {
+      mockMinioClient.statObject.mockRejectedValue(new Error("Network error"));
 
-      const result = await service.fileExists('test/file.zip');
+      const result = await service.fileExists("test/file.zip");
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Network error');
+      expect(result.error).toContain("Network error");
     });
   });
 
-  describe('validateZipStructure', () => {
-    it('should validate ZIP structure successfully', async () => {
+  describe("validateZipStructure", () => {
+    it("should validate ZIP structure successfully", async () => {
       const zipBuffer = createSampleZipBuffer();
       const mockStream = {
         [Symbol.asyncIterator]: async function* () {
           yield zipBuffer;
-        }
+        },
       };
       mockMinioClient.getObject.mockResolvedValue(mockStream as any);
 
-      const result = await service.validateZipStructure('test/bot.zip', ['main.js']);
+      const result = await service.validateZipStructure("test/bot.zip", [
+        "main.js",
+      ]);
 
       expect(result.success).toBe(true);
-      expect(mockMinioClient.getObject).toHaveBeenCalledWith('custom-bots', 'test/bot.zip');
+      expect(mockMinioClient.getObject).toHaveBeenCalledWith(
+        "custom-bots",
+        "test/bot.zip",
+      );
     });
 
-    it('should fail if required files are missing', async () => {
+    it("should fail if required files are missing", async () => {
       const zipBuffer = createSampleZipBuffer();
       const mockStream = {
         [Symbol.asyncIterator]: async function* () {
           yield zipBuffer;
-        }
+        },
       };
       mockMinioClient.getObject.mockResolvedValue(mockStream as any);
 
-      const result = await service.validateZipStructure('test/bot.zip', ['main.js', 'missing-file.js']);
+      const result = await service.validateZipStructure("test/bot.zip", [
+        "main.js",
+        "missing-file.js",
+      ]);
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Required file missing');
+      expect(result.error).toContain("Required file missing");
     });
 
-    it('should handle corrupted ZIP files', async () => {
-      const corruptBuffer = Buffer.from('not a zip file');
-      mockMinioClient.getObject.mockResolvedValue(createMockStream(corruptBuffer) as any);
+    it("should handle corrupted ZIP files", async () => {
+      const corruptBuffer = Buffer.from("not a zip file");
+      mockMinioClient.getObject.mockResolvedValue(
+        createMockStream(corruptBuffer) as any,
+      );
 
-      const result = await service.validateZipStructure('test/corrupt.zip', ['main.js']);
+      const result = await service.validateZipStructure("test/corrupt.zip", [
+        "main.js",
+      ]);
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Error validating ZIP structure');
+      expect(result.error).toContain("Error validating ZIP structure");
     });
   });
 
-  describe('uploadBotFile', () => {
-    it('should upload bot file successfully', async () => {
+  describe("uploadBotFile", () => {
+    it("should upload bot file successfully", async () => {
       const fileBuffer = createSampleZipBuffer();
       mockMinioClient.putObject.mockResolvedValue({
-        etag: 'test-etag',
-        versionId: 'test-version',
+        etag: "test-etag",
+        versionId: "test-version",
       } as any);
 
       const result = await service.uploadBotFile(
         fileBuffer,
-        '1.0.0',
-        'user123',
-        'test-bot'
+        "1.0.0",
+        "user123",
+        "test-bot",
       );
 
       expect(result.success).toBe(true);
-      expect(result.data).toBe('user123/test-bot/1.0.0');
+      expect(result.data).toBe("user123/test-bot/1.0.0");
       expect(mockMinioClient.putObject).toHaveBeenCalledWith(
-        'custom-bots',
-        'user123/test-bot/1.0.0',
+        "custom-bots",
+        "user123/test-bot/1.0.0",
         fileBuffer,
         fileBuffer.length,
         {
-          'Content-Type': 'application/zip',
-          'X-Upload-Source': 'custom-bot-api',
-          'X-Upload-Time': expect.any(String),
-        }
+          "Content-Type": "application/zip",
+          "X-Upload-Source": "custom-bot-api",
+          "X-Upload-Time": expect.any(String),
+        },
       );
     });
 
-    it('should handle upload errors', async () => {
+    it("should handle upload errors", async () => {
       const fileBuffer = createSampleZipBuffer();
-      mockMinioClient.putObject.mockRejectedValue(new Error('Upload failed'));
+      mockMinioClient.putObject.mockRejectedValue(new Error("Upload failed"));
 
       const result = await service.uploadBotFile(
         fileBuffer,
-        '1.0.0',
-        'user123',
-        'test-bot'
+        "1.0.0",
+        "user123",
+        "test-bot",
       );
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Upload failed');
+      expect(result.error).toContain("Upload failed");
     });
   });
 
-  describe('generateSignedUploadUrl', () => {
-    it('should generate signed upload URL successfully', async () => {
-      const mockUrl = 'https://minio.test/upload-url';
+  describe("generateSignedUploadUrl", () => {
+    it("should generate signed upload URL successfully", async () => {
+      const mockUrl = "https://minio.test/upload-url";
       mockMinioClient.presignedPutObject.mockResolvedValue(mockUrl);
 
       const result = await service.generateSignedUploadUrl(
-        'user123',
-        'test-bot',
-        '1.0.0'
+        "user123",
+        "test-bot",
+        "1.0.0",
       );
 
       expect(result.success).toBe(true);
       expect(result.data.uploadUrl).toBe(mockUrl);
-      expect(result.data.filePath).toBe('user123/test-bot/1.0.0');
+      expect(result.data.filePath).toBe("user123/test-bot/1.0.0");
       expect(result.data.expiresAt).toBeDefined();
       expect(mockMinioClient.presignedPutObject).toHaveBeenCalledWith(
-        'custom-bots',
-        'user123/test-bot/1.0.0',
-        24 * 60 * 60 // 24 hours
+        "custom-bots",
+        "user123/test-bot/1.0.0",
+        24 * 60 * 60, // 24 hours
       );
     });
 
-    it('should handle URL generation errors', async () => {
-      mockMinioClient.presignedPutObject.mockRejectedValue(new Error('URL generation failed'));
+    it("should handle URL generation errors", async () => {
+      mockMinioClient.presignedPutObject.mockRejectedValue(
+        new Error("URL generation failed"),
+      );
 
       const result = await service.generateSignedUploadUrl(
-        'user123',
-        'test-bot',
-        '1.0.0'
+        "user123",
+        "test-bot",
+        "1.0.0",
       );
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('URL generation failed');
+      expect(result.error).toContain("URL generation failed");
     });
   });
 
-  describe('downloadFile', () => {
-    it('should download file successfully', async () => {
+  describe("downloadFile", () => {
+    it("should download file successfully", async () => {
       const fileBuffer = createSampleZipBuffer();
       const mockStream = {
         [Symbol.asyncIterator]: async function* () {
           yield fileBuffer;
-        }
+        },
       };
       mockMinioClient.getObject.mockResolvedValue(mockStream as any);
 
-      const result = await service.downloadFile('user123/test-bot/1.0.0');
+      const result = await service.downloadFile("user123/test-bot/1.0.0");
 
       expect(result.success).toBe(true);
       expect(Buffer.isBuffer(result.data)).toBe(true);
-      expect(mockMinioClient.getObject).toHaveBeenCalledWith('custom-bots', 'user123/test-bot/1.0.0');
+      expect(mockMinioClient.getObject).toHaveBeenCalledWith(
+        "custom-bots",
+        "user123/test-bot/1.0.0",
+      );
     });
 
-    it('should handle download errors', async () => {
-      mockMinioClient.getObject.mockRejectedValue(new Error('File not found'));
+    it("should handle download errors", async () => {
+      mockMinioClient.getObject.mockRejectedValue(new Error("File not found"));
 
-      const result = await service.downloadFile('user123/nonexistent.zip');
+      const result = await service.downloadFile("user123/nonexistent.zip");
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('File not found');
+      expect(result.error).toContain("File not found");
     });
   });
 
-  describe('deleteFile', () => {
-    it('should delete file successfully', async () => {
+  describe("deleteFile", () => {
+    it("should delete file successfully", async () => {
       mockMinioClient.removeObject.mockResolvedValue(undefined);
 
-      const result = await service.deleteFile('user123/test-bot/1.0.0');
+      const result = await service.deleteFile("user123/test-bot/1.0.0");
 
       expect(result.success).toBe(true);
-      expect(mockMinioClient.removeObject).toHaveBeenCalledWith('custom-bots', 'user123/test-bot/1.0.0');
+      expect(mockMinioClient.removeObject).toHaveBeenCalledWith(
+        "custom-bots",
+        "user123/test-bot/1.0.0",
+      );
     });
 
-    it('should handle deletion errors', async () => {
-      mockMinioClient.removeObject.mockRejectedValue(new Error('Deletion failed'));
+    it("should handle deletion errors", async () => {
+      mockMinioClient.removeObject.mockRejectedValue(
+        new Error("Deletion failed"),
+      );
 
-      const result = await service.deleteFile('user123/test-bot/1.0.0');
+      const result = await service.deleteFile("user123/test-bot/1.0.0");
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Deletion failed');
+      expect(result.error).toContain("Deletion failed");
     });
   });
 
-  describe('getFileInfo', () => {
-    it('should get file info successfully', async () => {
+  describe("getFileInfo", () => {
+    it("should get file info successfully", async () => {
       const mockStat = {
         size: 1024,
-        lastModified: new Date('2025-01-01'),
-        etag: 'test-etag',
+        lastModified: new Date("2025-01-01"),
+        etag: "test-etag",
       };
       mockMinioClient.statObject.mockResolvedValue(mockStat as any);
 
-      const result = await service.getFileInfo('user123/test-bot/1.0.0');
+      const result = await service.getFileInfo("user123/test-bot/1.0.0");
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual({
         size: 1024,
-        lastModified: new Date('2025-01-01'),
-        etag: 'test-etag',
+        lastModified: new Date("2025-01-01"),
+        etag: "test-etag",
       });
     });
 
-    it('should handle file info errors', async () => {
-      mockMinioClient.statObject.mockRejectedValue(new Error('File not found'));
+    it("should handle file info errors", async () => {
+      mockMinioClient.statObject.mockRejectedValue(new Error("File not found"));
 
-      const result = await service.getFileInfo('user123/nonexistent.zip');
+      const result = await service.getFileInfo("user123/nonexistent.zip");
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('File not found');
+      expect(result.error).toContain("File not found");
     });
   });
 });

--- a/api/src/custom-bot/custom-bot-events.service.ts
+++ b/api/src/custom-bot/custom-bot-events.service.ts
@@ -1,7 +1,7 @@
-import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
-import { NatsService } from '@/nats/nats.service';
-import { CustomBotRepository } from './custom-bot.repository';
-import { StringCodec } from 'nats';
+import { Injectable, OnModuleInit, OnModuleDestroy } from "@nestjs/common";
+import { NatsService } from "@/nats/nats.service";
+import { CustomBotRepository } from "./custom-bot.repository";
+import { StringCodec, consumerOpts } from "nats";
 
 interface CustomBotAnalysisEvent {
   type: string;
@@ -36,7 +36,7 @@ export class CustomBotEventsService implements OnModuleInit, OnModuleDestroy {
       try {
         await sub.unsubscribe();
       } catch (error) {
-        console.error('Error unsubscribing from NATS:', error);
+        console.error("Error unsubscribing from NATS:", error);
       }
     }
   }
@@ -46,43 +46,47 @@ export class CustomBotEventsService implements OnModuleInit, OnModuleDestroy {
       // Wait for NATS connection to be established
       let retries = 0;
       const maxRetries = 10;
-      
+
       while (retries < maxRetries && !(await this.natsService.isConnected())) {
-        console.log(`⏳ Waiting for NATS connection... (${retries + 1}/${maxRetries})`);
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        console.log(
+          `⏳ Waiting for NATS connection... (${retries + 1}/${maxRetries})`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 1000));
         retries++;
       }
 
       if (!(await this.natsService.isConnected())) {
-        console.error('❌ Failed to establish NATS connection for event listeners');
+        console.error(
+          "❌ Failed to establish NATS connection for event listeners",
+        );
         return;
       }
 
-      console.log('📡 Setting up custom bot event listeners...');
+      console.log("📡 Setting up custom bot event listeners...");
 
       // Listen for analysis completion events
       await this.subscribeToAnalysisEvents();
 
-      console.log('✅ Custom bot event listeners setup complete');
-
+      console.log("✅ Custom bot event listeners setup complete");
     } catch (error) {
-      console.error('❌ Failed to setup custom bot event listeners:', error);
+      console.error("❌ Failed to setup custom bot event listeners:", error);
     }
   }
 
   private async subscribeToAnalysisEvents() {
     const connection = (this.natsService as any).connection;
     if (!connection) {
-      throw new Error('NATS connection not available');
+      throw new Error("NATS connection not available");
     }
 
     const jetStream = connection.jetstream();
 
     // Subscribe to all custom-bot analysis events
-    const subscription = await jetStream.subscribe('custom-bot.approved', {
-      queue: 'custom-bot-api-handlers',
-      manual_ack: true,
-    });
+    const opts = consumerOpts();
+    opts.deliverTo("custom-bot-approved-deliver");
+    opts.manualAck();
+    opts.queue("custom-bot-api-handlers");
+    const subscription = await jetStream.subscribe("custom-bot.approved", opts);
 
     this.subscriptions.push(subscription);
 
@@ -90,80 +94,106 @@ export class CustomBotEventsService implements OnModuleInit, OnModuleDestroy {
     (async () => {
       for await (const msg of subscription) {
         try {
-          const eventData: CustomBotAnalysisEvent = JSON.parse(this.sc.decode(msg.data));
+          const eventData: CustomBotAnalysisEvent = JSON.parse(
+            this.sc.decode(msg.data),
+          );
           await this.handleAnalysisEvent(eventData);
           msg.ack();
         } catch (error) {
-          console.error('Error processing custom-bot.approved event:', error);
+          console.error("Error processing custom-bot.approved event:", error);
           msg.nak();
         }
       }
     })();
 
     // Subscribe to declined events
-    const declinedSub = await jetStream.subscribe('custom-bot.declined', {
-      queue: 'custom-bot-api-handlers',
-      manual_ack: true,
-    });
+    const declinedOpts = consumerOpts();
+    declinedOpts.deliverTo("custom-bot-declined-deliver");
+    declinedOpts.manualAck();
+    declinedOpts.queue("custom-bot-api-handlers");
+    const declinedSub = await jetStream.subscribe(
+      "custom-bot.declined",
+      declinedOpts,
+    );
 
     this.subscriptions.push(declinedSub);
 
     (async () => {
       for await (const msg of declinedSub) {
         try {
-          const eventData: CustomBotAnalysisEvent = JSON.parse(this.sc.decode(msg.data));
+          const eventData: CustomBotAnalysisEvent = JSON.parse(
+            this.sc.decode(msg.data),
+          );
           await this.handleAnalysisEvent(eventData);
           msg.ack();
         } catch (error) {
-          console.error('Error processing custom-bot.declined event:', error);
+          console.error("Error processing custom-bot.declined event:", error);
           msg.nak();
         }
       }
     })();
 
     // Subscribe to awaiting review events
-    const reviewSub = await jetStream.subscribe('custom-bot.awaiting-human-review', {
-      queue: 'custom-bot-api-handlers',
-      manual_ack: true,
-    });
+    const reviewOpts = consumerOpts();
+    reviewOpts.deliverTo("custom-bot-review-deliver");
+    reviewOpts.manualAck();
+    reviewOpts.queue("custom-bot-api-handlers");
+    const reviewSub = await jetStream.subscribe(
+      "custom-bot.awaiting-human-review",
+      reviewOpts,
+    );
 
     this.subscriptions.push(reviewSub);
 
     (async () => {
       for await (const msg of reviewSub) {
         try {
-          const eventData: CustomBotAnalysisEvent = JSON.parse(this.sc.decode(msg.data));
+          const eventData: CustomBotAnalysisEvent = JSON.parse(
+            this.sc.decode(msg.data),
+          );
           await this.handleAnalysisEvent(eventData);
           msg.ack();
         } catch (error) {
-          console.error('Error processing custom-bot.awaiting-human-review event:', error);
+          console.error(
+            "Error processing custom-bot.awaiting-human-review event:",
+            error,
+          );
           msg.nak();
         }
       }
     })();
 
     // Subscribe to analysis failed events
-    const failedSub = await jetStream.subscribe('custom-bot.analysis-failed', {
-      queue: 'custom-bot-api-handlers',
-      manual_ack: true,
-    });
+    const failedOpts = consumerOpts();
+    failedOpts.deliverTo("custom-bot-failed-deliver");
+    failedOpts.manualAck();
+    failedOpts.queue("custom-bot-api-handlers");
+    const failedSub = await jetStream.subscribe(
+      "custom-bot.analysis-failed",
+      failedOpts,
+    );
 
     this.subscriptions.push(failedSub);
 
     (async () => {
       for await (const msg of failedSub) {
         try {
-          const eventData: CustomBotAnalysisEvent = JSON.parse(this.sc.decode(msg.data));
+          const eventData: CustomBotAnalysisEvent = JSON.parse(
+            this.sc.decode(msg.data),
+          );
           await this.handleAnalysisFailedEvent(eventData);
           msg.ack();
         } catch (error) {
-          console.error('Error processing custom-bot.analysis-failed event:', error);
+          console.error(
+            "Error processing custom-bot.analysis-failed event:",
+            error,
+          );
           msg.nak();
         }
       }
     })();
 
-    console.log('📨 Subscribed to custom bot analysis events');
+    console.log("📨 Subscribed to custom bot analysis events");
   }
 
   private async handleAnalysisEvent(event: CustomBotAnalysisEvent) {
@@ -173,14 +203,14 @@ export class CustomBotEventsService implements OnModuleInit, OnModuleDestroy {
       // Map event type to status
       let status: string;
       switch (event.type) {
-        case 'custom-bot.approved':
-          status = 'approved';
+        case "custom-bot.approved":
+          status = "approved";
           break;
-        case 'custom-bot.declined':
-          status = 'declined';
+        case "custom-bot.declined":
+          status = "declined";
           break;
-        case 'custom-bot.awaiting-human-review':
-          status = 'awaiting_human_review';
+        case "custom-bot.awaiting-human-review":
+          status = "awaiting_human_review";
           break;
         default:
           console.warn(`⚠️ Unknown event type: ${event.type}`);
@@ -194,7 +224,10 @@ export class CustomBotEventsService implements OnModuleInit, OnModuleDestroy {
       );
 
       if (!updateResult.success) {
-        console.error(`❌ Failed to update bot ${event.botId} status:`, updateResult.error);
+        console.error(
+          `❌ Failed to update bot ${event.botId} status:`,
+          updateResult.error,
+        );
         return;
       }
 
@@ -206,7 +239,10 @@ export class CustomBotEventsService implements OnModuleInit, OnModuleDestroy {
         );
 
         if (!analysisResult.success) {
-          console.error(`❌ Failed to store analysis for bot ${event.botId}:`, analysisResult.error);
+          console.error(
+            `❌ Failed to store analysis for bot ${event.botId}:`,
+            analysisResult.error,
+          );
         }
       }
 
@@ -216,15 +252,18 @@ export class CustomBotEventsService implements OnModuleInit, OnModuleDestroy {
       if (event.analysis) {
         const score = event.analysis.score || event.score || 0;
         const filesScanned = event.analysis.filesScanned?.length || 0;
-        const threatLevel = event.analysis.threatSummary?.threatLevel || 'unknown';
-        
+        const threatLevel =
+          event.analysis.threatSummary?.threatLevel || "unknown";
+
         console.log(
-          `📊 Analysis summary for ${event.botId}: Score=${score}/5, Files=${filesScanned}, Threat=${threatLevel}`
+          `📊 Analysis summary for ${event.botId}: Score=${score}/5, Files=${filesScanned}, Threat=${threatLevel}`,
         );
       }
-
     } catch (error) {
-      console.error(`❌ Error handling ${event.type} event for bot ${event.botId}:`, error);
+      console.error(
+        `❌ Error handling ${event.type} event for bot ${event.botId}:`,
+        error,
+      );
       throw error; // Re-throw to trigger NATS retry
     }
   }
@@ -236,21 +275,24 @@ export class CustomBotEventsService implements OnModuleInit, OnModuleDestroy {
       // Set status to awaiting human review for failed analyses
       const updateResult = await this.customBotRepository.updateBotStatus(
         event.botId,
-        'awaiting_human_review',
+        "awaiting_human_review",
       );
 
       if (!updateResult.success) {
-        console.error(`❌ Failed to update failed bot ${event.botId} status:`, updateResult.error);
+        console.error(
+          `❌ Failed to update failed bot ${event.botId} status:`,
+          updateResult.error,
+        );
         return;
       }
 
       // Store error information
       const errorAnalysis = {
         reviewedAt: event.timestamp,
-        reviewedBy: event.service || '0vers33r',
-        version: 'v3.0-oss',
+        reviewedBy: event.service || "0vers33r",
+        version: "v3.0-oss",
         score: 5, // Max score for errors
-        issues: ['analysis_error'],
+        issues: ["analysis_error"],
         error: event.error,
         details: event.details,
         filesScanned: [],
@@ -262,13 +304,20 @@ export class CustomBotEventsService implements OnModuleInit, OnModuleDestroy {
       );
 
       if (!analysisResult.success) {
-        console.error(`❌ Failed to store error analysis for bot ${event.botId}:`, analysisResult.error);
+        console.error(
+          `❌ Failed to store error analysis for bot ${event.botId}:`,
+          analysisResult.error,
+        );
       }
 
-      console.log(`⚠️ Marked bot ${event.botId} for human review due to analysis failure`);
-
+      console.log(
+        `⚠️ Marked bot ${event.botId} for human review due to analysis failure`,
+      );
     } catch (error) {
-      console.error(`❌ Error handling analysis-failed event for bot ${event.botId}:`, error);
+      console.error(
+        `❌ Error handling analysis-failed event for bot ${event.botId}:`,
+        error,
+      );
       throw error;
     }
   }

--- a/api/src/custom-bot/custom-bot.controller.ts
+++ b/api/src/custom-bot/custom-bot.controller.ts
@@ -12,12 +12,12 @@ import {
   HttpCode,
   UseGuards,
   Patch,
-} from '@nestjs/common';
-import { Request } from 'express';
-import { CustomBotService } from './custom-bot.service';
-import { CustomBotConfig } from './custom-bot.types';
-import { AuthCombinedGuard } from '@/auth/auth-combined.guard';
-import { StorageService } from './storage.service';
+} from "@nestjs/common";
+import { Request } from "express";
+import { CustomBotService } from "./custom-bot.service";
+import { CustomBotConfig } from "./custom-bot.types";
+import { AuthCombinedGuard } from "@/auth/auth-combined.guard";
+import { StorageService } from "./storage.service";
 
 interface CustomBotDeployDto {
   config: string; // JSON string
@@ -30,7 +30,7 @@ interface UploadUrlResponse {
   expiresAt: string;
 }
 
-@Controller('custom-bots')
+@Controller("custom-bots")
 @UseGuards(AuthCombinedGuard)
 export class CustomBotController {
   constructor(
@@ -38,20 +38,20 @@ export class CustomBotController {
     private readonly storageService: StorageService,
   ) {}
 
-  @Post(':name/upload-url')
+  @Post(":name/upload-url")
   @HttpCode(HttpStatus.OK)
   async generateUploadUrl(
-    @Param('name') name: string,
+    @Param("name") name: string,
     @Body() body: { version: string },
     @Req() request: Request,
   ): Promise<UploadUrlResponse> {
     const userId = (request as any).user?.uid;
     if (!userId) {
-      throw new BadRequestException('User ID is required');
+      throw new BadRequestException("User ID is required");
     }
 
     if (!body.version) {
-      throw new BadRequestException('Version is required');
+      throw new BadRequestException("Version is required");
     }
 
     const result = await this.storageService.generateSignedUploadUrl(
@@ -73,25 +73,27 @@ export class CustomBotController {
     };
   }
 
-  @Post(':name')
+  @Post(":name")
   @HttpCode(HttpStatus.CREATED)
   async createCustomBot(
-    @Param('name') name: string,
+    @Param("name") name: string,
     @Body() body: CustomBotDeployDto,
     @Req() request: Request,
   ) {
     const userId = (request as any).user?.uid;
     if (!userId) {
-      throw new BadRequestException('User ID is required');
+      throw new BadRequestException("User ID is required");
     }
 
     // Validate file path
     if (!body.filePath) {
-      throw new BadRequestException('file path is required');
+      throw new BadRequestException("file path is required");
     }
 
     // Validate that file exists at file path
-    const fileExistsResult = await this.storageService.fileExists(body.filePath);
+    const fileExistsResult = await this.storageService.fileExists(
+      body.filePath,
+    );
     if (!fileExistsResult.success) {
       throw new BadRequestException(
         `File validation failed: ${fileExistsResult.error}`,
@@ -99,25 +101,25 @@ export class CustomBotController {
     }
 
     if (!fileExistsResult.data) {
-      throw new BadRequestException('File not found at specified file path');
+      throw new BadRequestException("File not found at specified file path");
     }
 
     // Validate and parse config
     if (!body.config) {
-      throw new BadRequestException('Config field is required');
+      throw new BadRequestException("Config field is required");
     }
 
     let config: CustomBotConfig;
     try {
       config = JSON.parse(body.config);
     } catch (error) {
-      throw new BadRequestException('Config must be valid JSON');
+      throw new BadRequestException("Config must be valid JSON");
     }
 
     // Ensure the name in config matches URL parameter
     if (config.name !== name) {
       throw new BadRequestException(
-        'Bot name in config must match URL parameter',
+        "Bot name in config must match URL parameter",
       );
     }
 
@@ -134,29 +136,31 @@ export class CustomBotController {
     return {
       success: true,
       data: result.data,
-      message: 'Custom bot created successfully',
+      message: "Custom bot created successfully",
     };
   }
 
-  @Put(':name')
+  @Put(":name")
   @HttpCode(HttpStatus.OK)
   async updateCustomBot(
-    @Param('name') name: string,
+    @Param("name") name: string,
     @Body() body: CustomBotDeployDto,
     @Req() request: Request,
   ) {
     const userId = (request as any).user?.uid;
     if (!userId) {
-      throw new BadRequestException('User ID is required');
+      throw new BadRequestException("User ID is required");
     }
 
     // Validate file path
     if (!body.filePath) {
-      throw new BadRequestException('file path is required');
+      throw new BadRequestException("file path is required");
     }
 
     // Validate that file exists at file path
-    const fileExistsResult = await this.storageService.fileExists(body.filePath);
+    const fileExistsResult = await this.storageService.fileExists(
+      body.filePath,
+    );
     if (!fileExistsResult.success) {
       throw new BadRequestException(
         `File validation failed: ${fileExistsResult.error}`,
@@ -164,25 +168,25 @@ export class CustomBotController {
     }
 
     if (!fileExistsResult.data) {
-      throw new BadRequestException('File not found at specified file path');
+      throw new BadRequestException("File not found at specified file path");
     }
 
     // Validate and parse config
     if (!body.config) {
-      throw new BadRequestException('Config field is required');
+      throw new BadRequestException("Config field is required");
     }
 
     let config: CustomBotConfig;
     try {
       config = JSON.parse(body.config);
     } catch (error) {
-      throw new BadRequestException('Config must be valid JSON');
+      throw new BadRequestException("Config must be valid JSON");
     }
 
     // Ensure the name in config matches URL parameter
     if (config.name !== name) {
       throw new BadRequestException(
-        'Bot name in config must match URL parameter',
+        "Bot name in config must match URL parameter",
       );
     }
 
@@ -200,7 +204,7 @@ export class CustomBotController {
     return {
       success: true,
       data: result.data,
-      message: 'Custom bot updated successfully',
+      message: "Custom bot updated successfully",
     };
   }
 
@@ -209,7 +213,7 @@ export class CustomBotController {
   async getUserCustomBots(@Req() request: Request) {
     const userId = (request as any).user?.uid;
     if (!userId) {
-      throw new BadRequestException('User ID is required');
+      throw new BadRequestException("User ID is required");
     }
 
     const result = await this.customBotService.getUserCustomBots(userId);
@@ -221,13 +225,13 @@ export class CustomBotController {
     return {
       success: true,
       data: result.data,
-      message: 'User custom bots retrieved successfully',
+      message: "User custom bots retrieved successfully",
     };
   }
 
-  @Get(':name')
+  @Get(":name")
   @HttpCode(HttpStatus.OK)
-  async getAllVersions(@Param('name') name: string, @Req() request: Request) {
+  async getAllVersions(@Param("name") name: string, @Req() request: Request) {
     const result = await this.customBotService.getAllGlobalVersions(name);
 
     if (!result.success) {
@@ -237,15 +241,15 @@ export class CustomBotController {
     return {
       success: true,
       data: result.data,
-      message: 'Bot versions retrieved successfully',
+      message: "Bot versions retrieved successfully",
     };
   }
 
-  @Get(':name/:version')
+  @Get(":name/:version")
   @HttpCode(HttpStatus.OK)
   async getSpecificVersion(
-    @Param('name') name: string,
-    @Param('version') version: string,
+    @Param("name") name: string,
+    @Param("version") version: string,
     @Req() request: Request,
   ) {
     const result = await this.customBotService.getGlobalSpecificVersion(
@@ -260,7 +264,7 @@ export class CustomBotController {
     return {
       success: true,
       data: result.data,
-      message: 'Bot version retrieved successfully',
+      message: "Bot version retrieved successfully",
     };
   }
 }

--- a/api/src/custom-bot/custom-bot.module.ts
+++ b/api/src/custom-bot/custom-bot.module.ts
@@ -1,12 +1,12 @@
-import { Module } from '@nestjs/common';
-import { CustomBotController } from './custom-bot.controller';
-import { CustomBotService } from './custom-bot.service';
-import { CustomBotRepository } from './custom-bot.repository';
-import { StorageService } from './storage.service';
-import { CustomBotEventsService } from './custom-bot-events.service';
-import { ApiKeyModule } from '@/api-key/api-key.module';
-import { NatsModule } from '@/nats/nats.module';
-import { ConfigModule } from '@nestjs/config';
+import { Module } from "@nestjs/common";
+import { CustomBotController } from "./custom-bot.controller";
+import { CustomBotService } from "./custom-bot.service";
+import { CustomBotRepository } from "./custom-bot.repository";
+import { StorageService } from "./storage.service";
+import { CustomBotEventsService } from "./custom-bot-events.service";
+import { ApiKeyModule } from "@/api-key/api-key.module";
+import { NatsModule } from "@/nats/nats.module";
+import { ConfigModule } from "@nestjs/config";
 
 @Module({
   imports: [ConfigModule, ApiKeyModule, NatsModule],

--- a/api/src/custom-bot/custom-bot.repository.ts
+++ b/api/src/custom-bot/custom-bot.repository.ts
@@ -1,19 +1,26 @@
-import { Injectable } from '@nestjs/common';
-import { RoleRevisionRepository } from '@/common/role-revision.repository';
-import { CustomBot, CustomBotWithVersions, CustomBotVersion } from './custom-bot.types';
-import { Result, Ok, Failure } from '@/common/result';
-import { eq, and, desc } from 'drizzle-orm';
-import * as semver from 'semver';
+import { Injectable } from "@nestjs/common";
+import { RoleRevisionRepository } from "@/common/role-revision.repository";
+import {
+  CustomBot,
+  CustomBotWithVersions,
+  CustomBotVersion,
+} from "./custom-bot.types";
+import { Result, Ok, Failure } from "@/common/result";
+import { eq, and, desc } from "drizzle-orm";
+import * as semver from "semver";
 
 @Injectable()
 export class CustomBotRepository extends RoleRevisionRepository<CustomBot> {
-  protected readonly tableName = 'customBots' as const;
+  protected readonly tableName = "customBots" as const;
 
   constructor() {
-    super('name'); // Use 'name' as the revision key field
+    super("name"); // Use 'name' as the revision key field
   }
 
-  async userBotExists(userId: string, name: string): Promise<Result<boolean, string>> {
+  async userBotExists(
+    userId: string,
+    name: string,
+  ): Promise<Result<boolean, string>> {
     try {
       const result = await this.findByKey(userId, name);
       if (!result.success) {
@@ -37,7 +44,11 @@ export class CustomBotRepository extends RoleRevisionRepository<CustomBot> {
     }
   }
 
-  async userVersionExists(userId: string, name: string, version: string): Promise<Result<boolean, string>> {
+  async userVersionExists(
+    userId: string,
+    name: string,
+    version: string,
+  ): Promise<Result<boolean, string>> {
     try {
       const result = await this.findByKeyAndVersion(userId, name, version);
       return Ok(result.success);
@@ -46,7 +57,10 @@ export class CustomBotRepository extends RoleRevisionRepository<CustomBot> {
     }
   }
 
-  async globalVersionExists(name: string, version: string): Promise<Result<boolean, string>> {
+  async globalVersionExists(
+    name: string,
+    version: string,
+  ): Promise<Result<boolean, string>> {
     try {
       const result = await this.findGlobalByKeyAndVersion(name, version);
       return Ok(result.success);
@@ -55,7 +69,9 @@ export class CustomBotRepository extends RoleRevisionRepository<CustomBot> {
     }
   }
 
-  async getUserCustomBots(userId: string): Promise<Result<CustomBotWithVersions[], string>> {
+  async getUserCustomBots(
+    userId: string,
+  ): Promise<Result<CustomBotWithVersions[], string>> {
     try {
       // Get all custom bots for the user
       const result = await this.findAll(userId);
@@ -81,7 +97,10 @@ export class CustomBotRepository extends RoleRevisionRepository<CustomBot> {
 
       for (const [botName, bots] of botsByName) {
         // Sort by creation date descending (latest first)
-        bots.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+        bots.sort(
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        );
 
         const latestBot = bots[0];
 
@@ -112,7 +131,10 @@ export class CustomBotRepository extends RoleRevisionRepository<CustomBot> {
       }
 
       // Sort by latest update time descending
-      customBotsWithVersions.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+      customBotsWithVersions.sort(
+        (a, b) =>
+          new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+      );
 
       return Ok(customBotsWithVersions);
     } catch (error: any) {
@@ -120,7 +142,10 @@ export class CustomBotRepository extends RoleRevisionRepository<CustomBot> {
     }
   }
 
-  async getAllUserVersions(userId: string, name: string): Promise<Result<CustomBotWithVersions, string>> {
+  async getAllUserVersions(
+    userId: string,
+    name: string,
+  ): Promise<Result<CustomBotWithVersions, string>> {
     try {
       const result = await this.findByKey(userId, name);
       if (!result.success) {
@@ -128,7 +153,7 @@ export class CustomBotRepository extends RoleRevisionRepository<CustomBot> {
       }
 
       if (result.data.length === 0) {
-        return Failure('Bot not found');
+        return Failure("Bot not found");
       }
 
       const bots = result.data;
@@ -161,7 +186,9 @@ export class CustomBotRepository extends RoleRevisionRepository<CustomBot> {
     }
   }
 
-  async getAllGlobalVersions(name: string): Promise<Result<CustomBotWithVersions, string>> {
+  async getAllGlobalVersions(
+    name: string,
+  ): Promise<Result<CustomBotWithVersions, string>> {
     try {
       const result = await this.findGlobalByKey(name);
       if (!result.success) {
@@ -169,7 +196,7 @@ export class CustomBotRepository extends RoleRevisionRepository<CustomBot> {
       }
 
       if (result.data.length === 0) {
-        return Failure('Bot not found');
+        return Failure("Bot not found");
       }
 
       const bots = result.data;
@@ -202,15 +229,25 @@ export class CustomBotRepository extends RoleRevisionRepository<CustomBot> {
     }
   }
 
-  async getSpecificUserVersion(userId: string, name: string, version: string): Promise<Result<CustomBot, string>> {
+  async getSpecificUserVersion(
+    userId: string,
+    name: string,
+    version: string,
+  ): Promise<Result<CustomBot, string>> {
     return this.findByKeyAndVersion(userId, name, version);
   }
 
-  async getSpecificGlobalVersion(name: string, version: string): Promise<Result<CustomBot, string>> {
+  async getSpecificGlobalVersion(
+    name: string,
+    version: string,
+  ): Promise<Result<CustomBot, string>> {
     return this.findGlobalByKeyAndVersion(name, version);
   }
 
-  async createNewGlobalVersion(userId: string, botData: Partial<CustomBot>): Promise<Result<CustomBot, string>> {
+  async createNewGlobalVersion(
+    userId: string,
+    botData: Partial<CustomBot>,
+  ): Promise<Result<CustomBot, string>> {
     return this.create({
       ...botData,
       userId,
@@ -221,25 +258,30 @@ export class CustomBotRepository extends RoleRevisionRepository<CustomBot> {
     return semver.gt(newVersion, currentVersion);
   }
 
-  async checkUserOwnership(userId: string, name: string): Promise<Result<boolean, string>> {
+  async checkUserOwnership(
+    userId: string,
+    name: string,
+  ): Promise<Result<boolean, string>> {
     const result = await this.findGlobalByKey(name);
     if (!result.success) {
       return Failure(result.error);
     }
     const bots = result.data;
     if (bots.length === 0) {
-      return Failure('Bot not found');
+      return Failure("Bot not found");
     }
     const bot = bots[0];
     if (bot.userId !== userId) {
-      return Failure('Insufficient permissions');
+      return Failure("Insufficient permissions");
     }
     return Ok(true);
   }
 
-  
   // Legacy aliases for backward compatibility
-  async getVersionsForBot(userId: string, name: string): Promise<Result<CustomBotVersion[], string>> {
+  async getVersionsForBot(
+    userId: string,
+    name: string,
+  ): Promise<Result<CustomBotVersion[], string>> {
     const result = await this.getAllUserVersions(userId, name);
     if (!result.success) {
       return Failure(result.error);
@@ -247,31 +289,39 @@ export class CustomBotRepository extends RoleRevisionRepository<CustomBot> {
     return Ok(result.data.versions);
   }
 
-  async getBotsWithVersions(userId: string): Promise<Result<CustomBotWithVersions[], string>> {
+  async getBotsWithVersions(
+    userId: string,
+  ): Promise<Result<CustomBotWithVersions[], string>> {
     return this.getUserCustomBots(userId);
   }
 
-  async createBot(userId: string, customBot: Partial<CustomBot>): Promise<Result<CustomBot, string>> {
+  async createBot(
+    userId: string,
+    customBot: Partial<CustomBot>,
+  ): Promise<Result<CustomBot, string>> {
     const data = {
       userId,
       name: customBot.name!,
       version: customBot.version!,
       config: customBot.config!,
       filePath: customBot.filePath!,
-      status: customBot.status || 'pending_review',
+      status: customBot.status || "pending_review",
       marketplace: customBot.marketplace || null,
     };
 
     return this.create(data);
   }
 
-  async updateBotStatus(botId: string, status: string): Promise<Result<void, string>> {
+  async updateBotStatus(
+    botId: string,
+    status: string,
+  ): Promise<Result<void, string>> {
     try {
       const result = await this.db
         .update(this.table)
-        .set({ 
+        .set({
           status: status as any,
-          updatedAt: new Date()
+          updatedAt: new Date(),
         })
         .where(eq(this.table.id, botId));
 
@@ -281,16 +331,21 @@ export class CustomBotRepository extends RoleRevisionRepository<CustomBot> {
     }
   }
 
-  async updateBotAnalysis(botId: string, analysis: any): Promise<Result<void, string>> {
+  async updateBotAnalysis(
+    botId: string,
+    analysis: any,
+  ): Promise<Result<void, string>> {
     try {
       // Add analysis data to the bot record (this would require schema update)
       // For now, just log the analysis data
-      console.log(`📊 Analysis data for bot ${botId}:`, JSON.stringify(analysis, null, 2));
-      
+      console.log(
+        `📊 Analysis data for bot ${botId}:`,
+        JSON.stringify(analysis, null, 2),
+      );
+
       return Ok(null);
     } catch (error: any) {
       return Failure(`Failed to update bot analysis: ${error.message}`);
     }
   }
-
 }

--- a/api/src/custom-bot/custom-bot.schema.ts
+++ b/api/src/custom-bot/custom-bot.schema.ts
@@ -1,100 +1,100 @@
-import Ajv from 'ajv';
+import Ajv from "ajv";
 
 const ajv = new Ajv();
 
 export const customBotConfigSchema = {
-  type: 'object',
+  type: "object",
   required: [
-    'name',
-    'version',
-    'entrypoints',
-    'schema',
-    'readme',
-    'type',
-    'runtime',
+    "name",
+    "version",
+    "entrypoints",
+    "schema",
+    "readme",
+    "type",
+    "runtime",
   ],
   properties: {
     name: {
-      type: 'string',
-      pattern: '^[a-z0-9-]+$',
+      type: "string",
+      pattern: "^[a-z0-9-]+$",
       minLength: 3,
       maxLength: 50,
     },
     description: {
-      type: 'string',
+      type: "string",
       maxLength: 500,
     },
     version: {
-      type: 'string',
-      pattern: '^\\d+\\.\\d+\\.\\d+$',
+      type: "string",
+      pattern: "^\\d+\\.\\d+\\.\\d+$",
     },
     runtime: {
-      type: 'string',
-      enum: ['python3.11', 'nodejs20'],
+      type: "string",
+      enum: ["python3.11", "nodejs20"],
     },
     author: {
-      type: 'string',
+      type: "string",
       maxLength: 100,
     },
     type: {
-      type: 'string',
-      enum: ['scheduled', 'realtime', 'event'],
-      default: 'scheduled',
+      type: "string",
+      enum: ["scheduled", "realtime", "event"],
+      default: "scheduled",
     },
     entrypoints: {
-      type: 'object',
-      required: ['bot'],
+      type: "object",
+      required: ["bot"],
       properties: {
         bot: {
-          type: 'string',
-          pattern: '\\.(py|js)$',
+          type: "string",
+          pattern: "\\.(py|js)$",
         },
         backtest: {
-          type: 'string',
-          pattern: '\\.(py|js)$',
+          type: "string",
+          pattern: "\\.(py|js)$",
         },
       },
       additionalProperties: false,
     },
     schema: {
-      type: 'object',
-      required: ['bot'],
+      type: "object",
+      required: ["bot"],
       properties: {
         backtest: {
-          type: 'object',
+          type: "object",
         },
         bot: {
-          type: 'object',
+          type: "object",
         },
       },
       additionalProperties: false,
     },
     readme: {
-      type: 'string',
+      type: "string",
       minLength: 50,
       maxLength: 10000,
     },
     metadata: {
-      type: 'object',
+      type: "object",
       properties: {
         categories: {
-          type: 'array',
-          items: { type: 'string' },
+          type: "array",
+          items: { type: "string" },
           maxItems: 10,
         },
         instruments: {
-          type: 'array',
-          items: { type: 'string' },
+          type: "array",
+          items: { type: "string" },
           maxItems: 20,
         },
         exchanges: {
-          type: 'array',
-          items: { type: 'string' },
+          type: "array",
+          items: { type: "string" },
           maxItems: 20,
         },
         tags: {
-          type: 'array',
-          items: { type: 'string' },
+          type: "array",
+          items: { type: "string" },
           maxItems: 20,
         },
       },
@@ -105,12 +105,12 @@ export const customBotConfigSchema = {
   allOf: [
     {
       if: {
-        properties: { type: { const: 'scheduled' } },
-        required: ['type'],
+        properties: { type: { const: "scheduled" } },
+        required: ["type"],
       },
       then: {
         properties: {
-          runtime: { enum: ['python3.11'] },
+          runtime: { enum: ["python3.11"] },
         },
       },
     },
@@ -118,23 +118,23 @@ export const customBotConfigSchema = {
       if: {
         properties: {
           entrypoints: {
-            type: 'object',
+            type: "object",
             properties: {
-              backtest: { type: 'string' },
+              backtest: { type: "string" },
             },
-            required: ['backtest'],
+            required: ["backtest"],
           },
         },
-        required: ['entrypoints'],
+        required: ["entrypoints"],
       },
       then: {
         properties: {
           schema: {
-            type: 'object',
-            required: ['backtest', 'bot'],
+            type: "object",
+            required: ["backtest", "bot"],
           },
         },
-        required: ['schema'],
+        required: ["schema"],
       },
     },
   ],

--- a/api/src/custom-bot/custom-bot.service.ts
+++ b/api/src/custom-bot/custom-bot.service.ts
@@ -1,15 +1,15 @@
-import { Injectable } from '@nestjs/common';
-import { CustomBotRepository } from './custom-bot.repository';
-import { StorageService } from '@/custom-bot/storage.service';
-import { validateCustomBotConfigPayload } from './custom-bot.schema';
-import { NatsService } from '@/nats/nats.service';
+import { Injectable } from "@nestjs/common";
+import { CustomBotRepository } from "./custom-bot.repository";
+import { StorageService } from "@/custom-bot/storage.service";
+import { validateCustomBotConfigPayload } from "./custom-bot.schema";
+import { NatsService } from "@/nats/nats.service";
 
 import {
   CustomBotConfig,
   CustomBot,
   CustomBotWithVersions,
-} from './custom-bot.types';
-import { Result, Failure, Ok } from '@/common/result';
+} from "./custom-bot.types";
+import { Result, Failure, Ok } from "@/common/result";
 
 @Injectable()
 export class CustomBotService {
@@ -28,7 +28,7 @@ export class CustomBotService {
       // Validate config structure
       const validation = validateCustomBotConfigPayload(config);
       if (!validation.valid) {
-        return Failure(`Validation failed: ${validation.errors?.join(', ')}`);
+        return Failure(`Validation failed: ${validation.errors?.join(", ")}`);
       }
 
       // Check if bot already exists
@@ -40,31 +40,30 @@ export class CustomBotService {
       }
 
       if (
-        config.type === 'realtime' &&
+        config.type === "realtime" &&
         (!config.runtime ||
-          !['python3.11', 'nodejs20'].includes(config.runtime))
+          !["python3.11", "nodejs20"].includes(config.runtime))
       ) {
         return Failure(
-          'Realtime bots must specify a valid runtime (python3.11 or nodejs20)',
+          "Realtime bots must specify a valid runtime (python3.11 or nodejs20)",
         );
       }
 
-      if (config.type === 'scheduled' && config.runtime !== 'python3.11') {
+      if (config.type === "scheduled" && config.runtime !== "python3.11") {
         return Failure(
-          'Scheduled bots must use python3.11 runtime (nodejs20 is not supported for scheduled bots)',
+          "Scheduled bots must use python3.11 runtime (nodejs20 is not supported for scheduled bots)",
         );
       }
 
       if (existsResult.data) {
-        return Failure('Custom bot with this name already exists');
+        return Failure("Custom bot with this name already exists");
       }
 
       // Validate ZIP file structure from uploaded file
-      const zipValidation =
-        await this.storageService.validateZipStructure(
-          filePath,
-          Object.values(config.entrypoints).filter(Boolean),
-        );
+      const zipValidation = await this.storageService.validateZipStructure(
+        filePath,
+        Object.values(config.entrypoints).filter(Boolean),
+      );
       if (!zipValidation.success) {
         return Failure(`ZIP validation failed: ${zipValidation.error}`);
       }
@@ -75,7 +74,7 @@ export class CustomBotService {
         version: config.version,
         config,
         filePath: filePath,
-        status: 'pending_review', // Default status
+        status: "pending_review", // Default status
       };
 
       const result = await this.customBotRepository.createNewGlobalVersion(
@@ -88,15 +87,16 @@ export class CustomBotService {
         return Failure(result.error);
       }
 
-      const createdBotResult = await this.customBotRepository.getSpecificGlobalVersion(
-        config.name,
-        config.version,
-      );
+      const createdBotResult =
+        await this.customBotRepository.getSpecificGlobalVersion(
+          config.name,
+          config.version,
+        );
 
       // Publish custom-bot.submitted event for 0vers33r analysis
       if (createdBotResult.success) {
         const customBotSubmittedEvent = {
-          type: 'custom-bot.submitted',
+          type: "custom-bot.submitted",
           botId: createdBotResult.data.id,
           name: config.name,
           userId: userId,
@@ -106,20 +106,25 @@ export class CustomBotService {
         };
 
         const publishResult = await this.natsService.publish(
-          'custom-bot.submitted',
+          "custom-bot.submitted",
           customBotSubmittedEvent,
         );
 
         if (!publishResult.success) {
-          console.error('Failed to publish custom-bot.submitted event:', publishResult.error);
+          console.error(
+            "Failed to publish custom-bot.submitted event:",
+            publishResult.error,
+          );
         } else {
-          console.log(`📤 Published custom-bot.submitted event for bot ${createdBotResult.data.id}`);
+          console.log(
+            `📤 Published custom-bot.submitted event for bot ${createdBotResult.data.id}`,
+          );
         }
       }
 
       return createdBotResult;
     } catch (error: any) {
-      console.log('Error creating custom bot:', error);
+      console.log("Error creating custom bot:", error);
       return Failure(`Failed to create custom bot: ${error.message}`);
     }
   }
@@ -134,27 +139,27 @@ export class CustomBotService {
       // Validate config structure
       const validation = validateCustomBotConfigPayload(config);
       if (!validation.valid) {
-        return Failure(`Validation failed: ${validation.errors?.join(', ')}`);
+        return Failure(`Validation failed: ${validation.errors?.join(", ")}`);
       }
 
       // Ensure the name in config matches the parameter
       if (config.name !== name) {
-        return Failure('Bot name in config must match the URL parameter');
+        return Failure("Bot name in config must match the URL parameter");
       }
 
       if (
-        config.type === 'realtime' &&
+        config.type === "realtime" &&
         (!config.runtime ||
-          !['python3.11', 'nodejs20'].includes(config.runtime))
+          !["python3.11", "nodejs20"].includes(config.runtime))
       ) {
         return Failure(
-          'Realtime bots must specify a valid runtime (python3.11 or nodejs20)',
+          "Realtime bots must specify a valid runtime (python3.11 or nodejs20)",
         );
       }
 
-      if (config.type === 'scheduled' && config.runtime !== 'python3.11') {
+      if (config.type === "scheduled" && config.runtime !== "python3.11") {
         return Failure(
-          'Scheduled bots must use python3.11 runtime (nodejs20 is not supported for scheduled bots)',
+          "Scheduled bots must use python3.11 runtime (nodejs20 is not supported for scheduled bots)",
         );
       }
 
@@ -166,7 +171,7 @@ export class CustomBotService {
 
       if (!existsResult.data) {
         return Failure(
-          'Custom bot does not exist. Create it first using POST.',
+          "Custom bot does not exist. Create it first using POST.",
         );
       }
 
@@ -212,11 +217,10 @@ export class CustomBotService {
       }
 
       // Validate ZIP file structure from uploaded file
-      const zipValidation =
-        await this.storageService.validateZipStructure(
-          filePath,
-          Object.values(config.entrypoints).filter(Boolean),
-        );
+      const zipValidation = await this.storageService.validateZipStructure(
+        filePath,
+        Object.values(config.entrypoints).filter(Boolean),
+      );
       if (!zipValidation.success) {
         return Failure(`ZIP validation failed: ${zipValidation.error}`);
       }
@@ -227,7 +231,7 @@ export class CustomBotService {
         version: config.version,
         config,
         filePath: filePath,
-        status: 'pending_review', // Default status
+        status: "pending_review", // Default status
       };
 
       return await this.customBotRepository.createNewGlobalVersion(
@@ -235,7 +239,7 @@ export class CustomBotService {
         botData,
       );
     } catch (error: any) {
-      console.log('Error updating custom bot:', error);
+      console.log("Error updating custom bot:", error);
       return Failure(`Failed to update custom bot: ${error.message}`);
     }
   }
@@ -252,7 +256,7 @@ export class CustomBotService {
 
       return result;
     } catch (error: any) {
-      console.log('Error getting user custom bots:', error);
+      console.log("Error getting user custom bots:", error);
       return Failure(`Failed to get user custom bots: ${error.message}`);
     }
   }
@@ -291,5 +295,4 @@ export class CustomBotService {
       version,
     );
   }
-
 }

--- a/api/src/custom-bot/custom-bot.types.ts
+++ b/api/src/custom-bot/custom-bot.types.ts
@@ -1,15 +1,15 @@
-export type BotType = 'scheduled' | 'realtime' | 'event';
+export type BotType = "scheduled" | "realtime" | "event";
 
-export const BOT_TYPES: BotType[] = ['scheduled', 'realtime', 'event'];
+export const BOT_TYPES: BotType[] = ["scheduled", "realtime", "event"];
 
 export type CustomBotStatus =
-  | 'approved'
-  | 'declined'
-  | 'awaiting_human_review'
-  | 'pending_review'
-  | 'published';
+  | "approved"
+  | "declined"
+  | "awaiting_human_review"
+  | "pending_review"
+  | "published";
 
-export type Runtime = 'python3.11' | 'nodejs20';
+export type Runtime = "python3.11" | "nodejs20";
 
 export interface CustomBotConfig {
   name: string;
@@ -45,7 +45,7 @@ export interface CustomBot {
   filePath: string;
   userId: string;
   status: CustomBotStatus;
-  review?: any; // Security analysis results from 0vers33r  
+  review?: any; // Security analysis results from 0vers33r
   marketplace?: MarketplaceMetadata | null;
   createdAt: Date;
   updatedAt: Date;

--- a/api/src/custom-bot/storage.service.ts
+++ b/api/src/custom-bot/storage.service.ts
@@ -1,10 +1,10 @@
-import { Injectable } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { Result, Ok, Failure } from '@/common/result';
-import * as crypto from 'crypto';
-import * as Minio from 'minio';
-import AdmZip from 'adm-zip';
-import { Readable } from 'stream';
+import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Result, Ok, Failure } from "@/common/result";
+import * as crypto from "crypto";
+import * as Minio from "minio";
+import AdmZip from "adm-zip";
+import { Readable } from "stream";
 
 // Simple in-memory token storage (in production, use Redis)
 const uploadTokens = new Map<string, string>();
@@ -16,36 +16,45 @@ export class StorageService {
   private bucketName: string;
 
   constructor(private readonly configService: ConfigService) {
-    const endpoint = this.configService.get<string>('MINIO_ENDPOINT') || 'localhost';
-    const externalEndpoint = this.configService.get<string>('MINIO_EXTERNAL_ENDPOINT') || endpoint;
-    const port = parseInt(this.configService.get<string>('MINIO_PORT') || '9000');
-    
+    const endpoint =
+      this.configService.get<string>("MINIO_ENDPOINT") || "localhost";
+    const externalEndpoint =
+      this.configService.get<string>("MINIO_EXTERNAL_ENDPOINT") || endpoint;
+    const port = parseInt(
+      this.configService.get<string>("MINIO_PORT") || "9000",
+    );
+
     // Internal client for API operations
     this.minioClient = new Minio.Client({
       endPoint: endpoint,
       port,
-      useSSL: this.configService.get<string>('MINIO_USE_SSL') === 'true',
-      accessKey: this.configService.get<string>('MINIO_ACCESS_KEY') || 'minioadmin',
-      secretKey: this.configService.get<string>('MINIO_SECRET_KEY') || 'minioadmin',
+      useSSL: this.configService.get<string>("MINIO_USE_SSL") === "true",
+      accessKey:
+        this.configService.get<string>("MINIO_ACCESS_KEY") || "minioadmin",
+      secretKey:
+        this.configService.get<string>("MINIO_SECRET_KEY") || "minioadmin",
     });
 
     // External client for generating signed URLs accessible from outside
-    const [externalHost, externalPortStr] = externalEndpoint.split(':');
+    const [externalHost, externalPortStr] = externalEndpoint.split(":");
     const externalPort = externalPortStr ? parseInt(externalPortStr) : port;
-    
+
     this.externalMinioClient = new Minio.Client({
       endPoint: externalHost,
       port: externalPort,
-      useSSL: this.configService.get<string>('MINIO_USE_SSL') === 'true',
-      accessKey: this.configService.get<string>('MINIO_ACCESS_KEY') || 'minioadmin',
-      secretKey: this.configService.get<string>('MINIO_SECRET_KEY') || 'minioadmin',
+      useSSL: this.configService.get<string>("MINIO_USE_SSL") === "true",
+      accessKey:
+        this.configService.get<string>("MINIO_ACCESS_KEY") || "minioadmin",
+      secretKey:
+        this.configService.get<string>("MINIO_SECRET_KEY") || "minioadmin",
     });
 
-    this.bucketName = this.configService.get<string>('CUSTOM_BOTS_BUCKET') || 'custom-bots';
-    
+    this.bucketName =
+      this.configService.get<string>("CUSTOM_BOTS_BUCKET") || "custom-bots";
+
     // Ensure bucket exists on startup
-    this.ensureBucket().catch(error => {
-      console.error('Failed to ensure MinIO bucket exists:', error);
+    this.ensureBucket().catch((error) => {
+      console.error("Failed to ensure MinIO bucket exists:", error);
     });
   }
 
@@ -68,7 +77,10 @@ export class StorageService {
       return Ok(true);
     } catch (error) {
       // MinIO throws error if object doesn't exist
-      if (error.code === 'NoSuchKey' || error.message?.includes('does not exist')) {
+      if (
+        error.code === "NoSuchKey" ||
+        error.message?.includes("does not exist")
+      ) {
         return Ok(false);
       }
       return Failure(`Error checking file existence: ${error.message}`);
@@ -90,31 +102,34 @@ export class StorageService {
 
   async validateZipStructure(
     filePath: string,
-    requiredFiles: string[]
+    requiredFiles: string[],
   ): Promise<Result<boolean, string>> {
     try {
       // Download the ZIP file from MinIO
-      const stream = await this.minioClient.getObject(this.bucketName, filePath);
+      const stream = await this.minioClient.getObject(
+        this.bucketName,
+        filePath,
+      );
       const chunks: Buffer[] = [];
-      
+
       // Read stream into buffer
       for await (const chunk of stream) {
         chunks.push(chunk);
       }
       const buffer = Buffer.concat(chunks);
-      
+
       // Parse ZIP and check for required files
       const zip = new AdmZip(buffer);
       const entries = zip.getEntries();
-      
+
       // Check for required files
       for (const requiredFile of requiredFiles) {
-        const found = entries.some(entry => entry.entryName === requiredFile);
+        const found = entries.some((entry) => entry.entryName === requiredFile);
         if (!found) {
           return Failure(`Required file missing: ${requiredFile}`);
         }
       }
-      
+
       return Ok(true);
     } catch (error) {
       return Failure(`Error validating ZIP structure: ${error.message}`);
@@ -125,11 +140,11 @@ export class StorageService {
     content: Buffer,
     fileName: string,
     userId: string,
-    botName: string
+    botName: string,
   ): Promise<Result<string, string>> {
     try {
       const filePath = `${userId}/${botName}/${fileName}`;
-      
+
       // Upload to MinIO with metadata
       await this.minioClient.putObject(
         this.bucketName,
@@ -137,10 +152,10 @@ export class StorageService {
         content,
         content.length,
         {
-          'Content-Type': 'application/zip',
-          'X-Upload-Source': 'custom-bot-api',
-          'X-Upload-Time': new Date().toISOString(),
-        }
+          "Content-Type": "application/zip",
+          "X-Upload-Source": "custom-bot-api",
+          "X-Upload-Time": new Date().toISOString(),
+        },
       );
 
       console.log(`✅ Uploaded bot file to MinIO: ${filePath}`);
@@ -152,14 +167,17 @@ export class StorageService {
 
   async downloadFile(filePath: string): Promise<Result<Buffer, string>> {
     try {
-      const stream = await this.minioClient.getObject(this.bucketName, filePath);
+      const stream = await this.minioClient.getObject(
+        this.bucketName,
+        filePath,
+      );
       const chunks: Buffer[] = [];
-      
+
       // Read stream into buffer
       for await (const chunk of stream) {
         chunks.push(chunk);
       }
-      
+
       const buffer = Buffer.concat(chunks);
       return Ok(buffer);
     } catch (error) {
@@ -179,34 +197,39 @@ export class StorageService {
   async generateSignedUploadUrl(
     userId: string,
     name: string,
-    version: string
-  ): Promise<Result<{
-    uploadUrl: string;
-    filePath: string;
-    expiresAt: string;
-  }, string>> {
+    version: string,
+  ): Promise<
+    Result<
+      {
+        uploadUrl: string;
+        filePath: string;
+        expiresAt: string;
+      },
+      string
+    >
+  > {
     try {
       const filePath = `${userId}/${name}/${version}`;
-      
+
       // Generate presigned URL (24 hours expiry) using external client for external access
       const expiry = 24 * 60 * 60; // 24 hours in seconds
       const uploadUrl = await this.externalMinioClient.presignedPutObject(
         this.bucketName,
         filePath,
-        expiry
+        expiry,
       );
 
       const expiresAt = new Date(Date.now() + expiry * 1000).toISOString();
-      
+
       console.log(`📡 Generated signed upload URL: ${uploadUrl}`);
-      
+
       return Ok({
         uploadUrl,
         filePath,
         expiresAt,
       });
     } catch (error) {
-      console.error('❌ Error generating upload URL:', error);
+      console.error("❌ Error generating upload URL:", error);
       return Failure(`Error generating upload URL: ${error.message || error}`);
     }
   }
@@ -215,37 +238,45 @@ export class StorageService {
   async generateUploadToken(
     userId: string,
     botName: string,
-    version: string
+    version: string,
   ): Promise<Result<string, string>> {
     try {
-      const token = crypto.randomBytes(32).toString('hex');
+      const token = crypto.randomBytes(32).toString("hex");
       const key = `${userId}:${botName}:${version}`;
-      
+
       uploadTokens.set(token, key);
-      
+
       // Clean up token after 1 hour
-      setTimeout(() => {
-        uploadTokens.delete(token);
-      }, 60 * 60 * 1000);
-      
+      setTimeout(
+        () => {
+          uploadTokens.delete(token);
+        },
+        60 * 60 * 1000,
+      );
+
       return Ok(token);
     } catch (error) {
       return Failure(`Error generating upload token: ${error.message}`);
     }
   }
 
-  async validateUploadToken(token: string): Promise<Result<{
-    userId: string;
-    botName: string;
-    version: string;
-  }, string>> {
+  async validateUploadToken(token: string): Promise<
+    Result<
+      {
+        userId: string;
+        botName: string;
+        version: string;
+      },
+      string
+    >
+  > {
     try {
       const key = uploadTokens.get(token);
       if (!key) {
-        return Failure('Invalid or expired upload token');
+        return Failure("Invalid or expired upload token");
       }
-      
-      const [userId, botName, version] = key.split(':');
+
+      const [userId, botName, version] = key.split(":");
       return Ok({ userId, botName, version });
     } catch (error) {
       return Failure(`Error validating upload token: ${error.message}`);
@@ -254,24 +285,29 @@ export class StorageService {
 
   async uploadWithToken(
     token: string,
-    content: Buffer
+    content: Buffer,
   ): Promise<Result<string, string>> {
     try {
       const tokenResult = await this.validateUploadToken(token);
       if (!tokenResult.success) {
         return Failure(tokenResult.error);
       }
-      
+
       const { userId, botName, version } = tokenResult.data;
-      
-      const uploadResult = await this.uploadBotFile(content, version, userId, botName);
+
+      const uploadResult = await this.uploadBotFile(
+        content,
+        version,
+        userId,
+        botName,
+      );
       if (!uploadResult.success) {
         return Failure(uploadResult.error);
       }
-      
+
       // Clean up token after successful upload
       uploadTokens.delete(token);
-      
+
       return Ok(uploadResult.data);
     } catch (error) {
       return Failure(`Error uploading with token: ${error.message}`);
@@ -297,12 +333,16 @@ export class StorageService {
   async listObjects(prefix: string): Promise<Result<string[], string>> {
     try {
       const objects: string[] = [];
-      const stream = this.minioClient.listObjects(this.bucketName, prefix, true);
-      
+      const stream = this.minioClient.listObjects(
+        this.bucketName,
+        prefix,
+        true,
+      );
+
       for await (const obj of stream) {
         objects.push(obj.name);
       }
-      
+
       return Ok(objects);
     } catch (error) {
       return Failure(`Error listing objects: ${error.message}`);

--- a/api/src/database/connection.ts
+++ b/api/src/database/connection.ts
@@ -1,12 +1,12 @@
-import { drizzle } from 'drizzle-orm/postgres-js';
-import { drizzle as drizzleSqlite } from 'drizzle-orm/better-sqlite3';
-import postgres from 'postgres';
-import Database from 'better-sqlite3';
-import { loadConfig, DatabaseConfig } from '../config/database.config';
-import * as usersSchema from './schema/users';
-import * as customBotsSchema from './schema/custom-bots';
-import * as botsSchema from './schema/bots';
-import * as backtestsSchema from './schema/backtests';
+import { drizzle } from "drizzle-orm/postgres-js";
+import { drizzle as drizzleSqlite } from "drizzle-orm/better-sqlite3";
+import postgres from "postgres";
+import Database from "better-sqlite3";
+import { loadConfig, DatabaseConfig } from "../config/database.config";
+import * as usersSchema from "./schema/users";
+import * as customBotsSchema from "./schema/custom-bots";
+import * as botsSchema from "./schema/bots";
+import * as backtestsSchema from "./schema/backtests";
 // Logs are stored in external storage (MinIO/S3), not in database
 
 // Combined schema for PostgreSQL
@@ -29,10 +29,16 @@ export const sqliteSchema = {
 // Table registry for clean access
 export interface TableRegistry {
   users: typeof usersSchema.usersTable | typeof usersSchema.usersTableSqlite;
-  apiKeys: typeof usersSchema.apiKeysTable | typeof usersSchema.apiKeysTableSqlite;
-  customBots: typeof customBotsSchema.customBotsTable | typeof customBotsSchema.customBotsTableSqlite;
+  apiKeys:
+    | typeof usersSchema.apiKeysTable
+    | typeof usersSchema.apiKeysTableSqlite;
+  customBots:
+    | typeof customBotsSchema.customBotsTable
+    | typeof customBotsSchema.customBotsTableSqlite;
   bots: typeof botsSchema.botsTable | typeof botsSchema.botsTableSqlite;
-  backtests: typeof backtestsSchema.backtestsTable | typeof backtestsSchema.backtestsTableSqlite;
+  backtests:
+    | typeof backtestsSchema.backtestsTable
+    | typeof backtestsSchema.backtestsTableSqlite;
 }
 
 let dbInstance: any = null;
@@ -47,10 +53,10 @@ export function getDatabase() {
   const config = loadConfig();
   configCache = config;
 
-  if (config.type === 'sqlite') {
+  if (config.type === "sqlite") {
     const sqlite = new Database(config.url);
     dbInstance = drizzleSqlite(sqlite, { schema: sqliteSchema });
-    
+
     tablesCache = {
       users: usersSchema.usersTableSqlite,
       apiKeys: usersSchema.apiKeysTableSqlite,
@@ -68,7 +74,7 @@ export function getDatabase() {
       max: 10,
     });
     dbInstance = drizzle(client, { schema: pgSchema });
-    
+
     tablesCache = {
       users: usersSchema.usersTable,
       apiKeys: usersSchema.apiKeysTable,

--- a/api/src/database/migrate.ts
+++ b/api/src/database/migrate.ts
@@ -1,26 +1,27 @@
-import { migrate } from 'drizzle-orm/postgres-js/migrator';
-import { migrate as migrateSqlite } from 'drizzle-orm/better-sqlite3/migrator';
-import { getDatabase, getDatabaseConfig } from './connection';
-import { join } from 'path';
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import { migrate as migrateSqlite } from "drizzle-orm/better-sqlite3/migrator";
+import { getDatabase, getDatabaseConfig } from "./connection";
+import { join } from "path";
 
 async function runMigrations() {
   const config = getDatabaseConfig();
   const db = getDatabase();
-  const migrationsPath = process.env.MIGRATIONS_PATH || join(__dirname, 'migrations');
+  const migrationsPath =
+    process.env.MIGRATIONS_PATH || join(__dirname, "migrations");
 
   console.log(`Running migrations for ${config.type} database...`);
   console.log(`Migration path: ${migrationsPath}`);
-  
+
   try {
-    if (config.type === 'sqlite') {
+    if (config.type === "sqlite") {
       migrateSqlite(db, { migrationsFolder: migrationsPath });
-      console.log('✅ SQLite migrations completed successfully');
+      console.log("✅ SQLite migrations completed successfully");
     } else {
       await migrate(db, { migrationsFolder: migrationsPath });
-      console.log('✅ PostgreSQL migrations completed successfully');
+      console.log("✅ PostgreSQL migrations completed successfully");
     }
   } catch (error) {
-    console.error('❌ Migration failed:', error);
+    console.error("❌ Migration failed:", error);
     process.exit(1);
   }
 }
@@ -29,11 +30,11 @@ async function runMigrations() {
 if (require.main === module) {
   runMigrations()
     .then(() => {
-      console.log('🎉 Database migration completed');
+      console.log("🎉 Database migration completed");
       process.exit(0);
     })
     .catch((error) => {
-      console.error('❌ Migration script failed:', error);
+      console.error("❌ Migration script failed:", error);
       process.exit(1);
     });
 }

--- a/api/src/database/schema/backtests.ts
+++ b/api/src/database/schema/backtests.ts
@@ -1,33 +1,55 @@
-import { pgTable, varchar, timestamp, jsonb } from 'drizzle-orm/pg-core';
-import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
-import { createId } from '@paralleldrive/cuid2';
-import { usersTable, usersTableSqlite } from './users';
-import { customBotsTable, customBotsTableSqlite } from './custom-bots';
+import { pgTable, varchar, timestamp, jsonb } from "drizzle-orm/pg-core";
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+import { createId } from "@paralleldrive/cuid2";
+import { usersTable, usersTableSqlite } from "./users";
+import { customBotsTable, customBotsTableSqlite } from "./custom-bots";
 
 // PostgreSQL Backtests table (matches original backtests collection)
-export const backtestsTable = pgTable('backtests', {
-  id: varchar('id', { length: 255 }).primaryKey().$defaultFn(() => createId()),
-  userId: varchar('user_id', { length: 255 }).notNull().references(() => usersTable.id, { onDelete: 'cascade' }),
-  customBotId: varchar('custom_bot_id', { length: 255 }).notNull().references(() => customBotsTable.id, { onDelete: 'cascade' }),
-  name: varchar('name', { length: 255 }).notNull(),
-  config: jsonb('config').$type<Record<string, any>>().notNull(), // backtest configuration
-  analysis: jsonb('analysis').$type<Record<string, any>>(), // results analysis - optional
-  status: varchar('status', { length: 50 }).notNull(), // backtest status
-  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+export const backtestsTable = pgTable("backtests", {
+  id: varchar("id", { length: 255 })
+    .primaryKey()
+    .$defaultFn(() => createId()),
+  userId: varchar("user_id", { length: 255 })
+    .notNull()
+    .references(() => usersTable.id, { onDelete: "cascade" }),
+  customBotId: varchar("custom_bot_id", { length: 255 })
+    .notNull()
+    .references(() => customBotsTable.id, { onDelete: "cascade" }),
+  name: varchar("name", { length: 255 }).notNull(),
+  config: jsonb("config").$type<Record<string, any>>().notNull(), // backtest configuration
+  analysis: jsonb("analysis").$type<Record<string, any>>(), // results analysis - optional
+  status: varchar("status", { length: 50 }).notNull(), // backtest status
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
 });
 
 // SQLite Backtests table
-export const backtestsTableSqlite = sqliteTable('backtests', {
-  id: text('id').primaryKey().$defaultFn(() => createId()),
-  userId: text('user_id').notNull().references(() => usersTableSqlite.id, { onDelete: 'cascade' }),
-  customBotId: text('custom_bot_id').notNull().references(() => customBotsTableSqlite.id, { onDelete: 'cascade' }),
-  name: text('name').notNull(),
-  config: text('config', { mode: 'json' }).$type<Record<string, any>>().notNull(),
-  analysis: text('analysis', { mode: 'json' }).$type<Record<string, any>>(),
-  status: text('status').notNull(),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
+export const backtestsTableSqlite = sqliteTable("backtests", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => createId()),
+  userId: text("user_id")
+    .notNull()
+    .references(() => usersTableSqlite.id, { onDelete: "cascade" }),
+  customBotId: text("custom_bot_id")
+    .notNull()
+    .references(() => customBotsTableSqlite.id, { onDelete: "cascade" }),
+  name: text("name").notNull(),
+  config: text("config", { mode: "json" })
+    .$type<Record<string, any>>()
+    .notNull(),
+  analysis: text("analysis", { mode: "json" }).$type<Record<string, any>>(),
+  status: text("status").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
 });
 
 export type Backtest = typeof backtestsTable.$inferSelect;

--- a/api/src/database/schema/bots.ts
+++ b/api/src/database/schema/bots.ts
@@ -1,31 +1,53 @@
-import { pgTable, varchar, timestamp, jsonb } from 'drizzle-orm/pg-core';
-import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
-import { createId } from '@paralleldrive/cuid2';
-import { usersTable, usersTableSqlite } from './users';
-import { customBotsTable, customBotsTableSqlite } from './custom-bots';
+import { pgTable, varchar, timestamp, jsonb } from "drizzle-orm/pg-core";
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+import { createId } from "@paralleldrive/cuid2";
+import { usersTable, usersTableSqlite } from "./users";
+import { customBotsTable, customBotsTableSqlite } from "./custom-bots";
 
 // PostgreSQL Bots table (matches original bots collection - running bot instances)
-export const botsTable = pgTable('bots', {
-  id: varchar('id', { length: 255 }).primaryKey().$defaultFn(() => createId()),
-  userId: varchar('user_id', { length: 255 }).notNull().references(() => usersTable.id, { onDelete: 'cascade' }),
-  customBotId: varchar('custom_bot_id', { length: 255 }).notNull().references(() => customBotsTable.id, { onDelete: 'cascade' }),
-  name: varchar('name', { length: 255 }).notNull(),
-  config: jsonb('config').$type<Record<string, any>>().notNull(), // runtime configuration
-  topic: varchar('topic', { length: 255 }), // message queue topic
-  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+export const botsTable = pgTable("bots", {
+  id: varchar("id", { length: 255 })
+    .primaryKey()
+    .$defaultFn(() => createId()),
+  userId: varchar("user_id", { length: 255 })
+    .notNull()
+    .references(() => usersTable.id, { onDelete: "cascade" }),
+  customBotId: varchar("custom_bot_id", { length: 255 })
+    .notNull()
+    .references(() => customBotsTable.id, { onDelete: "cascade" }),
+  name: varchar("name", { length: 255 }).notNull(),
+  config: jsonb("config").$type<Record<string, any>>().notNull(), // runtime configuration
+  topic: varchar("topic", { length: 255 }), // message queue topic
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
 });
 
 // SQLite Bots table
-export const botsTableSqlite = sqliteTable('bots', {
-  id: text('id').primaryKey().$defaultFn(() => createId()),
-  userId: text('user_id').notNull().references(() => usersTableSqlite.id, { onDelete: 'cascade' }),
-  customBotId: text('custom_bot_id').notNull().references(() => customBotsTableSqlite.id, { onDelete: 'cascade' }),
-  name: text('name').notNull(),
-  config: text('config', { mode: 'json' }).$type<Record<string, any>>().notNull(),
-  topic: text('topic'),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
+export const botsTableSqlite = sqliteTable("bots", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => createId()),
+  userId: text("user_id")
+    .notNull()
+    .references(() => usersTableSqlite.id, { onDelete: "cascade" }),
+  customBotId: text("custom_bot_id")
+    .notNull()
+    .references(() => customBotsTableSqlite.id, { onDelete: "cascade" }),
+  name: text("name").notNull(),
+  config: text("config", { mode: "json" })
+    .$type<Record<string, any>>()
+    .notNull(),
+  topic: text("topic"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
 });
 
 export type Bot = typeof botsTable.$inferSelect;

--- a/api/src/database/schema/custom-bots.ts
+++ b/api/src/database/schema/custom-bots.ts
@@ -1,15 +1,15 @@
-import { pgTable, varchar, timestamp, jsonb } from 'drizzle-orm/pg-core';
-import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
-import { createId } from '@paralleldrive/cuid2';
-import { usersTable, usersTableSqlite } from './users';
+import { pgTable, varchar, timestamp, jsonb } from "drizzle-orm/pg-core";
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+import { createId } from "@paralleldrive/cuid2";
+import { usersTable, usersTableSqlite } from "./users";
 
 // Types matching original theo-api exactly
 export interface CustomBotConfig {
   name: string;
   description: string;
   version: string;
-  type: 'scheduled' | 'realtime' | 'event';
-  runtime: 'python3.11' | 'nodejs20';
+  type: "scheduled" | "realtime" | "event";
+  runtime: "python3.11" | "nodejs20";
   author: string;
   entrypoints: {
     bot: string;
@@ -43,36 +43,62 @@ export interface MarketplaceMetadata {
   lastUpdated?: Date;
 }
 
-export type CustomBotStatus = 'approved' | 'declined' | 'awaiting_human_review' | 'pending_review' | 'published';
+export type CustomBotStatus =
+  | "approved"
+  | "declined"
+  | "awaiting_human_review"
+  | "pending_review"
+  | "published";
 
 // PostgreSQL Custom Bots table (matches original custom-bots collection)
-export const customBotsTable = pgTable('custom_bots', {
-  id: varchar('id', { length: 255 }).primaryKey().$defaultFn(() => createId()),
-  userId: varchar('user_id', { length: 255 }).notNull().references(() => usersTable.id, { onDelete: 'cascade' }),
-  name: varchar('name', { length: 255 }).notNull(), // revision key
-  version: varchar('version', { length: 50 }).notNull(), // semver format
-  config: jsonb('config').$type<CustomBotConfig>().notNull(),
-  filePath: varchar('file_path', { length: 500 }), // Local file storage path
-  status: varchar('status', { length: 50 }).default('pending_review').notNull().$type<CustomBotStatus>(),
-  review: jsonb('review'), // Security analysis results from 0vers33r
-  marketplace: jsonb('marketplace').$type<MarketplaceMetadata>(),
-  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+export const customBotsTable = pgTable("custom_bots", {
+  id: varchar("id", { length: 255 })
+    .primaryKey()
+    .$defaultFn(() => createId()),
+  userId: varchar("user_id", { length: 255 })
+    .notNull()
+    .references(() => usersTable.id, { onDelete: "cascade" }),
+  name: varchar("name", { length: 255 }).notNull(), // revision key
+  version: varchar("version", { length: 50 }).notNull(), // semver format
+  config: jsonb("config").$type<CustomBotConfig>().notNull(),
+  filePath: varchar("file_path", { length: 500 }), // Local file storage path
+  status: varchar("status", { length: 50 })
+    .default("pending_review")
+    .notNull()
+    .$type<CustomBotStatus>(),
+  review: jsonb("review"), // Security analysis results from 0vers33r
+  marketplace: jsonb("marketplace").$type<MarketplaceMetadata>(),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
 });
 
 // SQLite Custom Bots table
-export const customBotsTableSqlite = sqliteTable('custom_bots', {
-  id: text('id').primaryKey().$defaultFn(() => createId()),
-  userId: text('user_id').notNull().references(() => usersTableSqlite.id, { onDelete: 'cascade' }),
-  name: text('name').notNull(),
-  version: text('version').notNull(),
-  config: text('config', { mode: 'json' }).$type<CustomBotConfig>().notNull(),
-  filePath: text('file_path'),
-  status: text('status').default('pending_review').notNull(),
-  review: text('review', { mode: 'json' }), // Security analysis results from 0vers33r
-  marketplace: text('marketplace', { mode: 'json' }).$type<MarketplaceMetadata>(),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
+export const customBotsTableSqlite = sqliteTable("custom_bots", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => createId()),
+  userId: text("user_id")
+    .notNull()
+    .references(() => usersTableSqlite.id, { onDelete: "cascade" }),
+  name: text("name").notNull(),
+  version: text("version").notNull(),
+  config: text("config", { mode: "json" }).$type<CustomBotConfig>().notNull(),
+  filePath: text("file_path"),
+  status: text("status").default("pending_review").notNull(),
+  review: text("review", { mode: "json" }), // Security analysis results from 0vers33r
+  marketplace: text("marketplace", {
+    mode: "json",
+  }).$type<MarketplaceMetadata>(),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
 });
 
 export type CustomBot = typeof customBotsTable.$inferSelect;

--- a/api/src/database/schema/index.ts
+++ b/api/src/database/schema/index.ts
@@ -1,7 +1,7 @@
 // Re-export all schema tables and types
-export * from './users';
-export * from './custom-bots';
+export * from "./users";
+export * from "./custom-bots";
 // Logs are stored in external storage (MinIO/S3), not in database
 
 // Re-export connection utilities
-export { getDatabase, getDatabaseConfig, schema } from '../connection';
+export { getDatabase, getDatabaseConfig, schema } from "../connection";

--- a/api/src/database/schema/users.ts
+++ b/api/src/database/schema/users.ts
@@ -1,61 +1,99 @@
-import { pgTable, varchar, timestamp, boolean, jsonb } from 'drizzle-orm/pg-core';
-import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
-import { createId } from '@paralleldrive/cuid2';
+import {
+  pgTable,
+  varchar,
+  timestamp,
+  boolean,
+  jsonb,
+} from "drizzle-orm/pg-core";
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+import { createId } from "@paralleldrive/cuid2";
 
 // PostgreSQL Users table (matches original users collection)
-export const usersTable = pgTable('users', {
-  id: varchar('id', { length: 255 }).primaryKey().$defaultFn(() => createId()),
-  username: varchar('username', { length: 255 }).notNull().unique(),
-  email: varchar('email', { length: 255 }).notNull().unique(),
-  passwordHash: varchar('password_hash', { length: 255 }).notNull(),
-  firstName: varchar('first_name', { length: 255 }),
-  lastName: varchar('last_name', { length: 255 }),
-  isActive: boolean('is_active').default(true).notNull(),
-  isEmailVerified: boolean('is_email_verified').default(false).notNull(),
-  lastLoginAt: timestamp('last_login_at', { withTimezone: true }),
-  metadata: jsonb('metadata').$type<Record<string, any>>().default({}),
-  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+export const usersTable = pgTable("users", {
+  id: varchar("id", { length: 255 })
+    .primaryKey()
+    .$defaultFn(() => createId()),
+  username: varchar("username", { length: 255 }).notNull().unique(),
+  email: varchar("email", { length: 255 }).notNull().unique(),
+  passwordHash: varchar("password_hash", { length: 255 }).notNull(),
+  firstName: varchar("first_name", { length: 255 }),
+  lastName: varchar("last_name", { length: 255 }),
+  isActive: boolean("is_active").default(true).notNull(),
+  isEmailVerified: boolean("is_email_verified").default(false).notNull(),
+  lastLoginAt: timestamp("last_login_at", { withTimezone: true }),
+  metadata: jsonb("metadata").$type<Record<string, any>>().default({}),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
 });
 
-// SQLite Users table  
-export const usersTableSqlite = sqliteTable('users', {
-  id: text('id').primaryKey().$defaultFn(() => createId()),
-  username: text('username').notNull().unique(),
-  email: text('email').notNull().unique(),
-  passwordHash: text('password_hash').notNull(),
-  firstName: text('first_name'),
-  lastName: text('last_name'),
-  isActive: integer('is_active', { mode: 'boolean' }).default(true).notNull(),
-  isEmailVerified: integer('is_email_verified', { mode: 'boolean' }).default(false).notNull(),
-  lastLoginAt: integer('last_login_at', { mode: 'timestamp' }),
-  metadata: text('metadata', { mode: 'json' }).$type<Record<string, any>>().default({}),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
+// SQLite Users table
+export const usersTableSqlite = sqliteTable("users", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => createId()),
+  username: text("username").notNull().unique(),
+  email: text("email").notNull().unique(),
+  passwordHash: text("password_hash").notNull(),
+  firstName: text("first_name"),
+  lastName: text("last_name"),
+  isActive: integer("is_active", { mode: "boolean" }).default(true).notNull(),
+  isEmailVerified: integer("is_email_verified", { mode: "boolean" })
+    .default(false)
+    .notNull(),
+  lastLoginAt: integer("last_login_at", { mode: "timestamp" }),
+  metadata: text("metadata", { mode: "json" })
+    .$type<Record<string, any>>()
+    .default({}),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
 });
 
 // PostgreSQL API Keys table
-export const apiKeysTable = pgTable('api_keys', {
-  id: varchar('id', { length: 255 }).primaryKey().$defaultFn(() => createId()),
-  userId: varchar('user_id', { length: 255 }).notNull().references(() => usersTable.id, { onDelete: 'cascade' }),
-  name: varchar('name', { length: 255 }).notNull(),
-  keyValue: varchar('key_value', { length: 255 }).notNull(),
-  isActive: boolean('is_active').default(true).notNull(),
-  lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
-  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+export const apiKeysTable = pgTable("api_keys", {
+  id: varchar("id", { length: 255 })
+    .primaryKey()
+    .$defaultFn(() => createId()),
+  userId: varchar("user_id", { length: 255 })
+    .notNull()
+    .references(() => usersTable.id, { onDelete: "cascade" }),
+  name: varchar("name", { length: 255 }).notNull(),
+  keyValue: varchar("key_value", { length: 255 }).notNull(),
+  isActive: boolean("is_active").default(true).notNull(),
+  lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
 });
 
 // SQLite API Keys table
-export const apiKeysTableSqlite = sqliteTable('api_keys', {
-  id: text('id').primaryKey().$defaultFn(() => createId()),
-  userId: text('user_id').notNull().references(() => usersTableSqlite.id, { onDelete: 'cascade' }),
-  name: text('name').notNull(),
-  keyValue: text('key_value').notNull(),
-  isActive: integer('is_active', { mode: 'boolean' }).default(true).notNull(),
-  lastUsedAt: integer('last_used_at', { mode: 'timestamp' }),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
+export const apiKeysTableSqlite = sqliteTable("api_keys", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => createId()),
+  userId: text("user_id")
+    .notNull()
+    .references(() => usersTableSqlite.id, { onDelete: "cascade" }),
+  name: text("name").notNull(),
+  keyValue: text("key_value").notNull(),
+  isActive: integer("is_active", { mode: "boolean" }).default(true).notNull(),
+  lastUsedAt: integer("last_used_at", { mode: "timestamp" }),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
 });
 
 export type User = typeof usersTable.$inferSelect;

--- a/api/src/database/seed.ts
+++ b/api/src/database/seed.ts
@@ -1,39 +1,39 @@
-import { getDatabase, getDatabaseConfig } from './connection';
-import { usersTable, usersTableSqlite } from './schema/users';
-import { hash } from 'bcrypt';
-import { createId } from '@paralleldrive/cuid2';
+import { getDatabase, getDatabaseConfig } from "./connection";
+import { usersTable, usersTableSqlite } from "./schema/users";
+import { hash } from "bcrypt";
+import { createId } from "@paralleldrive/cuid2";
 
 async function seedDatabase() {
   const config = getDatabaseConfig();
   const db = getDatabase();
-  
+
   console.log(`Seeding ${config.type} database...`);
 
   try {
     // Create default admin user
-    const adminPasswordHash = await hash('admin123', 10);
+    const adminPasswordHash = await hash("admin123", 10);
     const adminUser = {
       id: createId(),
-      username: 'admin',
-      email: 'admin@the0.local',
+      username: "admin",
+      email: "admin@the0.local",
       passwordHash: adminPasswordHash,
-      firstName: 'Admin',
-      lastName: 'User',
+      firstName: "Admin",
+      lastName: "User",
       isActive: true,
       isEmailVerified: true,
-      metadata: { role: 'admin', createdBy: 'seed' },
+      metadata: { role: "admin", createdBy: "seed" },
     };
 
-    if (config.type === 'sqlite') {
+    if (config.type === "sqlite") {
       await db.insert(usersTableSqlite).values(adminUser).onConflictDoNothing();
     } else {
       await db.insert(usersTable).values(adminUser).onConflictDoNothing();
     }
 
-    console.log('✅ Admin user created: admin@the0.local / admin123');
-    console.log('✅ Database seeding completed successfully');
+    console.log("✅ Admin user created: admin@the0.local / admin123");
+    console.log("✅ Database seeding completed successfully");
   } catch (error) {
-    console.error('❌ Database seeding failed:', error);
+    console.error("❌ Database seeding failed:", error);
     process.exit(1);
   }
 }
@@ -42,11 +42,11 @@ async function seedDatabase() {
 if (require.main === module) {
   seedDatabase()
     .then(() => {
-      console.log('🎉 Database seeding completed');
+      console.log("🎉 Database seeding completed");
       process.exit(0);
     })
     .catch((error) => {
-      console.error('❌ Seeding script failed:', error);
+      console.error("❌ Seeding script failed:", error);
       process.exit(1);
     });
 }

--- a/api/src/logs/dto/get-logs-query.dto.ts
+++ b/api/src/logs/dto/get-logs-query.dto.ts
@@ -1,5 +1,5 @@
-import { IsOptional, IsString, IsInt, Min, Max } from 'class-validator';
-import { Transform } from 'class-transformer';
+import { IsOptional, IsString, IsInt, Min, Max } from "class-validator";
+import { Transform } from "class-transformer";
 
 export class GetLogsQueryDto {
   @IsOptional()

--- a/api/src/logs/logs.controller.ts
+++ b/api/src/logs/logs.controller.ts
@@ -6,19 +6,19 @@ import {
   UseGuards,
   BadRequestException,
   NotFoundException,
-} from '@nestjs/common';
-import { LogsService } from './logs.service';
-import { GetLogsQueryDto } from './dto/get-logs-query.dto';
-import { AuthCombinedGuard } from '@/auth/auth-combined.guard';
+} from "@nestjs/common";
+import { LogsService } from "./logs.service";
+import { GetLogsQueryDto } from "./dto/get-logs-query.dto";
+import { AuthCombinedGuard } from "@/auth/auth-combined.guard";
 
-@Controller('logs')
+@Controller("logs")
 @UseGuards(AuthCombinedGuard)
 export class LogsController {
   constructor(private readonly logsService: LogsService) {}
 
-  @Get(':botId')
+  @Get(":botId")
   async getLogs(
-    @Param('botId') botId: string,
+    @Param("botId") botId: string,
     @Query() query: GetLogsQueryDto,
   ) {
     const result = await this.logsService.getLogs(botId, {
@@ -30,8 +30,8 @@ export class LogsController {
 
     if (!result.success) {
       if (
-        result.error?.includes('not found') ||
-        result.error?.includes('access denied')
+        result.error?.includes("not found") ||
+        result.error?.includes("access denied")
       ) {
         throw new NotFoundException(result.error);
       }
@@ -41,7 +41,7 @@ export class LogsController {
     return {
       success: true,
       data: result.data,
-      message: 'Logs retrieved successfully',
+      message: "Logs retrieved successfully",
     };
   }
 }

--- a/api/src/logs/logs.module.ts
+++ b/api/src/logs/logs.module.ts
@@ -1,9 +1,9 @@
-import { Module } from '@nestjs/common';
-import { LogsService } from './logs.service';
-import { LogsController } from './logs.controller';
-import { ConfigModule } from '@nestjs/config';
-import { BotModule } from '@/bot/bot.module';
-import { ApiKeyModule } from '@/api-key/api-key.module';
+import { Module } from "@nestjs/common";
+import { LogsService } from "./logs.service";
+import { LogsController } from "./logs.controller";
+import { ConfigModule } from "@nestjs/config";
+import { BotModule } from "@/bot/bot.module";
+import { ApiKeyModule } from "@/api-key/api-key.module";
 
 @Module({
   imports: [ConfigModule, BotModule, ApiKeyModule],

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,37 +1,38 @@
-import { ValidationPipe } from '@nestjs/common';
-import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
-import { runMigrations } from './database/migrate';
-
+import { ValidationPipe } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
+import { AppModule } from "./app.module";
+import { runMigrations } from "./database/migrate";
 
 async function bootstrap() {
   // Run database migrations before starting the application
-  console.log('🔄 Running database migrations...');
+  console.log("🔄 Running database migrations...");
   await runMigrations();
-  console.log('✅ Database migrations completed');
-  
+  console.log("✅ Database migrations completed");
+
   const app = await NestFactory.create(AppModule);
-  
+
   // Enable CORS for OSS version
   app.enableCors({
-    origin: process.env.FRONTEND_URL || 'http://localhost:3001',
+    origin: process.env.FRONTEND_URL || "http://localhost:3001",
     credentials: true,
   });
-  
+
   // Global validation pipe
-  app.useGlobalPipes(new ValidationPipe({
-    whitelist: true,
-    forbidNonWhitelisted: true,
-    transform: true,
-  }));
-  
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+
   const port = process.env.PORT || 3000;
-  await app.listen(port, '0.0.0.0');
-  
+  await app.listen(port, "0.0.0.0");
+
   console.log(`🚀 The0 API is running on port ${port}`);
 }
 
 bootstrap().catch((error) => {
-  console.error('Failed to start The0 API:', error);
+  console.error("Failed to start The0 API:", error);
   process.exit(1);
 });

--- a/api/src/nats/__tests__/nats.service.spec.ts
+++ b/api/src/nats/__tests__/nats.service.spec.ts
@@ -1,22 +1,22 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { ConfigService } from '@nestjs/config';
-import { NatsService } from '../nats.service';
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigService } from "@nestjs/config";
+import { NatsService } from "../nats.service";
 
 // Mock NATS at the top level to avoid hoisting issues
-jest.mock('nats', () => {
+jest.mock("nats", () => {
   const mockConnection = {
     isClosed: jest.fn().mockReturnValue(false),
     close: jest.fn().mockResolvedValue(undefined),
     jetstreamManager: jest.fn(),
     jetstream: jest.fn(),
     info: {
-      server_name: 'test-server',
-      version: '2.9.0',
-      go: '1.19.0',
-      host: 'localhost',
+      server_name: "test-server",
+      version: "2.9.0",
+      go: "1.19.0",
+      host: "localhost",
       port: 4222,
       max_payload: 1048576,
-      connect_urls: ['nats://localhost:4222'],
+      connect_urls: ["nats://localhost:4222"],
     },
   };
 
@@ -41,15 +41,15 @@ jest.mock('nats', () => {
       decode: jest.fn((data: Buffer) => data.toString()),
     }),
     RetentionPolicy: {
-      Limits: 'limits',
+      Limits: "limits",
     },
     StorageType: {
-      File: 'file',
+      File: "file",
     },
   };
 });
 
-describe('NatsService', () => {
+describe("NatsService", () => {
   let service: NatsService;
   let configService: ConfigService;
 
@@ -62,8 +62,8 @@ describe('NatsService', () => {
           useValue: {
             get: jest.fn((key: string) => {
               switch (key) {
-                case 'NATS_URLS':
-                  return 'nats://localhost:4222';
+                case "NATS_URLS":
+                  return "nats://localhost:4222";
                 default:
                   return undefined;
               }
@@ -85,62 +85,62 @@ describe('NatsService', () => {
     jest.clearAllMocks();
   });
 
-  describe('Connection Management', () => {
-    it('should connect to NATS on module init', async () => {
+  describe("Connection Management", () => {
+    it("should connect to NATS on module init", async () => {
       const isConnected = await service.isConnected();
       expect(isConnected).toBe(true);
     });
 
-    it('should disconnect from NATS on module destroy', async () => {
+    it("should disconnect from NATS on module destroy", async () => {
       await service.onModuleDestroy();
       const isConnected = await service.isConnected();
       expect(isConnected).toBe(false);
     });
 
-    it('should return connection info', async () => {
+    it("should return connection info", async () => {
       const result = await service.getConnectionInfo();
       expect(result.success).toBe(true);
       expect(result.data).toEqual({
-        server_name: 'test-server',
-        version: '2.9.0',
-        go: '1.19.0',
-        host: 'localhost',
+        server_name: "test-server",
+        version: "2.9.0",
+        go: "1.19.0",
+        host: "localhost",
         port: 4222,
         max_payload: 1048576,
-        connect_urls: ['nats://localhost:4222'],
+        connect_urls: ["nats://localhost:4222"],
       });
     });
   });
 
-  describe('Generic Publishing', () => {
-    it('should publish to any topic', async () => {
-      const topic = 'test-topic';
-      const payload = { id: '123', data: 'test' };
+  describe("Generic Publishing", () => {
+    it("should publish to any topic", async () => {
+      const topic = "test-topic";
+      const payload = { id: "123", data: "test" };
 
       const result = await service.publish(topic, payload);
 
       expect(result.success).toBe(true);
     });
 
-    it('should handle publish errors', async () => {
+    it("should handle publish errors", async () => {
       // This test requires access to the mock, so we'll skip detailed mock verification
       // and just test the general error handling path
-      const topic = 'test-topic';
-      const payload = { id: '123', data: 'test' };
+      const topic = "test-topic";
+      const payload = { id: "123", data: "test" };
 
       const result = await service.publish(topic, payload);
       // Since we can't easily mock the error in this setup, we'll just verify it doesn't throw
       expect(result).toBeDefined();
     });
 
-    it('should fail to publish when not connected', async () => {
+    it("should fail to publish when not connected", async () => {
       // Simulate disconnected state by destroying the service
       await service.onModuleDestroy();
-      
-      const result = await service.publish('test-topic', {});
-      
+
+      const result = await service.publish("test-topic", {});
+
       expect(result.success).toBe(false);
-      expect(result.error).toBe('NATS connection not established');
+      expect(result.error).toBe("NATS connection not established");
     });
   });
 });

--- a/api/src/nats/nats.module.ts
+++ b/api/src/nats/nats.module.ts
@@ -1,6 +1,6 @@
-import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
-import { NatsService } from './nats.service';
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { NatsService } from "./nats.service";
 
 @Module({
   imports: [ConfigModule],

--- a/api/src/nats/nats.service.ts
+++ b/api/src/nats/nats.service.ts
@@ -1,14 +1,20 @@
-import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { connect, NatsConnection, StringCodec, JetStreamManager, RetentionPolicy, StorageType } from 'nats';
-import { Result, Ok, Failure } from '@/common/result';
+import { Injectable, OnModuleDestroy, OnModuleInit } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import {
+  connect,
+  NatsConnection,
+  StringCodec,
+  JetStreamManager,
+  RetentionPolicy,
+  StorageType,
+} from "nats";
+import { Result, Ok, Failure } from "@/common/result";
 
 @Injectable()
 export class NatsService implements OnModuleInit, OnModuleDestroy {
   private connection: NatsConnection | null = null;
   private jetStreamManager: JetStreamManager | null = null;
   private readonly sc = StringCodec();
-
 
   constructor(private readonly configService: ConfigService) {}
 
@@ -23,8 +29,10 @@ export class NatsService implements OnModuleInit, OnModuleDestroy {
 
   private async connect(): Promise<void> {
     try {
-      const servers = this.configService.get<string>('NATS_URLS')?.split(',') || ['nats://localhost:4222'];
-      
+      const servers = this.configService
+        .get<string>("NATS_URLS")
+        ?.split(",") || ["nats://localhost:4222"];
+
       this.connection = await connect({
         servers,
         reconnect: true,
@@ -33,10 +41,10 @@ export class NatsService implements OnModuleInit, OnModuleDestroy {
       });
 
       this.jetStreamManager = await this.connection.jetstreamManager();
-      
-      console.log('✅ Connected to NATS server');
+
+      console.log("✅ Connected to NATS server");
     } catch (error) {
-      console.error('❌ Failed to connect to NATS:', error);
+      console.error("❌ Failed to connect to NATS:", error);
       throw error;
     }
   }
@@ -46,47 +54,52 @@ export class NatsService implements OnModuleInit, OnModuleDestroy {
       await this.connection.close();
       this.connection = null;
       this.jetStreamManager = null;
-      console.log('🔌 Disconnected from NATS server');
+      console.log("🔌 Disconnected from NATS server");
     }
   }
 
   private async setupStreams(): Promise<void> {
     if (!this.jetStreamManager) {
-      throw new Error('NATS JetStream manager not initialized');
+      throw new Error("NATS JetStream manager not initialized");
     }
 
     try {
       // Try to delete existing stream first to recreate with new configuration
       try {
-        await this.jetStreamManager.streams.delete('THE0_EVENTS');
-        console.log('🗑️ Deleted existing THE0_EVENTS stream');
+        await this.jetStreamManager.streams.delete("THE0_EVENTS");
+        console.log("🗑️ Deleted existing THE0_EVENTS stream");
       } catch (deleteError: any) {
-        if (!deleteError.message?.includes('stream not found')) {
-          console.warn('⚠️ Failed to delete existing stream:', deleteError.message);
+        if (!deleteError.message?.includes("stream not found")) {
+          console.warn(
+            "⚠️ Failed to delete existing stream:",
+            deleteError.message,
+          );
         }
       }
 
       // Create stream for specific event patterns (avoid wildcards that require no-ack)
       await this.jetStreamManager.streams.add({
-        name: 'THE0_EVENTS',
+        name: "THE0_EVENTS",
         subjects: [
-          'custom-bot.submitted',
-          'custom-bot.approved', 
-          'custom-bot.declined',
-          'the0.bot.created',
-          'the0.bot.updated',
-          'the0.bot.deleted',
-          'the0.backtest.created',
-          'the0.backtest.completed'
+          "custom-bot.submitted",
+          "custom-bot.approved",
+          "custom-bot.declined",
+          "custom-bot.awaiting-human-review",
+          "custom-bot.analysis-failed",
+          "the0.bot.created",
+          "the0.bot.updated",
+          "the0.bot.deleted",
+          "the0.backtest.created",
+          "the0.backtest.completed",
         ],
         retention: RetentionPolicy.Limits,
         max_age: 7 * 24 * 60 * 60 * 1000 * 1000000, // 7 days in nanoseconds
         storage: StorageType.File,
       });
 
-      console.log('📡 NATS JetStream streams initialized');
+      console.log("📡 NATS JetStream streams initialized");
     } catch (error: any) {
-      console.error('❌ Failed to setup NATS streams:', error);
+      console.error("❌ Failed to setup NATS streams:", error);
       throw error;
     }
   }
@@ -94,17 +107,17 @@ export class NatsService implements OnModuleInit, OnModuleDestroy {
   // Generic publish method - business logic handled by callers
   async publish(topic: string, payload: any): Promise<Result<void, string>> {
     if (!this.connection) {
-      return Failure('NATS connection not established');
+      return Failure("NATS connection not established");
     }
 
     try {
       // For backtest events, use regular NATS publishing (not JetStream)
-      if (topic.startsWith('the0.backtest.')) {
+      if (topic.startsWith("the0.backtest.")) {
         this.connection.publish(topic, this.sc.encode(JSON.stringify(payload)));
         console.log(`✅ Published to NATS topic: ${topic}`);
         return Ok(undefined);
       }
-      
+
       // For other events, use JetStream
       const jetStream = this.connection.jetstream();
       await jetStream.publish(topic, this.sc.encode(JSON.stringify(payload)), {
@@ -124,7 +137,7 @@ export class NatsService implements OnModuleInit, OnModuleDestroy {
 
   async getConnectionInfo(): Promise<Result<any, string>> {
     if (!this.connection) {
-      return Failure('NATS connection not established');
+      return Failure("NATS connection not established");
     }
 
     try {

--- a/api/src/test/bootstrap.ts
+++ b/api/src/test/bootstrap.ts
@@ -1,10 +1,10 @@
 // Mock MinIO for OSS version
-jest.mock('minio', () => ({
+jest.mock("minio", () => ({
   Client: jest.fn().mockImplementation(() => ({
     getObject: jest.fn().mockResolvedValue({
       on: jest.fn((event, callback) => {
-        if (event === 'data') callback(Buffer.from('test content'));
-        if (event === 'end') callback();
+        if (event === "data") callback(Buffer.from("test content"));
+        if (event === "end") callback();
       }),
     }),
     putObject: jest.fn().mockResolvedValue({}),
@@ -12,13 +12,13 @@ jest.mock('minio', () => ({
 }));
 
 // Mock NATS
-jest.mock('nats', () => ({
+jest.mock("nats", () => ({
   connect: jest.fn(),
   StringCodec: jest.fn(),
 }));
 
 // Mock Redis
-jest.mock('redis', () => ({
+jest.mock("redis", () => ({
   createClient: jest.fn().mockReturnValue({
     connect: jest.fn(),
     disconnect: jest.fn(),
@@ -29,8 +29,8 @@ jest.mock('redis', () => ({
 }));
 
 // Mock bcrypt
-jest.mock('bcrypt', () => ({
-  hash: jest.fn().mockResolvedValue('hashed_password'),
+jest.mock("bcrypt", () => ({
+  hash: jest.fn().mockResolvedValue("hashed_password"),
   compare: jest.fn().mockResolvedValue(true),
 }));
 
@@ -40,12 +40,16 @@ const createMockQuery = () => ({
   where: jest.fn().mockReturnThis(),
   orderBy: jest.fn().mockReturnThis(),
   limit: jest.fn().mockReturnThis(),
-  returning: jest.fn().mockResolvedValue([{ id: 'test-id', createdAt: new Date(), updatedAt: new Date() }]),
+  returning: jest
+    .fn()
+    .mockResolvedValue([
+      { id: "test-id", createdAt: new Date(), updatedAt: new Date() },
+    ]),
   then: jest.fn().mockResolvedValue([]),
 });
 
 // Mock database connection
-jest.mock('@/database/connection', () => ({
+jest.mock("@/database/connection", () => ({
   getDatabase: jest.fn().mockReturnValue({
     select: jest.fn().mockImplementation(() => createMockQuery()),
     insert: jest.fn().mockImplementation(() => ({
@@ -57,17 +61,43 @@ jest.mock('@/database/connection', () => ({
     delete: jest.fn().mockImplementation(() => createMockQuery()),
   }),
   getTables: jest.fn().mockReturnValue({
-    users: { id: 'id', userId: 'userId', email: 'email', passwordHash: 'passwordHash', createdAt: 'createdAt', updatedAt: 'updatedAt' },
-    apiKeys: { id: 'id', userId: 'userId', keyValue: 'keyValue', isActive: 'isActive', createdAt: 'createdAt', updatedAt: 'updatedAt', lastUsedAt: 'lastUsedAt' },
-    customBots: { id: 'id', userId: 'userId', name: 'name', version: 'version', createdAt: 'createdAt' },
-    userBots: { id: 'id', userId: 'userId', customBotId: 'customBotId', createdAt: 'createdAt' },
-    backtests: { id: 'id', userId: 'userId', createdAt: 'createdAt' },
-    botLogs: { id: 'id', userId: 'userId', createdAt: 'createdAt' },
-    botExecutions: { id: 'id', userId: 'userId', createdAt: 'createdAt' },
-    systemLogs: { id: 'id', createdAt: 'createdAt' },
+    users: {
+      id: "id",
+      userId: "userId",
+      email: "email",
+      passwordHash: "passwordHash",
+      createdAt: "createdAt",
+      updatedAt: "updatedAt",
+    },
+    apiKeys: {
+      id: "id",
+      userId: "userId",
+      keyValue: "keyValue",
+      isActive: "isActive",
+      createdAt: "createdAt",
+      updatedAt: "updatedAt",
+      lastUsedAt: "lastUsedAt",
+    },
+    customBots: {
+      id: "id",
+      userId: "userId",
+      name: "name",
+      version: "version",
+      createdAt: "createdAt",
+    },
+    userBots: {
+      id: "id",
+      userId: "userId",
+      customBotId: "customBotId",
+      createdAt: "createdAt",
+    },
+    backtests: { id: "id", userId: "userId", createdAt: "createdAt" },
+    botLogs: { id: "id", userId: "userId", createdAt: "createdAt" },
+    botExecutions: { id: "id", userId: "userId", createdAt: "createdAt" },
+    systemLogs: { id: "id", createdAt: "createdAt" },
   }),
   getDatabaseConfig: jest.fn().mockReturnValue({
-    type: 'sqlite',
-    url: ':memory:',
+    type: "sqlite",
+    url: ":memory:",
   }),
 }));

--- a/api/src/upload/upload.controller.ts
+++ b/api/src/upload/upload.controller.ts
@@ -5,64 +5,76 @@ import {
   HttpException,
   HttpStatus,
   Req,
-} from '@nestjs/common';
-import { Request } from 'express';
-import { StorageService } from '../custom-bot/storage.service';
+} from "@nestjs/common";
+import { Request } from "express";
+import { StorageService } from "../custom-bot/storage.service";
 
-@Controller('api/upload')
+@Controller("api/upload")
 export class UploadController {
   constructor(private readonly storageService: StorageService) {}
 
-  @Put(':token')
-  async uploadFile(
-    @Param('token') token: string,
-    @Req() req: Request,
-  ) {
+  @Put(":token")
+  async uploadFile(@Param("token") token: string, @Req() req: Request) {
     // Validate the upload token
     if (!token || token.length !== 64) {
-      throw new HttpException('Invalid upload token', HttpStatus.UNAUTHORIZED);
+      throw new HttpException("Invalid upload token", HttpStatus.UNAUTHORIZED);
     }
 
     // Check content type
-    if (req.headers['content-type'] !== 'application/zip') {
-      throw new HttpException('Only zip files are allowed', HttpStatus.BAD_REQUEST);
+    if (req.headers["content-type"] !== "application/zip") {
+      throw new HttpException(
+        "Only zip files are allowed",
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     // Validate upload token with storage service
     const tokenResult = await this.storageService.validateUploadToken(token);
     if (!tokenResult.success) {
-      throw new HttpException('Invalid or expired upload token', HttpStatus.UNAUTHORIZED);
+      throw new HttpException(
+        "Invalid or expired upload token",
+        HttpStatus.UNAUTHORIZED,
+      );
     }
 
     try {
       // Read the request body into a buffer
       const chunks: Buffer[] = [];
-      
+
       for await (const chunk of req) {
         chunks.push(chunk);
       }
-      
+
       const fileBuffer = Buffer.concat(chunks);
-      
+
       // Upload to MinIO using the token
-      const uploadResult = await this.storageService.uploadWithToken(token, fileBuffer);
-      
+      const uploadResult = await this.storageService.uploadWithToken(
+        token,
+        fileBuffer,
+      );
+
       if (!uploadResult.success) {
-        throw new HttpException(`Upload failed: ${uploadResult.error}`, HttpStatus.INTERNAL_SERVER_ERROR);
+        throw new HttpException(
+          `Upload failed: ${uploadResult.error}`,
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
       }
-      
+
       return {
         success: true,
-        message: 'File uploaded successfully',
+        message: "File uploaded successfully",
         file: {
-          filename: uploadResult.data.split('/').pop() || 'bot.zip',
-          originalName: 'bot.zip',
+          filename: uploadResult.data.split("/").pop() || "bot.zip",
+          originalName: "bot.zip",
           size: fileBuffer.length,
           path: uploadResult.data,
         },
       };
     } catch (error) {
-      throw new HttpException(`Upload failed: ${error.message}`, HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        `Upload failed: ${error.message}`,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 }

--- a/api/src/upload/upload.module.ts
+++ b/api/src/upload/upload.module.ts
@@ -1,7 +1,7 @@
-import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
-import { UploadController } from './upload.controller';
-import { StorageService } from '../custom-bot/storage.service';
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { UploadController } from "./upload.controller";
+import { StorageService } from "../custom-bot/storage.service";
 
 @Module({
   imports: [ConfigModule],

--- a/api/test/app.e2e-spec.ts
+++ b/api/test/app.e2e-spec.ts
@@ -1,9 +1,9 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
-import { AppModule } from '../src/app.module';
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import { AppModule } from "../src/app.module";
 
-describe('AppController (e2e)', () => {
+describe("AppController (e2e)", () => {
   let app: INestApplication;
 
   beforeEach(async () => {
@@ -15,10 +15,10 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
-  it('/ (GET)', () => {
+  it("/ (GET)", () => {
     return request(app.getHttpServer())
-      .get('/')
+      .get("/")
       .expect(200)
-      .expect('Hello World!');
+      .expect("Hello World!");
   });
 });


### PR DESCRIPTION
## Background

This PR fixes the following issue with nats jetstream

```
❌ Failed to setup custom bot event listeners: TypeError: Cannot read properties of undefined (reading 'ack_policy')
    at JetStreamClientImpl.<anonymous> (/app/node_modules/nats/lib/jetstream/jsclient.js:420:28)
    at Generator.next (<anonymous>)
    at /app/node_modules/nats/lib/jetstream/jsclient.js:22:71
    at new Promise (<anonymous>)
    at __awaiter (/app/node_modules/nats/lib/jetstream/jsclient.js:18:12)
    at JetStreamClientImpl._processOptions (/app/node_modules/nats/lib/jetstream/jsclient.js:382:16)
    at JetStreamClientImpl.<anonymous> (/app/node_modules/nats/lib/jetstream/jsclient.js:361:36)
    at Generator.next (<anonymous>)
    at /app/node_modules/nats/lib/jetstream/jsclient.js:22:71
    at new Promise (<anonymous>)
```

It does this by correctly setting up subscriptions

```
const reviewOpts = consumerOpts();
    reviewOpts.deliverTo("custom-bot-review-deliver");
    reviewOpts.manualAck();
    reviewOpts.queue("custom-bot-api-handlers");
    const reviewSub = await jetStream.subscribe(
      "custom-bot.awaiting-human-review",
      reviewOpts,
    );
````

Also this PR formats the code of the API to maintain coding standards


