### PR TITLE
Fix log collector and bot schedule

### DIFF
--- a/runtime/internal/k8s/controller/log_collector.go
+++ b/runtime/internal/k8s/controller/log_collector.go
@@ -117,6 +117,12 @@ func NewK8sLogCollector(ctx context.Context, config K8sLogCollectorConfig, logge
 // Start begins the background goroutine that periodically collects logs.
 func (lc *K8sLogCollector) Start() {
 	lc.logger.Info("K8s Log Collector: Starting log collection service", "interval", lc.interval.String())
+
+	// Reinitialize channels and stopOnce for restart support
+	lc.stopCh = make(chan struct{})
+	lc.doneCh = make(chan struct{})
+	lc.stopOnce = sync.Once{}
+
 	lc.ticker = time.NewTicker(lc.interval)
 
 	go func() {

--- a/runtime/internal/model/bot.go
+++ b/runtime/internal/model/bot.go
@@ -34,6 +34,12 @@ type APIBotConfig struct {
 
 // IsEnabled returns true if the bot is enabled (default true for backward compatibility)
 func (b *Bot) IsEnabled() bool {
+	// Check struct field first (matches MongoDB query on top-level "enabled" field)
+	if b.Enabled != nil {
+		return *b.Enabled
+	}
+
+	// Fall back to Config["enabled"] for backward compatibility
 	if b.Config == nil {
 		return true // Default to enabled if no config
 	}

--- a/runtime/internal/model/botschedule.go
+++ b/runtime/internal/model/botschedule.go
@@ -12,6 +12,12 @@ type BotSchedule struct {
 
 // IsEnabled returns true if the schedule is enabled (default true for backward compatibility)
 func (b *BotSchedule) IsEnabled() bool {
+	// Check struct field first (matches MongoDB query on top-level "enabled" field)
+	if b.Enabled != nil {
+		return *b.Enabled
+	}
+
+	// Fall back to Config["enabled"] for backward compatibility
 	if b.Config == nil {
 		return true // Default to enabled if no config
 	}


### PR DESCRIPTION
This pull request improves the reliability and backward compatibility of bot and schedule enablement checks, and enhances the restart behavior of the Kubernetes log collector service. The main changes are grouped below:

**Bot and Schedule Enablement Logic:**

* Updated the `IsEnabled` method in the `Bot` struct to first check the top-level `Enabled` field (matching MongoDB queries) before falling back to the legacy `Config["enabled"]` value for backward compatibility.
* Updated the `IsEnabled` method in the `BotSchedule` struct to use the same logic as above, ensuring consistent enablement checks between bots and their schedules.

**Kubernetes Log Collector Service:**

* Modified the `Start` method in `K8sLogCollector` to reinitialize internal channels and the `stopOnce` sync primitive, allowing the log collector to be safely restarted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced restart capabilities for the log collection service.
  * Updated enable/disable evaluation logic for bots and bot schedules with priority-based field handling, maintaining backward compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->