### PR TITLE
Result File Protocol for Bot Output

### DIFF
--- a/docs/custom-bot-development/cpp-quick-start.md
+++ b/docs/custom-bot-development/cpp-quick-start.md
@@ -92,6 +92,7 @@ Create `main.cpp`:
 
 ```cpp
 #include <cstdlib>
+#include <fstream>
 #include <iostream>
 #include <string>
 
@@ -99,18 +100,21 @@ int main() {
     // Get bot configuration from environment
     const char* bot_id_env = std::getenv("BOT_ID");
     const char* config_env = std::getenv("BOT_CONFIG");
+    const char* mount_dir = std::getenv("CODE_MOUNT_DIR");
 
     std::string bot_id = bot_id_env ? bot_id_env : "unknown";
     std::string config = config_env ? config_env : "{}";
+    std::string result_path = std::string("/") + (mount_dir ? mount_dir : "bot") + "/result.json";
 
-    std::cerr << "Bot " << bot_id << " starting..." << std::endl;
-    std::cerr << "Config: " << config << std::endl;
+    std::cout << "Bot " << bot_id << " starting..." << std::endl;
+    std::cout << "Config: " << config << std::endl;
 
     // Your trading logic here
     // Example: Parse config, fetch prices, execute trades
 
-    // Output success result
-    std::cout << "{\"status\":\"success\",\"message\":\"Bot executed successfully\"}" << std::endl;
+    // Write result to file
+    std::ofstream result_file(result_path);
+    result_file << "{\"status\":\"success\",\"message\":\"Bot executed successfully\"}";
 
     return 0;
 }
@@ -353,11 +357,12 @@ int main() {
 
 ### Logging
 
-Use stderr for logs (stdout is reserved for JSON output):
+You can use stdout or stderr for logging - the SDK writes results to a file:
 
 ```cpp
-std::cerr << "DEBUG: Processing trade..." << std::endl;  // Logs
-std::cout << "{...}";  // Reserved for JSON result
+std::cout << "Starting trade..." << std::endl;  // Logs to stdout
+std::cerr << "DEBUG: Details..." << std::endl;  // Logs to stderr
+// Both appear in your bot's logs
 ```
 
 ### Memory Safety

--- a/docs/custom-bot-development/csharp-quick-start.md
+++ b/docs/custom-bot-development/csharp-quick-start.md
@@ -329,11 +329,12 @@ Input.Success("Validation passed");
 
 ### Logging
 
-Use stderr for logs (stdout is reserved for results):
+You can use stdout or stderr for logging - the SDK writes results to a file:
 
 ```csharp
-Console.Error.WriteLine("DEBUG: Processing trade...");  // Logs to stderr
-Console.WriteLine("...");  // Reserved for JSON result output
+Console.WriteLine("Starting trade...");       // Logs to stdout
+Console.Error.WriteLine("DEBUG: Details...");  // Logs to stderr
+// Both appear in your bot's logs
 ```
 
 ### Async Programming

--- a/docs/custom-bot-development/haskell-quick-start.md
+++ b/docs/custom-bot-development/haskell-quick-start.md
@@ -363,13 +363,14 @@ main = do
 
 ### Logging
 
-Use stderr for logs (stdout is reserved for results):
+You can use stdout or stderr for logging - the SDK writes results to a file:
 
 ```haskell
 import System.IO (hPutStrLn, stderr)
 
-hPutStrLn stderr "DEBUG: Processing trade..."  -- Logs to stderr
-putStrLn "..."  -- Reserved for JSON result output
+putStrLn "Starting trade..."                    -- Logs to stdout
+hPutStrLn stderr "DEBUG: Details..."            -- Logs to stderr
+-- Both appear in your bot's logs
 ```
 
 ---

--- a/docs/custom-bot-development/rust-quick-start.md
+++ b/docs/custom-bot-development/rust-quick-start.md
@@ -324,11 +324,12 @@ fn main() {
 
 ### Logging
 
-Use stderr for logs (stdout is reserved for results):
+You can use stdout or stderr for logging - the SDK writes results to a file:
 
 ```rust
-eprintln!("DEBUG: Processing trade...");  // Logs to stderr
-println!("...");  // Reserved for JSON result output
+println!("Starting trade...");   // Logs to stdout
+eprintln!("DEBUG: Details...");  // Logs to stderr
+// Both appear in your bot's logs
 ```
 
 ---

--- a/docs/custom-bot-development/scala-quick-start.md
+++ b/docs/custom-bot-development/scala-quick-start.md
@@ -83,19 +83,25 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.5")
 Create `src/main/scala/Main.scala`:
 
 ```scala
