### PR TITLE
Update SDK references to use v1.1.0 tag

### DIFF
--- a/docs/custom-bot-development/haskell-quick-start.md
+++ b/docs/custom-bot-development/haskell-quick-start.md
@@ -147,7 +147,7 @@ packages: .
 source-repository-package
     type: git
     location: https://github.com/alexanderwanyoike/the0.git
-    tag: main
+    tag: v1.1.0
     subdir: sdk/haskell
 ```
 

--- a/example-bots/cpp-sma-crossover/CMakeLists.txt
+++ b/example-bots/cpp-sma-crossover/CMakeLists.txt
@@ -30,7 +30,7 @@ FetchContent_MakeAvailable(json)
 # Fetch the0 SDK
 FetchContent_Declare(the0
     GIT_REPOSITORY https://github.com/alexanderwanyoike/the0.git
-    GIT_TAG release/v1-1-0/fixes-3
+    GIT_TAG v1.1.0
     SOURCE_SUBDIR sdk/cpp
 )
 FetchContent_MakeAvailable(the0)

--- a/example-bots/haskell-sma-crossover/cabal.project
+++ b/example-bots/haskell-sma-crossover/cabal.project
@@ -4,5 +4,5 @@ packages: .
 source-repository-package
     type: git
     location: https://github.com/alexanderwanyoike/the0.git
-    tag: dc4216d
+    tag: v1.1.0
     subdir: sdk/haskell


### PR DESCRIPTION
## Summary

- Update example bots and documentation to reference the v1.1.0 tag instead of branches or commit hashes
- Update README with multi-language support and SDK table

## Changes Made

### SDK References

| File | Before | After |
|------|--------|-------|
| `example-bots/cpp-sma-crossover/CMakeLists.txt` | `release/v1-1-0/fixes-3` | `v1.1.0` |
| `example-bots/haskell-sma-crossover/cabal.project` | `dc4216d` | `v1.1.0` |
| `docs/custom-bot-development/haskell-quick-start.md` | `main` | `v1.1.0` |

### README Updates

- Add language badges for all 7 supported languages (Python, TypeScript, Rust, C++, C#, Scala, Haskell)
- Update intro to mention multi-language and custom dashboards
- Add comprehensive SDK table with links to docs and package registries
- Add Custom Frontends section with React SDK

## Test Plan

- [x] Docs build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)