### PR TITLE
Initial haskell support

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Haskell GHC 9.6 runtime support** - Added `ghc96` to the Runtime type union for Haskell bot deployment
 - **Scala 3 runtime support** - Added `scala3` to the Runtime type union for Scala bot deployment
 - **C/C++ GCC 13 runtime support** - Added `gcc13` to the Runtime type union for C/C++ bot deployment
 - **C# .NET 8 runtime support** - Added `dotnet8` to the Runtime type union for C# bot deployment

--- a/api/src/custom-bot/custom-bot.types.ts
+++ b/api/src/custom-bot/custom-bot.types.ts
@@ -4,7 +4,7 @@ export const BOT_TYPES: BotType[] = ["scheduled", "realtime", "event"];
 
 export type CustomBotStatus = "active";
 
-export type Runtime = "python3.11" | "nodejs20" | "rust-stable" | "dotnet8" | "gcc13" | "scala3";
+export type Runtime = "python3.11" | "nodejs20" | "rust-stable" | "dotnet8" | "gcc13" | "scala3" | "ghc96";
 
 export interface CustomBotConfig {
   name: string;

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Haskell GHC 9.6 language support** - Build Haskell bots locally using Docker before deployment
+  - `HaskellBuilder` implementation of `LanguageBuilder` interface
+  - Detects `.cabal` projects and builds with `cabal build --enable-optimization=2`
+  - Uses `haskell:9.6-bookworm` Docker image for cross-platform builds
 - **Scala 3 language support** - Build Scala bots locally using Docker before deployment
   - `ScalaBuilder` implementation of `LanguageBuilder` interface
   - Detects `build.sbt` projects and builds with `sbt assembly`

--- a/cli/internal/builder_haskell.go
+++ b/cli/internal/builder_haskell.go
@@ -1,0 +1,367 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
+	"github.com/fatih/color"
+)
+
+const haskellImage = "haskell:9.6-bookworm"
+
+// HaskellBuilder handles Haskell project detection and building.
+type HaskellBuilder struct{}
+
+func init() {
+	RegisterBuilder(&HaskellBuilder{})
+}
+
+// Name returns the language name for logging.
+func (b *HaskellBuilder) Name() string {
+	return "Haskell"
+}
+
+// DockerImage returns the Docker image for Haskell builds.
+func (b *HaskellBuilder) DockerImage() string {
+	return haskellImage
+}
+
+// Detect checks if any .cabal file exists in the project.
+func (b *HaskellBuilder) Detect(projectPath string) bool {
+	files, err := filepath.Glob(filepath.Join(projectPath, "*.cabal"))
+	if err != nil {
+		return false
+	}
+	return len(files) > 0
+}
+
+// ShouldBuild checks if Haskell project needs building.
+func (b *HaskellBuilder) ShouldBuild(projectPath string) (bool, error) {
+	files, err := filepath.Glob(filepath.Join(projectPath, "*.cabal"))
+	if err != nil {
+		return false, err
+	}
+	if len(files) == 0 {
+		return false, nil
+	}
+	return true, nil
+}
+
+// Build performs the Docker-based Haskell build.
+func (b *HaskellBuilder) Build(vm *VendorManager) error {
+	blue := color.New(color.FgBlue)
+	green := color.New(color.FgGreen)
+
+	blue.Println("Building Haskell project...")
+
+	// Pull Haskell image if needed
+	if err := b.pullImage(vm); err != nil {
+		return fmt.Errorf("failed to pull Haskell image: %v", err)
+	}
+
+	// Run build container
+	containerID, err := b.runBuildContainer(vm)
+	if err != nil {
+		return fmt.Errorf("failed to run Haskell build container: %v", err)
+	}
+	defer vm.cleanupContainer(containerID)
+
+	// Verify binary was created
+	binaryPath := b.FindBinary(vm.projectPath)
+	if binaryPath == "" {
+		return fmt.Errorf("haskell build did not produce a binary in dist-newstyle/")
+	}
+
+	// Get binary info
+	binaryInfo, err := os.Stat(binaryPath)
+	if err != nil {
+		return fmt.Errorf("failed to stat binary: %v", err)
+	}
+
+	sizeStr := vm.formatFileSize(binaryInfo.Size())
+	green.Printf("v Haskell binary built: %s (%s)\n", filepath.Base(binaryPath), sizeStr)
+	return nil
+}
+
+// FindBinary finds the built binary in dist-newstyle/.
+// Cabal builds to: dist-newstyle/build/[arch]/ghc-[version]/[pkg-name]-[version]/x/[exe-name]/build/[exe-name]/[exe-name]
+func (b *HaskellBuilder) FindBinary(projectPath string) string {
+	distDir := filepath.Join(projectPath, "dist-newstyle")
+
+	if _, err := os.Stat(distDir); os.IsNotExist(err) {
+		return ""
+	}
+
+	var foundBinary string
+
+	// Walk dist-newstyle looking for executables
+	filepath.WalkDir(distDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || foundBinary != "" {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		// Skip non-executable files by extension
+		name := d.Name()
+		if strings.HasSuffix(name, ".hi") ||
+			strings.HasSuffix(name, ".o") ||
+			strings.HasSuffix(name, ".dyn_hi") ||
+			strings.HasSuffix(name, ".dyn_o") ||
+			strings.HasSuffix(name, ".a") ||
+			strings.HasSuffix(name, ".so") ||
+			strings.HasSuffix(name, ".conf") ||
+			strings.HasSuffix(name, ".cache") ||
+			strings.Contains(path, "/setup/") {
+			return nil
+		}
+
+		// Check if it's executable
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+
+		if info.Mode()&0111 != 0 {
+			// Verify it's in a build directory (executable should be in x/[name]/build/[name]/)
+			if strings.Contains(path, "/x/") && strings.Contains(path, "/build/") {
+				foundBinary = path
+				return filepath.SkipDir
+			}
+		}
+
+		return nil
+	})
+
+	return foundBinary
+}
+
+// pullImage pulls the Haskell image if it doesn't exist locally.
+func (b *HaskellBuilder) pullImage(vm *VendorManager) error {
+	ctx := context.Background()
+
+	images, err := vm.dockerClient.ImageList(ctx, image.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	imageExists := false
+	for _, img := range images {
+		for _, tag := range img.RepoTags {
+			if tag == haskellImage {
+				imageExists = true
+				break
+			}
+		}
+		if imageExists {
+			break
+		}
+	}
+
+	if imageExists {
+		return nil
+	}
+
+	blue := color.New(color.FgBlue)
+	blue.Printf("Pulling Docker image: %s...\n", haskellImage)
+
+	reader, err := vm.dockerClient.ImagePull(ctx, haskellImage, image.PullOptions{})
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	io.Copy(io.Discard, reader)
+	return nil
+}
+
+// runBuildContainer creates and runs a container for Haskell building.
+func (b *HaskellBuilder) runBuildContainer(vm *VendorManager) (string, error) {
+	ctx := context.Background()
+
+	ctrName := fmt.Sprintf("%shaskell-%d", vendorContainerName, time.Now().Unix())
+
+	absProjectPath, err := filepath.Abs(vm.projectPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to get absolute project path: %v", err)
+	}
+
+	// Get current user info for ownership
+	currentUser, err := user.Current()
+	var uid, gid string
+	if err == nil {
+		uid = currentUser.Uid
+		gid = currentUser.Gid
+	} else {
+		uid = "1000"
+		gid = "1000"
+	}
+
+	// Build command: cabal update, build with optimizations, then fix ownership
+	buildCmd := fmt.Sprintf(
+		"cabal update && cabal build --enable-optimization=2 2>&1; STATUS=$?; chown -R %s:%s /project/dist-newstyle 2>/dev/null || true; exit $STATUS",
+		uid, gid,
+	)
+
+	config := &container.Config{
+		Image: haskellImage,
+		Cmd: []string{
+			"sh", "-c",
+			buildCmd,
+		},
+		WorkingDir: "/project",
+		Env:        getHaskellBuildEnvVars(),
+	}
+
+	hostConfig := &container.HostConfig{
+		Binds: []string{
+			fmt.Sprintf("%s:/project", absProjectPath),
+		},
+		AutoRemove: false,
+	}
+
+	resp, err := vm.dockerClient.ContainerCreate(ctx, config, hostConfig, nil, nil, ctrName)
+	if err != nil {
+		return "", err
+	}
+
+	if err := vm.dockerClient.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
+		return "", err
+	}
+
+	// Stream logs
+	logReader, err := vm.dockerClient.ContainerLogs(ctx, resp.ID, container.LogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+		Follow:     true,
+		Timestamps: false,
+	})
+	if err != nil {
+		return resp.ID, fmt.Errorf("failed to get container logs: %v", err)
+	}
+
+	logDone := make(chan struct{})
+	go func() {
+		defer close(logDone)
+		defer logReader.Close()
+
+		blue := color.New(color.FgBlue)
+		buffer := make([]byte, 1024)
+		for {
+			n, err := logReader.Read(buffer)
+			if err != nil {
+				if err != io.EOF {
+					blue.Printf("Log read error: %v\n", err)
+				}
+				break
+			}
+			if n > 0 {
+				output := vm.cleanDockerLogOutput(buffer[:n])
+				if output != "" {
+					blue.Printf("  %s", output)
+				}
+			}
+		}
+	}()
+
+	// Wait for container to finish
+	statusCh, errCh := vm.dockerClient.ContainerWait(ctx, resp.ID, container.WaitConditionNotRunning)
+	select {
+	case err := <-errCh:
+		if err != nil {
+			return resp.ID, err
+		}
+	case status := <-statusCh:
+		<-logDone
+		if status.StatusCode != 0 {
+			logs, _ := vm.getContainerLogs(resp.ID)
+			red := color.New(color.FgRed)
+			red.Printf("Haskell build failed with exit code %d\n", status.StatusCode)
+			if logs != "" {
+				red.Printf("Full error log:\n%s\n", logs)
+			}
+			return resp.ID, fmt.Errorf("cabal build failed with exit code %d", status.StatusCode)
+		}
+	}
+
+	return resp.ID, nil
+}
+
+// getHaskellBuildEnvVars returns environment variables for Haskell build.
+func getHaskellBuildEnvVars() []string {
+	secrets, err := LoadBuildSecrets()
+	if err != nil || secrets == nil {
+		return nil
+	}
+
+	var envVars []string
+	if secrets.GitHubToken != "" {
+		// Configure git to use GitHub token for private dependencies
+		envVars = append(envVars, fmt.Sprintf("GITHUB_TOKEN=%s", secrets.GitHubToken))
+	}
+	return envVars
+}
+
+// Legacy functions for backwards compatibility
+
+// IsHaskellProject checks if the project is a Haskell project.
+func IsHaskellProject(projectPath string) bool {
+	builder := &HaskellBuilder{}
+	return builder.Detect(projectPath)
+}
+
+// ShouldBuildHaskell checks if Haskell project needs building.
+func ShouldBuildHaskell(projectPath string) (bool, error) {
+	builder := &HaskellBuilder{}
+	return builder.ShouldBuild(projectPath)
+}
+
+// BuildHaskellIfNeeded builds Haskell project only if needed and Docker is available.
+func BuildHaskellIfNeeded(projectPath string) error {
+	builder := &HaskellBuilder{}
+
+	shouldBuild, err := builder.ShouldBuild(projectPath)
+	if err != nil {
+		return err
+	}
+
+	if !shouldBuild {
+		return nil
+	}
+
+	blue := color.New(color.FgBlue)
+	red := color.New(color.FgRed)
+
+	blue.Println("Haskell project detected, building...")
+
+	if err := CheckDockerInstalled(); err != nil {
+		red.Printf("Docker required for Haskell build: %v\n", err)
+		red.Println("Solution: Install Docker or pre-build with 'cabal build --enable-optimization=2'")
+		return fmt.Errorf("docker unavailable for haskell build")
+	}
+
+	vm, err := NewVendorManager(projectPath)
+	if err != nil {
+		return fmt.Errorf("failed to initialize vendor manager: %v", err)
+	}
+	defer vm.Close()
+
+	if err := vm.CheckDockerRunning(); err != nil {
+		red.Printf("Docker daemon not running: %v\n", err)
+		red.Println("Solution: Start Docker or pre-build with 'cabal build --enable-optimization=2'")
+		return fmt.Errorf("docker daemon not running for haskell build")
+	}
+
+	return builder.Build(vm)
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Haskell Quick Start Guide** - Complete guide for building Haskell trading bots with the0 SDK
+  - SDK installation and usage with `The0.Input` module
+  - Project structure and Cabal configuration examples
+  - Best practices for error handling, validation, and logging
 - **Scala Quick Start Guide** - Complete guide for building Scala 3 trading bots with the0 SDK
   - SDK installation and usage with `the0.Input` object
   - SBT project structure and configuration examples

--- a/docs/custom-bot-development/haskell-quick-start.md
+++ b/docs/custom-bot-development/haskell-quick-start.md
@@ -1,0 +1,381 @@
+---
+title: "Haskell Quick Start"
+description: "Build your first Haskell trading bot with the0"
+tags: ["custom-bots", "haskell", "quick-start"]
+order: 13
+---
+
+# Haskell Quick Start Guide
+
+Build a functional, type-safe trading bot in Haskell with the0's SDK.
+
+---
+
+## Prerequisites
+
+- GHC 9.6+ and Cabal installed
+- the0 CLI installed
+- Valid the0 API key
+
+---
+
+## Project Structure
+
+```
+my-haskell-bot/
+├── my-haskell-bot.cabal   # Package definition
+├── cabal.project          # Cabal project config (optional)
+├── app/
+│   └── Main.hs            # Your bot entry point
+├── bot-config.yaml        # Bot configuration
+├── bot-schema.json        # Parameter schema
+└── README.md              # Documentation
+```
+
+---
+
+## Step 1: Create Your Project
+
+```bash
+# Create project directory
+mkdir my-haskell-bot
+cd my-haskell-bot
+
+# Initialize Cabal project
+cabal init --minimal --exe --main-is=app/Main.hs
+```
+
+---
+
+## Step 2: Configure Your .cabal File
+
+Edit your `.cabal` file to add the the0 SDK:
+
+```cabal
+cabal-version:      3.0
+name:               my-haskell-bot
+version:            0.1.0.0
+build-type:         Simple
+
+executable my-haskell-bot
+    main-is:          Main.hs
+    hs-source-dirs:   app
+    build-depends:    base ^>=4.18,
+                      the0,
+                      aeson ^>=2.2
+    default-language: Haskell2010
+    ghc-options:      -Wall -O2
+```
+
+Add the SDK via `cabal.project`:
+
+```
+packages: .
+
+source-repository-package
+    type: git
+    location: https://github.com/alexanderwanyoike/the0
+    subdir: sdk/haskell
+```
+
+---
+
+## Step 3: Write Your Bot
+
+Create `app/Main.hs`:
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import The0.Input
+import Data.Aeson (Value(..))
+import qualified Data.Aeson.KeyMap as KM
+import System.IO (hPutStrLn, stderr)
+
+main :: IO ()
+main = do
+    -- Parse bot configuration
+    (botId, config) <- parse
+
+    hPutStrLn stderr $ "Bot " ++ botId ++ " starting..."
+
+    -- Access configuration values
+    case config of
+        Object obj -> do
+            case KM.lookup "symbol" obj of
+                Just (String symbol) ->
+                    hPutStrLn stderr $ "Trading symbol: " ++ show symbol
+                _ -> pure ()
+
+            case KM.lookup "amount" obj of
+                Just (Number amount) ->
+                    hPutStrLn stderr $ "Trade amount: " ++ show amount
+                _ -> pure ()
+        _ -> pure ()
+
+    -- Your trading logic here
+    -- Example: Check price, execute trade, log results
+
+    -- Signal success when done
+    success "Bot executed successfully"
+```
+
+---
+
+## Step 4: Create Bot Configuration
+
+Create `bot-config.yaml`:
+
+```yaml
+name: my-haskell-bot
+description: "A functional Haskell trading bot"
+version: "1.0.0"
+author: "Your Name"
+type: scheduled
+runtime: ghc96
+
+entrypoints:
+  bot: app/Main.hs
+
+schema:
+  bot: bot-schema.json
+
+readme: README.md
+```
+
+---
+
+## Step 5: Define Parameter Schema
+
+Create `bot-schema.json`:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Bot Configuration",
+  "description": "Configuration for the Haskell trading bot",
+  "properties": {
+    "symbol": {
+      "type": "string",
+      "title": "Trading Symbol",
+      "description": "The trading pair symbol",
+      "default": "BTC/USDT"
+    },
+    "amount": {
+      "type": "number",
+      "title": "Trade Amount",
+      "description": "Amount to trade per execution",
+      "default": 100
+    }
+  },
+  "required": ["symbol"]
+}
+```
+
+---
+
+## Step 6: Deploy
+
+```bash
+# Deploy your bot
+the0 custom-bot deploy
+```
+
+The build happens automatically in the cloud - no need to compile locally!
+
+---
+
+## SDK API Reference
+
+The `The0.Input` module provides these functions:
+
+### `parse :: IO (String, Value)`
+
+Parse bot configuration from environment. Returns `(botId, config)`.
+
+```haskell
+(botId, config) <- parse
+```
+
+### `parseAsMap :: IO (String, Map String Value)`
+
+Parse configuration as a Map for easier access.
+
+```haskell
+(botId, config) <- parseAsMap
+case Map.lookup "symbol" config of
+    Just (String s) -> putStrLn $ "Symbol: " ++ show s
+    _ -> pure ()
+```
+
+### `success :: String -> IO ()`
+
+Output a success result.
+
+```haskell
+success "Trade executed successfully"
+```
+
+### `error :: String -> IO a`
+
+Output an error result and exit with code 1.
+
+```haskell
+The0.Input.error "Failed to connect to exchange"
+```
+
+### `result :: Value -> IO ()`
+
+Output a custom JSON result.
+
+```haskell
+import Data.Aeson (object, (.=))
+
+result $ object
+    [ "status" .= ("success" :: String)
+    , "trade_id" .= ("12345" :: String)
+    , "filled_amount" .= (0.5 :: Double)
+    ]
+```
+
+---
+
+## Adding Dependencies
+
+Add any package from Hackage to your `.cabal` file:
+
+```cabal
+build-depends:    base ^>=4.18,
+                  the0,
+                  aeson ^>=2.2,
+                  http-conduit ^>=2.3,
+                  time ^>=1.12,
+                  text ^>=2.0
+```
+
+The CLI builds your bot before deployment - no need to compile locally!
+
+---
+
+## Example: HTTP Request Bot
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import The0.Input
+import Data.Aeson (Value(..), decode)
+import qualified Data.Aeson.KeyMap as KM
+import Network.HTTP.Simple
+import qualified Data.ByteString.Lazy.Char8 as BL
+import System.IO (hPutStrLn, stderr)
+
+main :: IO ()
+main = do
+    (botId, config) <- parse
+
+    -- Get API endpoint from config
+    let endpoint = case config of
+            Object obj -> case KM.lookup "api_endpoint" obj of
+                Just (String url) -> show url
+                _ -> "https://api.example.com/price"
+            _ -> "https://api.example.com/price"
+
+    hPutStrLn stderr $ "Bot " ++ botId ++ " fetching from " ++ endpoint
+
+    -- Make HTTP request
+    response <- httpLBS =<< parseRequest endpoint
+
+    case decode (getResponseBody response) :: Maybe Value of
+        Just jsonData -> do
+            hPutStrLn stderr $ "Received: " ++ show jsonData
+            success "Data fetched successfully"
+        Nothing -> The0.Input.error "Failed to parse response"
+```
+
+---
+
+## Best Practices
+
+### Error Handling
+
+Use Haskell's type system for robust error handling:
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+
+import The0.Input
+import Control.Exception (try, SomeException)
+
+executeTrade :: String -> Double -> IO (Either String String)
+executeTrade symbol amount = do
+    -- Your trade logic
+    pure $ Right "trade_id_123"
+
+main :: IO ()
+main = do
+    (botId, config) <- parse
+
+    result <- executeTrade "BTC/USDT" 100.0
+    case result of
+        Right tradeId -> do
+            putStrLn $ "Trade executed: " ++ tradeId
+            success $ "Trade " ++ tradeId ++ " completed"
+        Left err ->
+            The0.Input.error $ "Trade failed: " ++ err
+```
+
+### Configuration Validation
+
+Validate configuration early with pattern matching:
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+
+import The0.Input
+import Data.Aeson (Value(..))
+import qualified Data.Aeson.KeyMap as KM
+import System.IO (hPutStrLn, stderr)
+
+main :: IO ()
+main = do
+    (botId, config) <- parse
+
+    -- Validate required fields
+    case config of
+        Object obj -> case KM.lookup "symbol" obj of
+            Just (String symbol) -> do
+                let amount = case KM.lookup "amount" obj of
+                        Just (Number n) -> realToFrac n
+                        _ -> 100.0 :: Double
+
+                hPutStrLn stderr $ "Trading " ++ show symbol ++ " with amount " ++ show amount
+                success "Validation passed"
+
+            _ -> The0.Input.error "Missing required field: symbol"
+
+        _ -> The0.Input.error "Invalid configuration format"
+```
+
+### Logging
+
+Use stderr for logs (stdout is reserved for results):
+
+```haskell
+import System.IO (hPutStrLn, stderr)
+
+hPutStrLn stderr "DEBUG: Processing trade..."  -- Logs to stderr
+putStrLn "..."  -- Reserved for JSON result output
+```
+
+---
+
+## Related Documentation
+
+- [Configuration Reference](/custom-bot-development/configuration)
+- [Bot Types](/custom-bot-development/bot-types)
+- [Deployment Guide](/custom-bot-development/deployment)

--- a/runtime/internal/docker-runner/docker_runner.go
+++ b/runtime/internal/docker-runner/docker_runner.go
@@ -181,7 +181,7 @@ func NewDockerRunner(options DockerRunnerOptions) (*dockerRunner, error) {
 }
 
 func (r *dockerRunner) isValidRuntime(runtime string) bool {
-	validRuntimes := []string{"python3.11", "nodejs20", "rust-stable", "dotnet8", "gcc13", "scala3"}
+	validRuntimes := []string{"python3.11", "nodejs20", "rust-stable", "dotnet8", "gcc13", "scala3", "ghc96"}
 	for _, valid := range validRuntimes {
 		if runtime == valid {
 			return true
@@ -204,6 +204,8 @@ func (r *dockerRunner) getDockerImage(runtime string) string {
 		return "gcc:13"
 	case "scala3":
 		return "eclipse-temurin:21-jre"
+	case "ghc96":
+		return "haskell:9.6-slim-bookworm"
 	default:
 		return "python:3.11-slim" // fallback
 	}

--- a/runtime/internal/docker-runner/entrypoints/code_entrypoint_factory.go
+++ b/runtime/internal/docker-runner/entrypoints/code_entrypoint_factory.go
@@ -34,6 +34,8 @@ func (f *codeEntrypointFactory) GetCode() (string, error) {
 			return Gcc13BotEntrypoint, nil
 		case "scala3":
 			return Scala3BotEntrypoint, nil
+		case "ghc96":
+			return Ghc96BotEntrypoint, nil
 		}
 	}
 	return "", fmt.Errorf("unsupported entry point type or runtime: %s, %s", f.entryPointType, f.runtime)

--- a/runtime/internal/docker-runner/entrypoints/ghc96.go
+++ b/runtime/internal/docker-runner/entrypoints/ghc96.go
@@ -1,0 +1,6 @@
+package entrypoints
+
+// Ghc96BotEntrypoint is an empty placeholder for Haskell GHC 9.6 bots.
+// Haskell bots are pre-built by the CLI, so no code wrapper is needed.
+// The bash entrypoint in bash_entrypoint_factory.go handles execution.
+const Ghc96BotEntrypoint = ""

--- a/runtime/internal/fixtures/haskell-test-bot/README.md
+++ b/runtime/internal/fixtures/haskell-test-bot/README.md
@@ -1,0 +1,26 @@
+# Haskell Test Bot Fixture
+
+This is a minimal Haskell bot for integration testing.
+
+## Building the Binary
+
+To run integration tests, you need to pre-build the binary:
+
+```bash
+cd runtime/internal/fixtures/haskell-test-bot
+cabal build --enable-optimization=2
+```
+
+The binary will be created at:
+`dist-newstyle/build/x86_64-linux/ghc-9.6.*/haskell-test-bot-0.1.0.0/x/haskell-test-bot/build/haskell-test-bot/haskell-test-bot`
+
+## Structure
+
+```
+haskell-test-bot/
+├── haskell-test-bot.cabal  # Package definition
+├── app/
+│   └── Main.hs             # Entry point
+├── dist-newstyle/          # Build output (after building)
+└── README.md
+```

--- a/runtime/internal/fixtures/haskell-test-bot/app/Main.hs
+++ b/runtime/internal/fixtures/haskell-test-bot/app/Main.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Data.Aeson (Value, decode)
+import qualified Data.ByteString.Lazy.Char8 as BL
+import System.Environment (lookupEnv)
+import System.IO (hPutStrLn, stderr)
+
+main :: IO ()
+main = do
+    -- Get BOT_ID and BOT_CONFIG from environment
+    botId <- lookupEnv "BOT_ID" >>= \case
+        Just bid -> pure bid
+        Nothing -> pure "unknown"
+
+    configStr <- lookupEnv "BOT_CONFIG" >>= \case
+        Just cfg -> pure cfg
+        Nothing -> pure "{}"
+
+    -- Parse config
+    let config = case decode (BL.pack configStr) :: Maybe Value of
+            Just v -> v
+            Nothing -> error "Invalid JSON config"
+
+    -- Print inputs to stderr for test verification
+    hPutStrLn stderr $ "BOT_ID: " ++ botId
+    hPutStrLn stderr $ "BOT_CONFIG: " ++ configStr
+
+    -- Output success JSON to stdout
+    putStrLn $ "{\"status\":\"success\",\"message\":\"Haskell bot executed\",\"bot_id\":\"" ++ botId ++ "\"}"

--- a/runtime/internal/fixtures/haskell-test-bot/haskell-test-bot.cabal
+++ b/runtime/internal/fixtures/haskell-test-bot/haskell-test-bot.cabal
@@ -1,0 +1,13 @@
+cabal-version:      3.0
+name:               haskell-test-bot
+version:            0.1.0.0
+build-type:         Simple
+
+executable haskell-test-bot
+    main-is:          Main.hs
+    hs-source-dirs:   app
+    build-depends:    base ^>=4.18,
+                      aeson ^>=2.2,
+                      bytestring ^>=0.11
+    default-language: Haskell2010
+    ghc-options:      -Wall -O2

--- a/sdk/haskell/README.md
+++ b/sdk/haskell/README.md
@@ -1,0 +1,122 @@
+# the0 SDK for Haskell
+
+This SDK provides utilities for building trading bots on the0 platform using Haskell.
+
+## Installation
+
+Add `the0` to your `.cabal` file dependencies:
+
+```cabal
+build-depends: the0
+```
+
+Or if using as a local package, add to your `cabal.project`:
+
+```
+packages: .
+          path/to/the0
+```
+
+## Usage
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+
+import The0.Input
+import Data.Aeson (Value(..))
+
+main :: IO ()
+main = do
+    (botId, config) <- parse
+    putStrLn $ "Bot " ++ botId ++ " starting"
+
+    -- Access config values
+    -- config is an Aeson Value (JSON)
+
+    -- Your trading logic here
+
+    success "Bot executed successfully"
+```
+
+## API Reference
+
+### `parse :: IO (String, Value)`
+
+Parse bot configuration from environment variables.
+
+Returns a tuple of `(botId, config)` where:
+- `botId` is the unique bot instance identifier
+- `config` is the bot configuration as an Aeson `Value`
+
+**Throws:** Error if `BOT_ID` or `BOT_CONFIG` environment variables are not set.
+
+### `parseAsMap :: IO (String, Map String Value)`
+
+Parse bot configuration with config as a Map for easier field access.
+
+Returns a tuple of `(botId, config)` where:
+- `botId` is the unique bot instance identifier
+- `config` is the bot configuration as a `Map String Value`
+
+### `success :: String -> IO ()`
+
+Output a success result to stdout.
+
+Prints a JSON object: `{"status":"success","message":"<your message>"}`
+
+### `error :: String -> IO a`
+
+Output an error result to stdout and exit with code 1.
+
+Prints a JSON object: `{"status":"error","message":"<your message>"}`
+
+### `result :: Value -> IO ()`
+
+Output a custom JSON result to stdout.
+
+Serializes the provided `Value` as JSON and prints it.
+
+## Example Bot
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import The0.Input
+import Data.Aeson
+import qualified Data.Map.Strict as Map
+import System.IO (hPutStrLn, stderr)
+
+main :: IO ()
+main = do
+    (botId, config) <- parseAsMap
+    hPutStrLn stderr $ "Bot " ++ botId ++ " starting"
+
+    -- Access configuration
+    let symbol = Map.lookup "symbol" config
+
+    case symbol of
+        Just (String s) -> do
+            hPutStrLn stderr $ "Trading symbol: " ++ show s
+            success "Trade executed"
+        _ -> The0.Input.error "Missing symbol configuration"
+```
+
+## Building Your Bot
+
+```bash
+# Initialize a new Haskell project
+cabal init --minimal
+
+# Add the0 SDK as a dependency in your .cabal file
+
+# Build your bot
+cabal build --enable-optimization=2
+
+# The binary will be in dist-newstyle/build/...
+```
+
+## License
+
+Apache-2.0

--- a/sdk/haskell/the0.cabal
+++ b/sdk/haskell/the0.cabal
@@ -1,0 +1,23 @@
+cabal-version:      3.0
+name:               the0
+version:            0.1.0.0
+synopsis:           the0 trading bot SDK for Haskell
+description:        Utilities for building trading bots on the0 platform.
+license:            Apache-2.0
+license-file:       LICENSE
+author:             the0 team
+maintainer:         hello@the0.dev
+category:           Development
+build-type:         Simple
+extra-doc-files:    README.md
+
+library
+    exposed-modules:    The0.Input
+    build-depends:      base ^>=4.18,
+                        aeson ^>=2.2,
+                        bytestring ^>=0.11,
+                        text ^>=2.0,
+                        containers ^>=0.6
+    hs-source-dirs:     src
+    default-language:   Haskell2010
+    ghc-options:        -Wall


### PR DESCRIPTION
## Summary

- **Haskell GHC 9.6 language support** - Build and deploy trading bots written in Haskell
- **SDK package** - Created `The0.Input` module with `parse`, `parseAsMap`, `success`, `error`, and `result` functions
- **CLI compilation** - Haskell bots are compiled locally via Docker (`haskell:9.6-bookworm`) before deployment using Cabal
- **Runtime execution** - Pre-built binaries executed in lightweight `haskell:9.6-slim-bookworm` container
- **LanguageBuilder pattern** - Follows established interface for compiled language support

## Changes

### SDK (`sdk/haskell/`)
- `the0.cabal` - Cabal package definition with aeson, bytestring, text, containers dependencies
- `src/The0/Input.hs` - Module providing `parse`, `parseAsMap`, `success`, `error`, and `result` functions
- `README.md` - SDK documentation with usage examples

The SDK is available as a git dependency:
```
source-repository-package
    type: git
    location: https://github.com/alexanderwanyoike/the0
    subdir: sdk/haskell
```

### CLI (`cli/internal/builder_haskell.go`)
- `HaskellBuilder` struct implementing `LanguageBuilder` interface
- `Detect()` - Checks for `*.cabal` files
- `ShouldBuild()` - Returns true if Cabal project detected
- `Build()` - Runs `cabal update && cabal build --enable-optimization=2` in Docker
- `FindBinary()` - Locates executable in `dist-newstyle/build/.../x/.../build/` path
- `DockerImage()` - Returns `haskell:9.6-bookworm`

### Runtime (`runtime/internal/docker-runner/`)
- `entrypoints/ghc96.go` - Empty placeholder (pre-built binary, no wrapper needed)
- `entrypoints/bash_entrypoint_factory.go` - Added `ghc96BashEntrypoint` that finds and executes binary from `dist-newstyle/`
- `entrypoints/code_entrypoint_factory.go` - Added `ghc96` case returning empty entrypoint
- `docker_runner.go` - Added `ghc96` to valid runtimes, maps to `haskell:9.6-slim-bookworm` image

### API (`api/src/custom-bot/custom-bot.types.ts`)
- Added `ghc96` to `Runtime` type union

### Documentation (`docs/custom-bot-development/`)
- `haskell-quick-start.md` - Complete guide for building Haskell trading bots

### Test Fixtures (`runtime/internal/fixtures/haskell-test-bot/`)
- Minimal Haskell bot for integration testing
- `haskell-test-bot.cabal` and `app/Main.hs`

## Test Plan

- [x] Runtime builds: `cd runtime && go build ./...`
- [x] CLI builds: `cd cli && go build ./...`
- [x] API builds: `cd api && yarn build`
- [ ] Integration test with pre-built Haskell binary (requires local GHC to build fixture)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>