### PR TITLE
Add Scala 3 language support

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Scala 3 runtime support** - Added `scala3` to the Runtime type union for Scala bot deployment
 - **C/C++ GCC 13 runtime support** - Added `gcc13` to the Runtime type union for C/C++ bot deployment
 - **C# .NET 8 runtime support** - Added `dotnet8` to the Runtime type union for C# bot deployment
 - **Rust runtime support** - Added `rust-stable` to the Runtime type union for Rust bot deployment

--- a/api/src/custom-bot/custom-bot.types.ts
+++ b/api/src/custom-bot/custom-bot.types.ts
@@ -4,7 +4,7 @@ export const BOT_TYPES: BotType[] = ["scheduled", "realtime", "event"];
 
 export type CustomBotStatus = "active";
 
-export type Runtime = "python3.11" | "nodejs20" | "rust-stable" | "dotnet8" | "gcc13";
+export type Runtime = "python3.11" | "nodejs20" | "rust-stable" | "dotnet8" | "gcc13" | "scala3";
 
 export interface CustomBotConfig {
   name: string;

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Scala 3 language support** - Build Scala bots locally using Docker before deployment
+  - `ScalaBuilder` implementation of `LanguageBuilder` interface
+  - Detects `build.sbt` projects and builds with `sbt assembly`
+  - Uses `sbtscala/scala-sbt` Docker image for cross-platform builds
+  - Auto-configures sbt-assembly plugin if not present
 - **C/C++ GCC 13 language support** - Build C/C++ bots locally using Docker before deployment
   - `CppBuilder` implementation of `LanguageBuilder` interface
   - Detects `CMakeLists.txt` (priority) or `Makefile` projects

--- a/cli/internal/builder_scala.go
+++ b/cli/internal/builder_scala.go
@@ -1,0 +1,387 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
+	"github.com/fatih/color"
+)
+
+const scala3Image = "sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.7_3.3.7"
+
+// ScalaBuilder handles Scala 3 project detection and building.
+type ScalaBuilder struct{}
+
+func init() {
+	RegisterBuilder(&ScalaBuilder{})
+}
+
+// Name returns the language name for logging.
+func (b *ScalaBuilder) Name() string {
+	return "Scala 3"
+}
+
+// DockerImage returns the Docker image for Scala builds.
+func (b *ScalaBuilder) DockerImage() string {
+	return scala3Image
+}
+
+// Detect checks if build.sbt exists in the project.
+func (b *ScalaBuilder) Detect(projectPath string) bool {
+	buildSbt := filepath.Join(projectPath, "build.sbt")
+	if _, err := os.Stat(buildSbt); err == nil {
+		return true
+	}
+	return false
+}
+
+// ShouldBuild checks if Scala project needs building.
+func (b *ScalaBuilder) ShouldBuild(projectPath string) (bool, error) {
+	if !b.Detect(projectPath) {
+		return false, nil
+	}
+	return true, nil
+}
+
+// Build performs the Docker-based Scala build.
+func (b *ScalaBuilder) Build(vm *VendorManager) error {
+	blue := color.New(color.FgBlue)
+	green := color.New(color.FgGreen)
+
+	blue.Println("Building Scala project...")
+
+	// Ensure project has assembly plugin
+	if err := b.ensureAssemblyPlugin(vm.projectPath); err != nil {
+		return fmt.Errorf("failed to setup assembly plugin: %v", err)
+	}
+
+	// Pull Scala image if needed
+	if err := b.pullImage(vm); err != nil {
+		return fmt.Errorf("failed to pull Scala image: %v", err)
+	}
+
+	// Run build container
+	containerID, err := b.runBuildContainer(vm)
+	if err != nil {
+		return fmt.Errorf("failed to run Scala build container: %v", err)
+	}
+	defer vm.cleanupContainer(containerID)
+
+	// Verify output was created
+	binaryPath := b.FindBinary(vm.projectPath)
+	if binaryPath == "" {
+		return fmt.Errorf("Scala build did not produce output in target/scala-*/")
+	}
+
+	// Get binary info
+	binaryInfo, err := os.Stat(binaryPath)
+	if err != nil {
+		return fmt.Errorf("failed to stat JAR: %v", err)
+	}
+
+	sizeStr := vm.formatFileSize(binaryInfo.Size())
+	green.Printf("v Scala project built: %s (%s)\n", filepath.Base(binaryPath), sizeStr)
+	return nil
+}
+
+// FindBinary finds the built assembly JAR in target/scala-*/.
+func (b *ScalaBuilder) FindBinary(projectPath string) string {
+	targetDir := filepath.Join(projectPath, "target")
+
+	// Look for scala-* directories
+	entries, err := os.ReadDir(targetDir)
+	if err != nil {
+		return ""
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if !strings.HasPrefix(entry.Name(), "scala-") {
+			continue
+		}
+
+		scalaDir := filepath.Join(targetDir, entry.Name())
+		files, err := os.ReadDir(scalaDir)
+		if err != nil {
+			continue
+		}
+
+		// Look for assembly JAR
+		for _, file := range files {
+			if file.IsDir() {
+				continue
+			}
+			name := file.Name()
+			if strings.HasSuffix(name, "-assembly.jar") || strings.Contains(name, "-assembly") && strings.HasSuffix(name, ".jar") {
+				return filepath.Join(scalaDir, name)
+			}
+		}
+	}
+
+	return ""
+}
+
+// ensureAssemblyPlugin ensures the project has sbt-assembly plugin configured.
+func (b *ScalaBuilder) ensureAssemblyPlugin(projectPath string) error {
+	projectDir := filepath.Join(projectPath, "project")
+	pluginsFile := filepath.Join(projectDir, "plugins.sbt")
+
+	// Check if plugins.sbt exists
+	if _, err := os.Stat(pluginsFile); err == nil {
+		// File exists, check if it has assembly plugin
+		content, err := os.ReadFile(pluginsFile)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(string(content), "sbt-assembly") {
+			return nil // Already configured
+		}
+		// Append assembly plugin
+		f, err := os.OpenFile(pluginsFile, os.O_APPEND|os.O_WRONLY, 0644)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, err = f.WriteString("\naddSbtPlugin(\"com.eed3si9n\" % \"sbt-assembly\" % \"2.1.5\")\n")
+		return err
+	}
+
+	// Create project directory if needed
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		return err
+	}
+
+	// Create plugins.sbt with assembly plugin
+	content := `addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.5")
+`
+	return os.WriteFile(pluginsFile, []byte(content), 0644)
+}
+
+// pullImage pulls the Scala image if it doesn't exist locally.
+func (b *ScalaBuilder) pullImage(vm *VendorManager) error {
+	ctx := context.Background()
+
+	images, err := vm.dockerClient.ImageList(ctx, image.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	imageExists := false
+	for _, img := range images {
+		for _, tag := range img.RepoTags {
+			if tag == scala3Image {
+				imageExists = true
+				break
+			}
+		}
+		if imageExists {
+			break
+		}
+	}
+
+	if imageExists {
+		return nil
+	}
+
+	blue := color.New(color.FgBlue)
+	blue.Printf("Pulling Docker image: %s...\n", scala3Image)
+
+	reader, err := vm.dockerClient.ImagePull(ctx, scala3Image, image.PullOptions{})
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	io.Copy(io.Discard, reader)
+	return nil
+}
+
+// runBuildContainer creates and runs a container for Scala building.
+func (b *ScalaBuilder) runBuildContainer(vm *VendorManager) (string, error) {
+	ctx := context.Background()
+
+	ctrName := fmt.Sprintf("%sscala-%d", vendorContainerName, time.Now().Unix())
+
+	absProjectPath, err := filepath.Abs(vm.projectPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to get absolute project path: %v", err)
+	}
+
+	// Get current user info for ownership
+	currentUser, err := user.Current()
+	var uid, gid string
+	if err == nil {
+		uid = currentUser.Uid
+		gid = currentUser.Gid
+	} else {
+		uid = "1000"
+		gid = "1000"
+	}
+
+	// Build command: sbt assembly, then fix ownership
+	buildCmd := fmt.Sprintf(
+		"sbt assembly 2>&1; STATUS=$?; chown -R %s:%s /project/target /project/project/target 2>/dev/null || true; exit $STATUS",
+		uid, gid,
+	)
+
+	config := &container.Config{
+		Image: scala3Image,
+		Cmd: []string{
+			"bash", "-c",
+			buildCmd,
+		},
+		WorkingDir: "/project",
+		Env:        getScalaBuildEnvVars(),
+	}
+
+	hostConfig := &container.HostConfig{
+		Binds: []string{
+			fmt.Sprintf("%s:/project", absProjectPath),
+		},
+		AutoRemove: false,
+	}
+
+	resp, err := vm.dockerClient.ContainerCreate(ctx, config, hostConfig, nil, nil, ctrName)
+	if err != nil {
+		return "", err
+	}
+
+	if err := vm.dockerClient.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
+		return "", err
+	}
+
+	// Stream logs
+	logReader, err := vm.dockerClient.ContainerLogs(ctx, resp.ID, container.LogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+		Follow:     true,
+		Timestamps: false,
+	})
+	if err != nil {
+		return resp.ID, fmt.Errorf("failed to get container logs: %v", err)
+	}
+
+	logDone := make(chan struct{})
+	go func() {
+		defer close(logDone)
+		defer logReader.Close()
+
+		blue := color.New(color.FgBlue)
+		buffer := make([]byte, 1024)
+		for {
+			n, err := logReader.Read(buffer)
+			if err != nil {
+				if err != io.EOF {
+					blue.Printf("Log read error: %v\n", err)
+				}
+				break
+			}
+			if n > 0 {
+				output := vm.cleanDockerLogOutput(buffer[:n])
+				if output != "" {
+					blue.Printf("  %s", output)
+				}
+			}
+		}
+	}()
+
+	// Wait for container to finish
+	statusCh, errCh := vm.dockerClient.ContainerWait(ctx, resp.ID, container.WaitConditionNotRunning)
+	select {
+	case err := <-errCh:
+		if err != nil {
+			return resp.ID, err
+		}
+	case status := <-statusCh:
+		<-logDone
+		if status.StatusCode != 0 {
+			logs, _ := vm.getContainerLogs(resp.ID)
+			red := color.New(color.FgRed)
+			red.Printf("Scala build failed with exit code %d\n", status.StatusCode)
+			if logs != "" {
+				red.Printf("Full error log:\n%s\n", logs)
+			}
+			return resp.ID, fmt.Errorf("sbt assembly failed with exit code %d", status.StatusCode)
+		}
+	}
+
+	return resp.ID, nil
+}
+
+// getScalaBuildEnvVars returns environment variables for Scala build.
+func getScalaBuildEnvVars() []string {
+	secrets, err := LoadBuildSecrets()
+	if err != nil || secrets == nil {
+		return nil
+	}
+
+	var envVars []string
+	if secrets.GitHubToken != "" {
+		// Configure SBT to use GitHub token for private packages
+		envVars = append(envVars, fmt.Sprintf("GITHUB_TOKEN=%s", secrets.GitHubToken))
+	}
+	return envVars
+}
+
+// Legacy functions for backwards compatibility
+
+// IsScalaProject checks if the project is a Scala project.
+func IsScalaProject(projectPath string) bool {
+	builder := &ScalaBuilder{}
+	return builder.Detect(projectPath)
+}
+
+// ShouldBuildScala checks if Scala project needs building.
+func ShouldBuildScala(projectPath string) (bool, error) {
+	builder := &ScalaBuilder{}
+	return builder.ShouldBuild(projectPath)
+}
+
+// BuildScalaIfNeeded builds Scala project only if needed and Docker is available.
+func BuildScalaIfNeeded(projectPath string) error {
+	builder := &ScalaBuilder{}
+
+	shouldBuild, err := builder.ShouldBuild(projectPath)
+	if err != nil {
+		return err
+	}
+
+	if !shouldBuild {
+		return nil
+	}
+
+	blue := color.New(color.FgBlue)
+	red := color.New(color.FgRed)
+
+	blue.Println("Scala project detected, building...")
+
+	if err := CheckDockerInstalled(); err != nil {
+		red.Printf("Docker required for Scala build: %v\n", err)
+		red.Println("Solution: Install Docker or pre-build with 'sbt assembly'")
+		return fmt.Errorf("docker unavailable for Scala build")
+	}
+
+	vm, err := NewVendorManager(projectPath)
+	if err != nil {
+		return fmt.Errorf("failed to initialize vendor manager: %v", err)
+	}
+	defer vm.Close()
+
+	if err := vm.CheckDockerRunning(); err != nil {
+		red.Printf("Docker daemon not running: %v\n", err)
+		red.Println("Solution: Start Docker or pre-build with 'sbt assembly'")
+		return fmt.Errorf("docker daemon not running for Scala build")
+	}
+
+	return builder.Build(vm)
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Scala Quick Start Guide** - Complete guide for building Scala 3 trading bots with the0 SDK
+  - SDK installation and usage with `the0.Input` object
+  - SBT project structure and configuration examples
+  - Best practices for error handling, async programming, and logging
 - **C/C++ Quick Start Guide** - Complete guide for building C/C++ trading bots with the0
   - SDK installation and usage with `the0.h` header-only library
   - CMake and Makefile project setup examples

--- a/docs/custom-bot-development/scala-quick-start.md
+++ b/docs/custom-bot-development/scala-quick-start.md
@@ -1,0 +1,378 @@
+---
+title: "Scala Quick Start"
+description: "Build your first Scala 3 trading bot with the0"
+tags: ["custom-bots", "scala", "jvm", "quick-start"]
+order: 14
+---
+
+# Scala Quick Start Guide
+
+Build a trading bot in Scala 3 with the0's scala3 runtime.
+
+---
+
+## Prerequisites
+
+- Scala 3.x and SBT (for local development)
+- the0 CLI installed
+- Valid the0 API key
+
+---
+
+## Project Structure
+
+```
+my-scala-bot/
+├── build.sbt             # SBT project file
+├── project/
+│   ├── build.properties  # SBT version
+│   └── plugins.sbt       # sbt-assembly plugin
+├── src/main/scala/
+│   └── Main.scala        # Your bot entry point
+├── bot-config.yaml       # Bot configuration
+├── bot-schema.json       # Parameter schema
+└── README.md             # Documentation
+```
+
+---
+
+## Step 1: Create Your Project
+
+```bash
+mkdir my-scala-bot
+cd my-scala-bot
+mkdir -p src/main/scala project
+```
+
+---
+
+## Step 2: Create build.sbt
+
+```scala
+ThisBuild / scalaVersion := "3.3.3"
+ThisBuild / version := "1.0.0"
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "my-scala-bot",
+    assembly / mainClass := Some("Main"),
+    assembly / assemblyJarName := "my-scala-bot-assembly.jar"
+  )
+```
+
+---
+
+## Step 3: Configure SBT
+
+Create `project/build.properties`:
+
+```properties
+sbt.version=1.9.9
+```
+
+Create `project/plugins.sbt`:
+
+```scala
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.5")
+```
+
+---
+
+## Step 4: Write Your Bot
+
+Create `src/main/scala/Main.scala`:
+
+```scala
+object Main extends App {
+  // Get bot configuration from environment
+  val botId = sys.env.getOrElse("BOT_ID", "unknown")
+  val config = sys.env.getOrElse("BOT_CONFIG", "{}")
+
+  System.err.println(s"Bot $botId starting...")
+  System.err.println(s"Config: $config")
+
+  // Your trading logic here
+  // Example: Parse config, fetch prices, execute trades
+
+  // Output success result
+  println("""{"status":"success","message":"Bot executed successfully"}""")
+}
+```
+
+---
+
+## Step 5: Using the SDK (Recommended)
+
+Copy the `the0` package from `sdk/scala/` for proper JSON handling:
+
+```scala
+import the0.Input
+
+object Main extends App {
+  val (botId, config) = Input.parse()
+
+  System.err.println(s"Bot $botId starting...")
+
+  // Your trading logic here
+
+  Input.success("Bot executed successfully")
+}
+```
+
+---
+
+## Step 6: Create Bot Configuration
+
+Create `bot-config.yaml`:
+
+```yaml
+name: my-scala-bot
+description: "A Scala trading bot"
+version: "1.0.0"
+author: "Your Name"
+type: scheduled
+runtime: scala3
+
+entrypoints:
+  bot: src/main/scala/Main.scala
+
+schema:
+  bot: bot-schema.json
+
+readme: README.md
+```
+
+---
+
+## Step 7: Define Parameter Schema
+
+Create `bot-schema.json`:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Bot Configuration",
+  "description": "Configuration for the Scala trading bot",
+  "properties": {
+    "symbol": {
+      "type": "string",
+      "title": "Trading Symbol",
+      "description": "The trading pair symbol",
+      "default": "BTC/USDT"
+    },
+    "amount": {
+      "type": "number",
+      "title": "Trade Amount",
+      "description": "Amount to trade per execution",
+      "default": 100
+    }
+  },
+  "required": ["symbol"]
+}
+```
+
+---
+
+## Step 8: Deploy
+
+```bash
+# Deploy your bot
+the0 custom-bot deploy
+```
+
+The build happens automatically in Docker - no need to compile locally!
+
+---
+
+## SDK API Reference
+
+The `the0.Input` object provides these functions:
+
+### `Input.parse(): (String, String)`
+
+Parse bot configuration from environment variables.
+
+```scala
+val (botId, config) = Input.parse()
+// botId: Value of BOT_ID env var
+// config: JSON string from BOT_CONFIG
+```
+
+### `Input.success(message: String): Unit`
+
+Output a success result to stdout.
+
+```scala
+Input.success("Trade completed")
+// Outputs: {"status":"success","message":"Trade completed"}
+```
+
+### `Input.error(message: String): Nothing`
+
+Output an error result and exit with code 1.
+
+```scala
+Input.error("Failed to connect")
+// Outputs: {"status":"error","message":"Failed to connect"}
+// Exits with code 1
+```
+
+### `Input.result(status: String, message: String): Unit`
+
+Output a custom result with status and message.
+
+```scala
+Input.result("warning", "Rate limit approaching")
+```
+
+### `Input.resultRaw(json: String): Unit`
+
+Output a raw JSON string to stdout.
+
+```scala
+Input.resultRaw("""{"status":"success","trade_id":"abc123"}""")
+```
+
+---
+
+## Example: HTTP Request Bot
+
+Using sttp for HTTP requests:
+
+```scala
+import the0.Input
+import sttp.client3._
+
+object Main extends App {
+  val (botId, config) = Input.parse()
+  System.err.println(s"Bot $botId fetching data...")
+
+  val backend = HttpClientSyncBackend()
+
+  val response = basicRequest
+    .get(uri"https://api.example.com/price")
+    .send(backend)
+
+  response.body match {
+    case Right(body) =>
+      System.err.println(s"Response: $body")
+      Input.success("Data fetched successfully")
+    case Left(error) =>
+      Input.error(s"Request failed: $error")
+  }
+}
+```
+
+Add to `build.sbt`:
+
+```scala
+libraryDependencies += "com.softwaremill.sttp.client3" %% "core" % "3.9.3"
+```
+
+---
+
+## Example: JSON Parsing with Circe
+
+```scala
+import the0.Input
+import io.circe.parser._
+
+object Main extends App {
+  val (botId, configJson) = Input.parse()
+
+  parse(configJson) match {
+    case Right(json) =>
+      val symbol = json.hcursor.get[String]("symbol").getOrElse("BTC/USDT")
+      val amount = json.hcursor.get[Double]("amount").getOrElse(100.0)
+
+      System.err.println(s"Trading $symbol with amount $amount")
+
+      // Your trading logic here
+
+      Input.success(s"Trade completed for $symbol")
+
+    case Left(error) =>
+      Input.error(s"Failed to parse config: ${error.message}")
+  }
+}
+```
+
+Add to `build.sbt`:
+
+```scala
+libraryDependencies ++= Seq(
+  "io.circe" %% "circe-core" % "0.14.6",
+  "io.circe" %% "circe-parser" % "0.14.6"
+)
+```
+
+---
+
+## Best Practices
+
+### Error Handling
+
+Use Try for robust error handling:
+
+```scala
+import the0.Input
+import scala.util.{Try, Success, Failure}
+
+object Main extends App {
+  Try {
+    val (botId, config) = Input.parse()
+
+    if (botId.isEmpty) {
+      throw new IllegalArgumentException("Bot ID is required")
+    }
+
+    // Your trading logic here
+
+    Input.success("Bot executed successfully")
+  } match {
+    case Success(_) => // Already handled
+    case Failure(e) => Input.error(e.getMessage)
+  }
+}
+```
+
+### Logging
+
+Use stderr for logs (stdout is reserved for JSON output):
+
+```scala
+System.err.println("DEBUG: Processing trade...")  // Logs
+println("{...}")  // Reserved for JSON result - use Input methods instead
+```
+
+### Async Operations with Futures
+
+```scala
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import the0.Input
+
+object Main extends App {
+  val (botId, config) = Input.parse()
+
+  val result = Await.result(
+    Future {
+      // Async trading logic
+      "Trade completed"
+    },
+    30.seconds
+  )
+
+  Input.success(result)
+}
+```
+
+---
+
+## Related Documentation
+
+- [Configuration Reference](/custom-bot-development/configuration)
+- [Bot Types](/custom-bot-development/bot-types)
+- [Deployment Guide](/custom-bot-development/deployment)

--- a/runtime/internal/docker-runner/docker_runner.go
+++ b/runtime/internal/docker-runner/docker_runner.go
@@ -181,7 +181,7 @@ func NewDockerRunner(options DockerRunnerOptions) (*dockerRunner, error) {
 }
 
 func (r *dockerRunner) isValidRuntime(runtime string) bool {
-	validRuntimes := []string{"python3.11", "nodejs20", "rust-stable", "dotnet8", "gcc13"}
+	validRuntimes := []string{"python3.11", "nodejs20", "rust-stable", "dotnet8", "gcc13", "scala3"}
 	for _, valid := range validRuntimes {
 		if runtime == valid {
 			return true
@@ -202,6 +202,8 @@ func (r *dockerRunner) getDockerImage(runtime string) string {
 		return "mcr.microsoft.com/dotnet/runtime:8.0"
 	case "gcc13":
 		return "gcc:13"
+	case "scala3":
+		return "eclipse-temurin:21-jre"
 	default:
 		return "python:3.11-slim" // fallback
 	}

--- a/runtime/internal/docker-runner/entrypoints/code_entrypoint_factory.go
+++ b/runtime/internal/docker-runner/entrypoints/code_entrypoint_factory.go
@@ -32,6 +32,8 @@ func (f *codeEntrypointFactory) GetCode() (string, error) {
 			return Dotnet8BotEntrypoint, nil
 		case "gcc13":
 			return Gcc13BotEntrypoint, nil
+		case "scala3":
+			return Scala3BotEntrypoint, nil
 		}
 	}
 	return "", fmt.Errorf("unsupported entry point type or runtime: %s, %s", f.entryPointType, f.runtime)

--- a/runtime/internal/docker-runner/entrypoints/scala3.go
+++ b/runtime/internal/docker-runner/entrypoints/scala3.go
@@ -1,0 +1,6 @@
+package entrypoints
+
+// Scala3BotEntrypoint is an empty placeholder for Scala 3 bots.
+// Scala bots are pre-built by the CLI, so no code wrapper is needed.
+// The bash entrypoint in bash_entrypoint_factory.go handles execution.
+const Scala3BotEntrypoint = ""

--- a/runtime/internal/fixtures/scala-test-bot/.gitignore
+++ b/runtime/internal/fixtures/scala-test-bot/.gitignore
@@ -1,0 +1,36 @@
+# Scala/SBT
+target/
+.target/
+dist/
+build/
+.cache
+.history
+.lib/
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+.scala_dependencies
+.worksheet
+
+# IDE
+.idea/
+.idea_modules/
+*.iml
+.vscode/
+.metals/
+.bloop/
+.bsp/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Misc
+*.swp
+*.swo
+*~
+.env
+.env.local

--- a/runtime/internal/fixtures/scala-test-bot/build.sbt
+++ b/runtime/internal/fixtures/scala-test-bot/build.sbt
@@ -1,0 +1,9 @@
+ThisBuild / scalaVersion := "3.3.3"
+ThisBuild / version := "1.0.0"
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "scala-test-bot",
+    assembly / mainClass := Some("Main"),
+    assembly / assemblyJarName := "scala-test-bot-assembly.jar"
+  )

--- a/runtime/internal/fixtures/scala-test-bot/project/build.properties
+++ b/runtime/internal/fixtures/scala-test-bot/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.9

--- a/runtime/internal/fixtures/scala-test-bot/project/plugins.sbt
+++ b/runtime/internal/fixtures/scala-test-bot/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.5")

--- a/runtime/internal/fixtures/scala-test-bot/src/main/scala/Main.scala
+++ b/runtime/internal/fixtures/scala-test-bot/src/main/scala/Main.scala
@@ -1,0 +1,10 @@
+object Main extends App {
+  val botId = sys.env.getOrElse("BOT_ID", "unknown")
+  val config = sys.env.getOrElse("BOT_CONFIG", "{}")
+
+  System.err.println(s"BOT_ID: $botId")
+  System.err.println(s"BOT_CONFIG: $config")
+
+  // Output success JSON
+  println(s"""{"status":"success","message":"Scala bot executed","bot_id":"$botId"}""")
+}

--- a/sdk/scala/.gitignore
+++ b/sdk/scala/.gitignore
@@ -1,0 +1,36 @@
+# Scala/SBT
+target/
+.target/
+dist/
+build/
+.cache
+.history
+.lib/
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+.scala_dependencies
+.worksheet
+
+# IDE
+.idea/
+.idea_modules/
+*.iml
+.vscode/
+.metals/
+.bloop/
+.bsp/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Misc
+*.swp
+*.swo
+*~
+.env
+.env.local

--- a/sdk/scala/README.md
+++ b/sdk/scala/README.md
@@ -1,0 +1,242 @@
+# the0 Scala SDK
+
+SDK for building trading bots on the0 platform in Scala 3.
+
+## Installation
+
+Add the SDK to your project by copying the `the0` package or adding it as a dependency.
+
+### Option 1: Copy the Package
+
+Copy `src/main/scala/the0/Input.scala` to your project's source directory.
+
+### Option 2: Local Dependency
+
+```sbt
+lazy val the0Sdk = ProjectRef(file("path/to/sdk/scala"), "root")
+
+lazy val root = (project in file("."))
+  .dependsOn(the0Sdk)
+```
+
+## Requirements
+
+- Scala 3.x
+- SBT 1.9+
+- sbt-assembly plugin (for creating fat JARs)
+
+## Usage
+
+### Basic Example
+
+```scala
+import the0.Input
+
+object Main extends App {
+  // Parse bot configuration from environment
+  val (botId, config) = Input.parse()
+
+  System.err.println(s"Bot $botId starting")
+  System.err.println(s"Config: $config")
+
+  // Your trading logic here
+
+  Input.success("Bot executed successfully")
+}
+```
+
+### With JSON Parsing
+
+Using a JSON library like circe or play-json:
+
+```scala
+import the0.Input
+import io.circe.parser._
+
+object Main extends App {
+  val (botId, configJson) = Input.parse()
+
+  // Parse config as JSON
+  parse(configJson) match {
+    case Right(json) =>
+      val symbol = json.hcursor.get[String]("symbol").getOrElse("BTC/USDT")
+      val amount = json.hcursor.get[Double]("amount").getOrElse(100.0)
+
+      System.err.println(s"Trading $symbol with amount $amount")
+
+      // Your trading logic here
+
+      Input.success(s"Trade completed for $symbol")
+
+    case Left(error) =>
+      Input.error(s"Failed to parse config: ${error.message}")
+  }
+}
+```
+
+## API Reference
+
+### `Input.parse(): (String, String)`
+
+Parse bot configuration from environment variables.
+
+- Returns: `(botId, configJson)` tuple
+- `botId`: Value of `BOT_ID` environment variable (empty string if not set)
+- `configJson`: Value of `BOT_CONFIG` environment variable (`"{}"` if not set)
+
+```scala
+val (botId, config) = Input.parse()
+```
+
+### `Input.success(message: String): Unit`
+
+Output a success result to stdout.
+
+```scala
+Input.success("Trade completed")
+// Outputs: {"status":"success","message":"Trade completed"}
+```
+
+### `Input.error(message: String): Nothing`
+
+Output an error result to stdout and exit with code 1.
+
+```scala
+Input.error("Failed to connect")
+// Outputs: {"status":"error","message":"Failed to connect"}
+// Then exits with code 1
+```
+
+### `Input.result(status: String, message: String): Unit`
+
+Output a custom result with status and message.
+
+```scala
+Input.result("warning", "Rate limit approaching")
+// Outputs: {"status":"warning","message":"Rate limit approaching"}
+```
+
+### `Input.resultRaw(json: String): Unit`
+
+Output a raw JSON string to stdout.
+
+```scala
+Input.resultRaw("""{"status":"success","trade_id":"abc123","price":45000.50}""")
+```
+
+## Project Setup
+
+### build.sbt
+
+```sbt
+ThisBuild / scalaVersion := "3.4.0"
+ThisBuild / version := "1.0.0"
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "my-scala-bot",
+    libraryDependencies ++= Seq(
+      "io.circe" %% "circe-core" % "0.14.6",
+      "io.circe" %% "circe-parser" % "0.14.6"
+    ),
+    assembly / mainClass := Some("Main"),
+    assembly / assemblyJarName := "my-scala-bot-assembly.jar"
+  )
+```
+
+### project/plugins.sbt
+
+```sbt
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.5")
+```
+
+## Bot Configuration
+
+Create `bot-config.yaml`:
+
+```yaml
+name: my-scala-bot
+description: "A Scala trading bot"
+version: "1.0.0"
+author: "Your Name"
+type: scheduled
+runtime: scala3
+
+entrypoints:
+  bot: src/main/scala/Main.scala
+
+schema:
+  bot: bot-schema.json
+
+readme: README.md
+```
+
+## Deployment
+
+```bash
+# Deploy your bot
+the0 custom-bot deploy
+```
+
+The CLI automatically builds your Scala project using `sbt assembly` in Docker before deployment.
+
+## Best Practices
+
+### Error Handling
+
+```scala
+import the0.Input
+import scala.util.{Try, Success, Failure}
+
+object Main extends App {
+  Try {
+    val (botId, config) = Input.parse()
+
+    if (botId.isEmpty) {
+      throw new IllegalArgumentException("Bot ID is required")
+    }
+
+    // Your trading logic here
+
+    Input.success("Bot executed successfully")
+  } match {
+    case Success(_) => // Already handled
+    case Failure(e) => Input.error(e.getMessage)
+  }
+}
+```
+
+### Logging
+
+Use stderr for logs (stdout is reserved for JSON output):
+
+```scala
+System.err.println("DEBUG: Processing trade...")  // Logs
+println("{...}")  // Reserved for JSON result - use Input.success/error/result instead
+```
+
+### Async Operations
+
+```scala
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+
+object Main extends App {
+  val (botId, config) = Input.parse()
+
+  val result = Await.result(
+    Future {
+      // Async trading logic
+      "Trade completed"
+    },
+    30.seconds
+  )
+
+  Input.success(result)
+}
+```
+
+## License
+
+Apache 2.0 - See LICENSE file in the root of this repository.

--- a/sdk/scala/build.sbt
+++ b/sdk/scala/build.sbt
@@ -1,0 +1,11 @@
+ThisBuild / scalaVersion := "3.3.3"
+ThisBuild / version := "0.1.0"
+ThisBuild / organization := "dev.the0"
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "the0-scala-sdk",
+    libraryDependencies ++= Seq(
+      "org.scalatest" %% "scalatest" % "3.2.18" % Test
+    )
+  )

--- a/sdk/scala/project/build.properties
+++ b/sdk/scala/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.9

--- a/sdk/scala/src/main/scala/the0/Input.scala
+++ b/sdk/scala/src/main/scala/the0/Input.scala
@@ -1,0 +1,91 @@
+package the0
+
+import scala.util.{Try, Success, Failure}
+
+/**
+ * the0 SDK for Scala trading bots.
+ *
+ * Provides utilities for parsing bot configuration and outputting results.
+ *
+ * Example:
+ * {{{
+ * import the0.Input
+ *
+ * object Main extends App {
+ *   val (botId, config) = Input.parse()
+ *   System.err.println(s"Bot $botId starting")
+ *
+ *   // Your trading logic here
+ *
+ *   Input.success("Bot executed successfully")
+ * }
+ * }}}
+ */
+object Input {
+
+  /**
+   * Parse bot configuration from environment variables.
+   *
+   * @return A tuple of (botId, configJson) where:
+   *         - botId: Value of BOT_ID environment variable (empty string if not set)
+   *         - configJson: Value of BOT_CONFIG environment variable (empty object "{}" if not set)
+   */
+  def parse(): (String, String) = {
+    val botId = sys.env.getOrElse("BOT_ID", "")
+    val config = sys.env.getOrElse("BOT_CONFIG", "{}")
+    (botId, config)
+  }
+
+  /**
+   * Output a success result to stdout.
+   *
+   * @param message The success message to include in the output
+   */
+  def success(message: String): Unit = {
+    val escaped = escapeJson(message)
+    println(s"""{"status":"success","message":"$escaped"}""")
+  }
+
+  /**
+   * Output an error result to stdout and exit with code 1.
+   *
+   * @param message The error message to include in the output
+   */
+  def error(message: String): Nothing = {
+    val escaped = escapeJson(message)
+    println(s"""{"status":"error","message":"$escaped"}""")
+    sys.exit(1)
+  }
+
+  /**
+   * Output a custom result to stdout.
+   *
+   * @param status The status string (e.g., "success", "error")
+   * @param message The message string
+   */
+  def result(status: String, message: String): Unit = {
+    val escapedStatus = escapeJson(status)
+    val escapedMessage = escapeJson(message)
+    println(s"""{"status":"$escapedStatus","message":"$escapedMessage"}""")
+  }
+
+  /**
+   * Output a raw JSON string to stdout.
+   *
+   * @param json The JSON string to output (must be valid JSON)
+   */
+  def resultRaw(json: String): Unit = {
+    println(json)
+  }
+
+  /**
+   * Escape a string for use in JSON.
+   */
+  private def escapeJson(s: String): String = {
+    s.replace("\\", "\\\\")
+     .replace("\"", "\\\"")
+     .replace("\n", "\\n")
+     .replace("\r", "\\r")
+     .replace("\t", "\\t")
+  }
+}


### PR DESCRIPTION
## Summary
- Adds complete Scala 3 language support to the0 platform using the `scala3` runtime
- Implements SDK with `the0.Input` object for parse/success/error/result functions
- Follows established `LanguageBuilder` pattern used by Rust, C#, and C++
- Auto-configures sbt-assembly plugin if not present in user projects

## Test plan
- [x] Runtime integration test passes (`TestIntegration_RealDocker_ScalaBot`)
- [x] CLI build succeeds
- [x] Runtime build succeeds
- [x] API build succeeds
- [x] Docs build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)