### PR TITLE
Fix agent documentation on backtesting

### DIFF
--- a/services/the0-ai/the0/tools/docs/custom-bot-development/backtesting.md
+++ b/services/the0-ai/the0/tools/docs/custom-bot-development/backtesting.md
@@ -123,7 +123,7 @@ Tabular data for detailed analysis:
 ### Python Structure
 
 ```python
-def backtest(id: str, config: dict) -> dict:
+def main(id: str, config: dict) -> dict:
     # Your backtesting logic here
 
     return {
@@ -176,7 +176,7 @@ import plotly.graph_objects as go
 import numpy as np
 from datetime import datetime, timedelta
 
-def backtest(id: str, config: dict) -> dict:
+def main(id: str, config: dict) -> dict:
   """
   Simple backtest implementation example
   """


### PR DESCRIPTION
This pull request makes a minor change to the Python code example in the backtesting documentation. The function name has been updated from `backtest` to `main` for consistency.

* Renamed the function `backtest` to `main` in the code examples in `backtesting.md`. [[1]](diffhunk://#diff-bd03c082cecc14a876e14694733a4409027a583771742c7addf78388ca15502bL126-R126) [[2]](diffhunk://#diff-bd03c082cecc14a876e14694733a4409027a583771742c7addf78388ca15502bL179-R179)