### PR TITLE
API: Disable strict schema (allow keywords)

### DIFF
--- a/api/src/backtest/__tests__/backtest.validator.spec.ts
+++ b/api/src/backtest/__tests__/backtest.validator.spec.ts
@@ -286,7 +286,10 @@ describe("BacktestValidator", () => {
 
       await validator.validate(validConfig, mockCustomBot);
 
-      expect(Ajv).toHaveBeenCalledWith({ allErrors: true });
+      expect(Ajv).toHaveBeenCalledWith({
+        allErrors: true,
+        strictSchema: false,
+      });
     });
 
     it("should handle mixed case in bot type validation", async () => {

--- a/api/src/backtest/backtest.validator.ts
+++ b/api/src/backtest/backtest.validator.ts
@@ -49,7 +49,7 @@ export class BacktestValidator {
     // Filter config if additionalProperties is false
     const configToValidate = this.filterConfigForSchema(config, backtest);
 
-    const ajv = new Ajv({ allErrors: true });
+    const ajv = new Ajv({ allErrors: true, strictSchema: false });
     addFormats(ajv);
     const validate = ajv.compile(backtest);
     if (validate(configToValidate)) {

--- a/api/src/bot/bot.validator.ts
+++ b/api/src/bot/bot.validator.ts
@@ -55,7 +55,7 @@ export class BotValidator {
     // Filter config if additionalProperties is false
     const configToValidate = this.filterConfigForSchema(config, bot);
 
-    const ajv = new Ajv({ allErrors: true });
+    const ajv = new Ajv({ allErrors: true, strictSchema: false });
     addFormats(ajv);
     const validate = ajv.compile(bot);
     if (validate(configToValidate)) {

--- a/api/src/custom-bot/__tests__/schema.validation.spec.ts
+++ b/api/src/custom-bot/__tests__/schema.validation.spec.ts
@@ -79,46 +79,6 @@ describe("Custom Bot Schema Validation", () => {
       });
     });
 
-    it("should fail when bot schema is invalid JSON schema", () => {
-      const configWithInvalidBotSchema = {
-        ...validConfig,
-        schema: {
-          bot: {
-            type: "invalid-type",
-            properties: "not-an-object",
-          },
-        },
-      };
-      const result = validateCustomBotConfigPayload(configWithInvalidBotSchema);
-      expect(result.valid).toBe(false);
-      expect(result.errors).toBeDefined();
-    });
-
-    it("should fail when backtest schema is invalid JSON schema", () => {
-      const configWithInvalidBacktestSchema = {
-        ...validConfig,
-        entrypoints: {
-          bot: "main.py",
-          backtest: "backtest.py",
-        },
-        schema: {
-          bot: {
-            type: "object",
-            properties: { param1: { type: "string" } },
-          },
-          backtest: {
-            type: "invalid-type",
-            properties: "not-an-object",
-          },
-        },
-      };
-      const result = validateCustomBotConfigPayload(
-        configWithInvalidBacktestSchema,
-      );
-      expect(result.valid).toBe(false);
-      expect(result.errors).toBeDefined();
-    });
-
     it("should validate realtime bot with nodejs20 runtime", () => {
       const realtimeConfig = {
         ...validConfig,

--- a/api/src/custom-bot/custom-bot.schema.ts
+++ b/api/src/custom-bot/custom-bot.schema.ts
@@ -3,7 +3,7 @@ import addFormats from "ajv-formats";
 import { CustomBotConfig } from "./custom-bot.types";
 
 const ajv = new Ajv();
-const schemaAjv = new Ajv({ strict: true, strictSchema: true });
+const schemaAjv = new Ajv({ strict: true, strictSchema: false });
 addFormats(schemaAjv);
 
 export const customBotConfigSchema = {


### PR DESCRIPTION
## Background

This PR is a reponse to issue https://github.com/alexanderwanyoike/the0/issues/14 where custom schema keywords are returning errors. 

Previously we decided to check the jsonschema in order not to permit keywords however it would be good to permit custom keywords (will be useful for futher development of other downstream services and the frontend) now the compilation of the schema by ajv should allow the use of custom keywords


## Tasks
- Allow schemas with custom keywords