+import java.io.{File, PrintWriter}
+
 object Main extends App {
   // Get bot configuration from environment
   val botId = sys.env.getOrElse("BOT_ID", "unknown")
   val config = sys.env.getOrElse("BOT_CONFIG", "{}")
+  val mountDir = sys.env.getOrElse("CODE_MOUNT_DIR", "bot")
+  val resultPath = s"/$mountDir/result.json"
 
-  System.err.println(s"Bot $botId starting...")
-  System.err.println(s"Config: $config")
+  println(s"Bot $botId starting...")
+  println(s"Config: $config")
 
   // Your trading logic here
   // Example: Parse config, fetch prices, execute trades
 
-  // Output success result
-  println("""{"status":"success","message":"Bot executed successfully"}""")
+  // Write result to file
+  val pw = new PrintWriter(new File(resultPath))
+  pw.write("""{"status":"success","message":"Bot executed successfully"}""")
+  pw.close()
 }
 ```
 
@@ -339,11 +345,12 @@ object Main extends App {
 
 ### Logging
 
-Use stderr for logs (stdout is reserved for JSON output):
+You can use stdout or stderr for logging - the SDK writes results to a file:
 
 ```scala
-System.err.println("DEBUG: Processing trade...")  // Logs
-println("{...}")  // Reserved for JSON result - use Input methods instead
+println("Starting trade...")                      // Logs to stdout
+System.err.println("DEBUG: Details...")           // Logs to stderr
+// Both appear in your bot's logs
 ```
 
 ### Async Operations with Futures

--- a/runtime/internal/docker-runner/entrypoints/nodejs20.go
+++ b/runtime/internal/docker-runner/entrypoints/nodejs20.go
@@ -11,6 +11,20 @@ const path = require('path');
 
 const controller = new AbortController();
 
+function getResultFilePath() {
+    const codeMountDir = process.env.CODE_MOUNT_DIR || 'bot';
+    return '/' + codeMountDir + '/result.json';
+}
+
+function writeResult(data) {
+    const resultPath = getResultFilePath();
+    try {
+        fs.writeFileSync(resultPath, JSON.stringify(data));
+    } catch (error) {
+        console.error('RESULT_ERROR: Failed to write result file: ' + error.message);
+    }
+}
+
 function handleSignal(signal) {
     console.error('SIGNAL: Received ' + signal + ', triggering abort.');
     // --- Trigger the abort signal ---
@@ -80,7 +94,7 @@ function importMainModule(scriptPath) {
     } catch (error) {
         console.error('IMPORT_ERROR: Import failed: ' + error.message);
         console.error('IMPORT_ERROR: Stack trace: ' + error.stack);
-        console.log(JSON.stringify({"status": "error", "message": error.message}));
+        writeResult({"status": "error", "message": error.message});
         process.exit(1);
     }
 }
@@ -111,12 +125,12 @@ function main() {
         .then(result => {
             console.error('EXECUTE_SUCCESS: Bot execution completed on its own.');
             const output = result || {"status": "success", "message": "Bot executed successfully"};
-            console.log(JSON.stringify(output));
+            writeResult(output);
             process.exit(0);
         })
         .catch(error => {
             console.error('EXECUTE_ERROR: Bot execution failed: ' + error.message, error.stack);
-            console.log(JSON.stringify({ "status": "error", "message": error.message }));
+            writeResult({ "status": "error", "message": error.message });
             process.exit(1);
         });
 }

--- a/sdk/dotnet/Input.cs
+++ b/sdk/dotnet/Input.cs
@@ -9,6 +9,33 @@ namespace The0;
 public static class Input
 {
     /// <summary>
+    /// Get the path to the result file.
+    /// </summary>
+    private static string ResultFilePath
+    {
+        get
+        {
+            var mountDir = Environment.GetEnvironmentVariable("CODE_MOUNT_DIR") ?? "bot";
+            return $"/{mountDir}/result.json";
+        }
+    }
+
+    /// <summary>
+    /// Write result to the result file.
+    /// </summary>
+    private static void WriteResult(string content)
+    {
+        try
+        {
+            File.WriteAllText(ResultFilePath, content);
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"RESULT_ERROR: Failed to write result file: {e.Message}");
+        }
+    }
+
+    /// <summary>
     /// Parse bot configuration from environment variables.
     /// Returns a tuple of (BotId, Config) where Config is a JsonNode.
     /// </summary>
@@ -42,36 +69,36 @@ public static class Input
     }
 
     /// <summary>
-    /// Output a success result to stdout.
-    /// Prints a JSON object with status "success" and the provided message.
+    /// Output a success result to the result file.
+    /// Writes a JSON object with status "success" and the provided message.
     /// </summary>
     /// <param name="message">The success message to include in the output</param>
     public static void Success(string message)
     {
         var escaped = message.Replace("\\", "\\\\").Replace("\"", "\\\"");
-        Console.WriteLine($"{{\"status\":\"success\",\"message\":\"{escaped}\"}}");
+        WriteResult($"{{\"status\":\"success\",\"message\":\"{escaped}\"}}");
     }
 
     /// <summary>
-    /// Output an error result to stdout and exit with code 1.
-    /// Prints a JSON object with status "error" and the provided message,
+    /// Output an error result to the result file and exit with code 1.
+    /// Writes a JSON object with status "error" and the provided message,
     /// then terminates the process with exit code 1.
     /// </summary>
     /// <param name="message">The error message to include in the output</param>
     public static void Error(string message)
     {
         var escaped = message.Replace("\\", "\\\\").Replace("\"", "\\\"");
-        Console.WriteLine($"{{\"status\":\"error\",\"message\":\"{escaped}\"}}");
+        WriteResult($"{{\"status\":\"error\",\"message\":\"{escaped}\"}}");
         Environment.Exit(1);
     }
 
     /// <summary>
-    /// Output a custom JSON result to stdout.
-    /// Serializes the provided object as JSON and prints it.
+    /// Output a custom JSON result to the result file.
+    /// Serializes the provided object as JSON and writes it.
     /// </summary>
     /// <param name="data">The object to serialize and output</param>
     public static void Result(object data)
     {
-        Console.WriteLine(JsonSerializer.Serialize(data));
+        WriteResult(JsonSerializer.Serialize(data));
     }
 }


### PR DESCRIPTION
## Description

Implement a result file protocol where bots write their output to `/{entrypoint}/result.json` instead of stdout. This allows stdout/stderr to be used freely for logging and debugging in all languages, including compiled languages (Rust, C++, C#, Scala, Haskell).

Previously, compiled language bots had to reserve stdout for JSON output only, preventing users from using `println!`, `std::cout`, etc. for debugging.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] Infrastructure/DevOps change

## Related Issues

Relates to #84

## Changes Made

### Runtime
- Updated `docker_runner.go` to read results from `/{entrypoint}/result.json` after container execution
- Generate default result if file is missing (exit 0 → success with null, exit 1+ → error)

### Wrappers
- Updated `python311.go` with `get_result_file_path()` and `write_result()` functions
- Updated `nodejs20.go` with `getResultFilePath()` and `writeResult()` functions

### SDKs (all updated to write to result file)
- `sdk/rust/src/lib.rs` - Added `result_file_path()` and `write_result()`
- `sdk/cpp/the0.h` - Added `result_file_path()` and `write_result()`
- `sdk/dotnet/Input.cs` - Added `ResultFilePath` and `WriteResult()`
- `sdk/scala/src/main/scala/the0/Input.scala` - Added `resultFilePath` and `writeResult()`
- `sdk/haskell/src/The0/Input.hs` - Added `resultFilePath` and `writeResult`

### Documentation
- Updated all quick-start guides (Rust, C++, C#, Scala, Haskell) logging sections
- Updated raw examples (without SDK) to write result to file

## Component(s) Affected

- [ ] Frontend (Next.js UI)
- [ ] API (NestJS backend)
- [x] Runtime (Bot execution services)
- [ ] CLI (Command-line tool)
- [ ] Infrastructure (Docker/K8s)
- [x] Documentation

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] Manual testing performed

### Test Commands Run

```bash
cd runtime && go build ./...
cd runtime && go test ./internal/docker-runner/... -v -short
```

### Test Results

```
=== RUN   TestIntegration_EntrypointScriptGeneration_Bot
--- PASS: TestIntegration_EntrypointScriptGeneration_Bot (0.00s)
=== RUN   TestIntegration_EntrypointScriptGeneration_NodeJS
--- PASS: TestIntegration_EntrypointScriptGeneration_NodeJS (0.00s)
=== RUN   TestIntegration_EntrypointScriptGeneration_Rust
--- PASS: TestIntegration_EntrypointScriptGeneration_Rust (0.00s)
PASS
ok      runtime/internal/docker-runner  0.982s
```

## Breaking Changes

**Old bots that wrote JSON to stdout will no longer have their output captured as results.** They will need to:
1. Update to the latest SDK, or
2. Manually write to `/{CODE_MOUNT_DIR}/result.json`

Result file behavior:
| Exit Code | Result File | Behavior |
|-----------|-------------|----------|
| 0 | Exists | Use file contents as result |
| 0 | Missing | Return `{"status":"success","result":null}` |
| 1+ | Exists | Use file contents (may contain error details) |
| 1+ | Missing | Return `{"status":"error","message":"Bot exited with code X"}` |

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked the build passes (`yarn build` for frontend/API, `go build` for Go services)
- [ ] I have updated CHANGELOG.md (if applicable)

## AI Assistance

- [x] AI tools were used in development
- Tools used: Claude Code

## Additional Notes

The result file path uses the `CODE_MOUNT_DIR` environment variable with a fallback to "bot":
```
/{CODE_MOUNT_DIR}/result.json
```

Examples:
- `/bot/result.json` (for bots)
- `/backtest/result.json` (for backtests)

---

**Reviewer Checklist** (for maintainers)

- [ ] Code quality is acceptable
- [ ] Tests are adequate
- [ ] Documentation is updated
- [ ] No security concerns
- [ ] Performance impact is acceptable
- [ ] Breaking changes are documented
- [ ] CI/CD passes