### PR TITLE
feat: CLI self-update command and version injection

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,65 @@
+name: Release CLI
+
+on:
+  push:
+    tags:
+      - 'cli/v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24.1'
+        cache-dependency-path: cli/go.sum
+
+    - name: Extract version from tag
+      id: version
+      run: echo "version=${GITHUB_REF_NAME#cli/v}" >> "$GITHUB_OUTPUT"
+
+    - name: Download dependencies
+      working-directory: ./cli
+      run: go mod download
+
+    - name: Run tests
+      working-directory: ./cli
+      run: go test ./tests/...
+
+    - name: Cross-compile binaries
+      working-directory: ./cli
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
+        LDFLAGS: -ldflags="-w -s -X main.VERSION=${{ steps.version.outputs.version }}"
+      run: |
+        mkdir -p bin
+        CGO_ENABLED=0 GOOS=linux   GOARCH=amd64 go build $LDFLAGS -o bin/the0-linux-amd64 .
+        CGO_ENABLED=0 GOOS=linux   GOARCH=arm64 go build $LDFLAGS -o bin/the0-linux-arm64 .
+        CGO_ENABLED=0 GOOS=darwin  GOARCH=amd64 go build $LDFLAGS -o bin/the0-darwin-amd64 .
+        CGO_ENABLED=0 GOOS=darwin  GOARCH=arm64 go build $LDFLAGS -o bin/the0-darwin-arm64 .
+        CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build $LDFLAGS -o bin/the0-windows-amd64.exe .
+
+    - name: Generate checksums
+      working-directory: ./cli/bin
+      run: sha256sum the0-* > checksums.txt
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        name: CLI v${{ steps.version.outputs.version }}
+        generate_release_notes: true
+        files: |
+          cli/bin/the0-linux-amd64
+          cli/bin/the0-linux-arm64
+          cli/bin/the0-darwin-amd64
+          cli/bin/the0-darwin-arm64
+          cli/bin/the0-windows-amd64.exe
+          cli/bin/checksums.txt

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -2,9 +2,12 @@
 
 .PHONY: build test clean install lint
 
+VERSION ?= dev
+LDFLAGS = -ldflags="-w -s -X main.VERSION=$(VERSION)"
+
 # Build the CLI binary
 build:
-	go build -o bin/the0 .
+	go build -ldflags="-X main.VERSION=$(VERSION)" -o bin/the0 .
 
 # Run tests
 test:
@@ -48,8 +51,8 @@ verify: fmt lint test build
 
 # Release build with optimizations
 release:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o bin/the0-linux-amd64 .
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags="-w -s" -o bin/the0-darwin-amd64 .
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags="-w -s" -o bin/the0-darwin-arm64 .
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags="-w -s" -o bin/the0-windows-amd64.exe .
-
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o bin/the0-linux-amd64 .
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(LDFLAGS) -o bin/the0-linux-arm64 .
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build $(LDFLAGS) -o bin/the0-darwin-amd64 .
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o bin/the0-darwin-arm64 .
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o bin/the0-windows-amd64.exe .

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"the0/internal"
+	"the0/internal/logger"
+)
+
+func NewUpdateCmd(currentVersion string) *cobra.Command {
+	var checkOnly bool
+	var yes bool
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update the0 CLI to the latest version",
+		Long:  "Check for and install the latest version of the0 CLI from GitHub Releases",
+		Run: func(cmd *cobra.Command, args []string) {
+			runUpdate(currentVersion, checkOnly, yes)
+		},
+	}
+
+	cmd.Flags().BoolVar(&checkOnly, "check", false, "Only check for updates, don't install")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+func runUpdate(currentVersion string, checkOnly bool, yes bool) {
+	updater := internal.NewUpdater(currentVersion)
+
+	logger.StartSpinner("Checking for updates")
+
+	release, err := updater.CheckLatestRelease()
+	if err != nil {
+		logger.StopSpinnerWithError("Failed to check for updates")
+		logger.Error("%v", err)
+		os.Exit(1)
+	}
+
+	latestVersion := internal.ExtractVersionFromTag(release.TagName)
+
+	isNewer, err := internal.CompareVersions(currentVersion, latestVersion)
+	if err != nil {
+		logger.StopSpinnerWithError("Failed to compare versions")
+		logger.Error("%v", err)
+		os.Exit(1)
+	}
+
+	// Update the cache regardless of outcome
+	_ = internal.WriteVersionCache(&internal.VersionCache{
+		LastCheck:     time.Now(),
+		LatestVersion: latestVersion,
+	})
+
+	if !isNewer {
+		logger.StopSpinnerWithSuccess("Already up to date")
+		logger.Print("  Current version: %s", internal.NormalizeVersion(currentVersion))
+		return
+	}
+
+	logger.StopSpinner()
+	logger.Print("  Update available: %s -> %s", internal.NormalizeVersion(currentVersion), latestVersion)
+
+	if checkOnly {
+		logger.Print("  Run 'the0 update' to install")
+		return
+	}
+
+	// Confirm unless --yes
+	if !yes {
+		logger.Printf("  Install update? [y/N] ")
+		reader := bufio.NewReader(os.Stdin)
+		answer, _ := reader.ReadString('\n')
+		answer = strings.TrimSpace(strings.ToLower(answer))
+		if answer != "y" && answer != "yes" {
+			logger.Print("  Update cancelled")
+			return
+		}
+	}
+
+	// Find the platform binary
+	binaryName := internal.GetPlatformBinaryName()
+	binaryAsset := internal.FindAssetByName(release, binaryName)
+	if binaryAsset == nil {
+		logger.Error("No binary found for your platform (%s)", binaryName)
+		logger.Print("  Available assets:")
+		for _, asset := range release.Assets {
+			logger.Print("    - %s", asset.Name)
+		}
+		os.Exit(1)
+	}
+
+	// Find checksums file
+	checksumAsset := internal.FindAssetByName(release, internal.ChecksumsFileName)
+
+	// Download binary
+	logger.StartSpinner("Downloading " + binaryName)
+
+	binaryData, err := updater.DownloadAsset(binaryAsset.BrowserDownloadURL)
+	if err != nil {
+		logger.StopSpinnerWithError("Download failed")
+		logger.Error("%v", err)
+		os.Exit(1)
+	}
+
+	logger.StopSpinnerWithSuccess(fmt.Sprintf("Downloaded %s (%.1f MB)", binaryName, float64(len(binaryData))/(1024*1024)))
+
+	// Verify checksum if available
+	if checksumAsset != nil {
+		logger.StartSpinner("Verifying checksum")
+
+		checksumData, err := updater.DownloadAsset(checksumAsset.BrowserDownloadURL)
+		if err != nil {
+			logger.StopSpinnerWithError("Failed to download checksums")
+			logger.Error("%v", err)
+			os.Exit(1)
+		}
+
+		if err := internal.VerifyChecksum(binaryData, checksumData, binaryName); err != nil {
+			logger.StopSpinnerWithError("Checksum verification failed")
+			logger.Error("%v", err)
+			os.Exit(1)
+		}
+
+		logger.StopSpinnerWithSuccess("Checksum verified")
+	}
+
+	// Replace binary
+	logger.StartSpinner("Installing update")
+
+	if err := internal.ReplaceBinary(binaryData); err != nil {
+		logger.StopSpinnerWithError("Installation failed")
+		logger.Error("%v", err)
+		logger.Print("  You may need to run with elevated permissions")
+		os.Exit(1)
+	}
+
+	logger.StopSpinnerWithSuccess(fmt.Sprintf("Updated to %s", latestVersion))
+}

--- a/cli/internal/updater.go
+++ b/cli/internal/updater.go
@@ -1,0 +1,262 @@
+package internal
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	GitHubOwner       = "alexanderwanyoike"
+	GitHubRepo        = "the0"
+	CLITagPrefix      = "cli/v"
+	VersionCacheFile  = ".the0/version-check.json"
+	CacheStaleDays    = 7
+	GitHubAPIBase     = "https://api.github.com"
+	ChecksumsFileName = "checksums.txt"
+)
+
+type Updater struct {
+	CurrentVersion string
+	GitHubOwner    string
+	GitHubRepo     string
+	HTTPClient     *http.Client
+}
+
+type GitHubRelease struct {
+	TagName string        `json:"tag_name"`
+	Name    string        `json:"name"`
+	Assets  []GitHubAsset `json:"assets"`
+}
+
+type GitHubAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+type VersionCache struct {
+	LastCheck     time.Time `json:"last_check"`
+	LatestVersion string    `json:"latest_version"`
+}
+
+func NewUpdater(currentVersion string) *Updater {
+	return &Updater{
+		CurrentVersion: currentVersion,
+		GitHubOwner:    GitHubOwner,
+		GitHubRepo:     GitHubRepo,
+		HTTPClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// CheckLatestRelease fetches GitHub releases and returns the latest CLI release.
+func (u *Updater) CheckLatestRelease() (*GitHubRelease, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/releases?per_page=20", GitHubAPIBase, u.GitHubOwner, u.GitHubRepo)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("User-Agent", "the0-cli/"+u.CurrentVersion)
+
+	resp, err := u.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch releases: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+	}
+
+	var releases []GitHubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		return nil, fmt.Errorf("failed to parse releases: %w", err)
+	}
+
+	for _, release := range releases {
+		if strings.HasPrefix(release.TagName, CLITagPrefix) {
+			return &release, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no CLI releases found")
+}
+
+// GetPlatformBinaryName returns the expected binary name for the current platform.
+func GetPlatformBinaryName() string {
+	name := fmt.Sprintf("the0-%s-%s", runtime.GOOS, runtime.GOARCH)
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	return name
+}
+
+// DownloadAsset downloads a binary from the given URL.
+func (u *Updater) DownloadAsset(url string) ([]byte, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create download request: %w", err)
+	}
+	req.Header.Set("User-Agent", "the0-cli/"+u.CurrentVersion)
+
+	resp, err := u.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download asset: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download returned status %d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read download: %w", err)
+	}
+
+	return data, nil
+}
+
+// VerifyChecksum verifies the SHA256 checksum of binary data against a checksums file.
+func VerifyChecksum(data []byte, checksumFile []byte, binaryName string) error {
+	actualHash := sha256.Sum256(data)
+	actualHex := hex.EncodeToString(actualHash[:])
+
+	lines := strings.Split(string(checksumFile), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) != 2 {
+			continue
+		}
+		if parts[1] == binaryName {
+			if parts[0] == actualHex {
+				return nil
+			}
+			return fmt.Errorf("checksum mismatch: expected %s, got %s", parts[0], actualHex)
+		}
+	}
+
+	return fmt.Errorf("no checksum found for %s", binaryName)
+}
+
+// ReplaceBinary replaces the current running binary with new data.
+func ReplaceBinary(newBinaryData []byte) error {
+	execPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to get executable path: %w", err)
+	}
+
+	execPath, err = filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve symlinks: %w", err)
+	}
+
+	// Write new binary to a temp file in the same directory
+	dir := filepath.Dir(execPath)
+	tmpFile, err := os.CreateTemp(dir, "the0-update-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	if _, err := tmpFile.Write(newBinaryData); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to write new binary: %w", err)
+	}
+	tmpFile.Close()
+
+	// Make executable
+	if err := os.Chmod(tmpPath, 0755); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to set permissions: %w", err)
+	}
+
+	// Atomic rename
+	if err := os.Rename(tmpPath, execPath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to replace binary: %w", err)
+	}
+
+	return nil
+}
+
+// ExtractVersionFromTag extracts the version from a tag like "cli/v1.4.0" -> "1.4.0".
+func ExtractVersionFromTag(tag string) string {
+	if strings.HasPrefix(tag, CLITagPrefix) {
+		return strings.TrimPrefix(tag, CLITagPrefix)
+	}
+	return strings.TrimPrefix(tag, "v")
+}
+
+// ReadVersionCache reads the cached version check result.
+func ReadVersionCache() (*VersionCache, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	cachePath := filepath.Join(homeDir, VersionCacheFile)
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var cache VersionCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return nil, err
+	}
+
+	return &cache, nil
+}
+
+// WriteVersionCache writes the version check result to cache.
+func WriteVersionCache(cache *VersionCache) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	cacheDir := filepath.Join(homeDir, ".the0")
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		return err
+	}
+
+	cachePath := filepath.Join(homeDir, VersionCacheFile)
+	data, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(cachePath, data, 0600)
+}
+
+// IsCacheStale returns true if the cache is older than CacheStaleDays.
+func IsCacheStale(cache *VersionCache) bool {
+	return time.Since(cache.LastCheck) > time.Duration(CacheStaleDays)*24*time.Hour
+}
+
+// FindAssetByName finds an asset in a release by filename.
+func FindAssetByName(release *GitHubRelease, name string) *GitHubAsset {
+	for _, asset := range release.Assets {
+		if asset.Name == name {
+			return &asset
+		}
+	}
+	return nil
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -3,14 +3,16 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	"the0/cmd"
+	"the0/internal"
 	"the0/internal/logger"
 )
 
-// Version is the current version of the CLI
-const VERSION = "1.3.1"
+// VERSION is overridden by -ldflags at build time
+var VERSION = "1.3.1"
 
 var (
 	verbose bool
@@ -44,9 +46,64 @@ the0 CLI - Terminal-based trading bot management`,
 	rootCmd.AddCommand(cmd.NewCustomBotCmd())
 	rootCmd.AddCommand(cmd.NewBotCmd())
 	rootCmd.AddCommand(cmd.NewAuthCmd())
+	rootCmd.AddCommand(cmd.NewUpdateCmd(VERSION))
+
+	// Startup version check (non-blocking, cache-based)
+	startupVersionCheck()
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// startupVersionCheck prints a notice if a newer version is cached, and
+// refreshes the cache in the background if stale.
+func startupVersionCheck() {
+	// Skip check for update and help commands
+	if len(os.Args) > 1 {
+		sub := os.Args[1]
+		if sub == "update" || sub == "help" || sub == "--help" || sub == "-h" || sub == "--version" {
+			return
+		}
+	}
+
+	cache, err := internal.ReadVersionCache()
+	if err != nil {
+		// No cache — spawn background refresh for next run
+		go backgroundVersionCheck()
+		return
+	}
+
+	if internal.IsCacheStale(cache) {
+		// Stale cache — spawn background refresh for next run
+		go backgroundVersionCheck()
+		return
+	}
+
+	// Cache is fresh — check if update is available
+	isNewer, err := internal.CompareVersions(VERSION, cache.LatestVersion)
+	if err != nil {
+		return
+	}
+
+	if isNewer {
+		fmt.Fprintf(os.Stderr,
+			"A new version of the0 CLI is available: %s (current: %s). Run 'the0 update' to upgrade.\n",
+			cache.LatestVersion, internal.NormalizeVersion(VERSION))
+	}
+}
+
+func backgroundVersionCheck() {
+	updater := internal.NewUpdater(VERSION)
+	release, err := updater.CheckLatestRelease()
+	if err != nil {
+		return
+	}
+
+	latestVersion := internal.ExtractVersionFromTag(release.TagName)
+	_ = internal.WriteVersionCache(&internal.VersionCache{
+		LastCheck:     time.Now(),
+		LatestVersion: latestVersion,
+	})
 }

--- a/cli/tests/updater_test.go
+++ b/cli/tests/updater_test.go
@@ -1,0 +1,389 @@
+package internal
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"the0/internal"
+)
+
+func TestCheckLatestRelease(t *testing.T) {
+	tests := []struct {
+		name          string
+		releases      []map[string]interface{}
+		expectedTag   string
+		expectedError bool
+		errorContains string
+	}{
+		{
+			name: "finds CLI release",
+			releases: []map[string]interface{}{
+				{
+					"tag_name": "runtime/v2.0.0",
+					"name":     "Runtime v2.0.0",
+					"assets":   []map[string]interface{}{},
+				},
+				{
+					"tag_name": "cli/v1.4.0",
+					"name":     "CLI v1.4.0",
+					"assets": []map[string]interface{}{
+						{"name": "the0-linux-amd64", "browser_download_url": "https://example.com/the0-linux-amd64"},
+					},
+				},
+			},
+			expectedTag: "cli/v1.4.0",
+		},
+		{
+			name: "skips non-CLI releases",
+			releases: []map[string]interface{}{
+				{
+					"tag_name": "api/v3.0.0",
+					"name":     "API v3.0.0",
+					"assets":   []map[string]interface{}{},
+				},
+				{
+					"tag_name": "frontend/v2.0.0",
+					"name":     "Frontend v2.0.0",
+					"assets":   []map[string]interface{}{},
+				},
+			},
+			expectedError: true,
+			errorContains: "no CLI releases found",
+		},
+		{
+			name:          "empty releases",
+			releases:      []map[string]interface{}{},
+			expectedError: true,
+			errorContains: "no CLI releases found",
+		},
+		{
+			name: "returns first CLI release (most recent)",
+			releases: []map[string]interface{}{
+				{
+					"tag_name": "cli/v1.5.0",
+					"name":     "CLI v1.5.0",
+					"assets":   []map[string]interface{}{},
+				},
+				{
+					"tag_name": "cli/v1.4.0",
+					"name":     "CLI v1.4.0",
+					"assets":   []map[string]interface{}{},
+				},
+			},
+			expectedTag: "cli/v1.5.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/repos/test-owner/test-repo/releases" {
+					t.Errorf("Expected releases path, got %s", r.URL.Path)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(tt.releases)
+			}))
+			defer server.Close()
+
+			updater := internal.NewUpdater("1.3.1")
+			updater.GitHubOwner = "test-owner"
+			updater.GitHubRepo = "test-repo"
+			updater.HTTPClient = server.Client()
+
+			// Override the API base by using a custom HTTP client that rewrites URLs
+			// Instead, we need to actually hit the test server. Let's use a transport.
+			transport := &rewriteTransport{
+				base:    server.Client().Transport,
+				baseURL: server.URL,
+			}
+			updater.HTTPClient = &http.Client{Transport: transport}
+
+			release, err := updater.CheckLatestRelease()
+
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("CheckLatestRelease() expected error but got nil")
+				} else if tt.errorContains != "" && !contains(err.Error(), tt.errorContains) {
+					t.Errorf("CheckLatestRelease() error = %v, expected to contain %v", err, tt.errorContains)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("CheckLatestRelease() unexpected error = %v", err)
+				}
+				if release == nil {
+					t.Fatal("CheckLatestRelease() returned nil release")
+				}
+				if release.TagName != tt.expectedTag {
+					t.Errorf("CheckLatestRelease() tag = %s, expected %s", release.TagName, tt.expectedTag)
+				}
+			}
+		})
+	}
+}
+
+// rewriteTransport rewrites GitHub API URLs to point at the test server.
+type rewriteTransport struct {
+	base    http.RoundTripper
+	baseURL string
+}
+
+func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Rewrite the host to our test server
+	req.URL.Scheme = "http"
+	req.URL.Host = t.baseURL[len("http://"):]
+	if t.base != nil {
+		return t.base.RoundTrip(req)
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+}
+
+func containsStr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGetPlatformBinaryName(t *testing.T) {
+	name := internal.GetPlatformBinaryName()
+
+	if name == "" {
+		t.Error("GetPlatformBinaryName() returned empty string")
+	}
+
+	// Should start with "the0-"
+	if name[:5] != "the0-" {
+		t.Errorf("GetPlatformBinaryName() = %s, expected to start with 'the0-'", name)
+	}
+}
+
+func TestExtractVersionFromTag(t *testing.T) {
+	tests := []struct {
+		tag      string
+		expected string
+	}{
+		{"cli/v1.4.0", "1.4.0"},
+		{"cli/v2.0.0-beta.1", "2.0.0-beta.1"},
+		{"cli/v0.1.0", "0.1.0"},
+		{"v1.0.0", "1.0.0"},
+		{"1.0.0", "1.0.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			result := internal.ExtractVersionFromTag(tt.tag)
+			if result != tt.expected {
+				t.Errorf("ExtractVersionFromTag(%s) = %s, expected %s", tt.tag, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestVerifyChecksum(t *testing.T) {
+	binaryData := []byte("test binary content")
+	hash := sha256.Sum256(binaryData)
+	validChecksum := hex.EncodeToString(hash[:])
+
+	tests := []struct {
+		name          string
+		data          []byte
+		checksumFile  string
+		binaryName    string
+		expectedError bool
+		errorContains string
+	}{
+		{
+			name:         "valid checksum",
+			data:         binaryData,
+			checksumFile: fmt.Sprintf("%s  the0-linux-amd64\n%s  the0-darwin-arm64\n", validChecksum, "0000000000000000000000000000000000000000000000000000000000000000"),
+			binaryName:   "the0-linux-amd64",
+		},
+		{
+			name:          "invalid checksum",
+			data:          binaryData,
+			checksumFile:  "0000000000000000000000000000000000000000000000000000000000000000  the0-linux-amd64\n",
+			binaryName:    "the0-linux-amd64",
+			expectedError: true,
+			errorContains: "checksum mismatch",
+		},
+		{
+			name:          "binary not in checksums",
+			data:          binaryData,
+			checksumFile:  fmt.Sprintf("%s  the0-darwin-arm64\n", validChecksum),
+			binaryName:    "the0-linux-amd64",
+			expectedError: true,
+			errorContains: "no checksum found",
+		},
+		{
+			name:          "empty checksums file",
+			data:          binaryData,
+			checksumFile:  "",
+			binaryName:    "the0-linux-amd64",
+			expectedError: true,
+			errorContains: "no checksum found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := internal.VerifyChecksum(tt.data, []byte(tt.checksumFile), tt.binaryName)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("VerifyChecksum() expected error but got nil")
+				} else if tt.errorContains != "" && !containsStr(err.Error(), tt.errorContains) {
+					t.Errorf("VerifyChecksum() error = %v, expected to contain %v", err, tt.errorContains)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("VerifyChecksum() unexpected error = %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestVersionCache(t *testing.T) {
+	// Use a temp directory to avoid polluting home
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	t.Run("write and read cache", func(t *testing.T) {
+		cache := &internal.VersionCache{
+			LastCheck:     time.Now().Truncate(time.Second),
+			LatestVersion: "1.5.0",
+		}
+
+		err := internal.WriteVersionCache(cache)
+		if err != nil {
+			t.Fatalf("WriteVersionCache() error = %v", err)
+		}
+
+		// Verify file was created
+		cachePath := filepath.Join(tmpDir, ".the0", "version-check.json")
+		if _, err := os.Stat(cachePath); os.IsNotExist(err) {
+			t.Fatal("Cache file was not created")
+		}
+
+		read, err := internal.ReadVersionCache()
+		if err != nil {
+			t.Fatalf("ReadVersionCache() error = %v", err)
+		}
+
+		if read.LatestVersion != cache.LatestVersion {
+			t.Errorf("ReadVersionCache() version = %s, expected %s", read.LatestVersion, cache.LatestVersion)
+		}
+	})
+
+	t.Run("read nonexistent cache", func(t *testing.T) {
+		os.Setenv("HOME", t.TempDir())
+		_, err := internal.ReadVersionCache()
+		if err == nil {
+			t.Error("ReadVersionCache() expected error for nonexistent cache")
+		}
+	})
+
+	t.Run("cache staleness", func(t *testing.T) {
+		fresh := &internal.VersionCache{
+			LastCheck:     time.Now(),
+			LatestVersion: "1.5.0",
+		}
+		if internal.IsCacheStale(fresh) {
+			t.Error("IsCacheStale() returned true for fresh cache")
+		}
+
+		stale := &internal.VersionCache{
+			LastCheck:     time.Now().Add(-8 * 24 * time.Hour),
+			LatestVersion: "1.5.0",
+		}
+		if !internal.IsCacheStale(stale) {
+			t.Error("IsCacheStale() returned false for stale cache")
+		}
+	})
+}
+
+func TestFindAssetByName(t *testing.T) {
+	release := &internal.GitHubRelease{
+		TagName: "cli/v1.4.0",
+		Assets: []internal.GitHubAsset{
+			{Name: "the0-linux-amd64", BrowserDownloadURL: "https://example.com/linux-amd64"},
+			{Name: "the0-darwin-arm64", BrowserDownloadURL: "https://example.com/darwin-arm64"},
+			{Name: "checksums.txt", BrowserDownloadURL: "https://example.com/checksums.txt"},
+		},
+	}
+
+	t.Run("finds existing asset", func(t *testing.T) {
+		asset := internal.FindAssetByName(release, "the0-linux-amd64")
+		if asset == nil {
+			t.Fatal("FindAssetByName() returned nil for existing asset")
+		}
+		if asset.BrowserDownloadURL != "https://example.com/linux-amd64" {
+			t.Errorf("FindAssetByName() URL = %s, expected https://example.com/linux-amd64", asset.BrowserDownloadURL)
+		}
+	})
+
+	t.Run("returns nil for missing asset", func(t *testing.T) {
+		asset := internal.FindAssetByName(release, "the0-freebsd-amd64")
+		if asset != nil {
+			t.Error("FindAssetByName() expected nil for missing asset")
+		}
+	})
+
+	t.Run("finds checksums file", func(t *testing.T) {
+		asset := internal.FindAssetByName(release, "checksums.txt")
+		if asset == nil {
+			t.Fatal("FindAssetByName() returned nil for checksums.txt")
+		}
+	})
+}
+
+func TestDownloadAsset(t *testing.T) {
+	expectedData := []byte("binary content here")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/download/the0-linux-amd64" {
+			w.Write(expectedData)
+		} else if r.URL.Path == "/download/error" {
+			w.WriteHeader(http.StatusInternalServerError)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	updater := internal.NewUpdater("1.3.1")
+
+	t.Run("successful download", func(t *testing.T) {
+		data, err := updater.DownloadAsset(server.URL + "/download/the0-linux-amd64")
+		if err != nil {
+			t.Fatalf("DownloadAsset() error = %v", err)
+		}
+		if string(data) != string(expectedData) {
+			t.Errorf("DownloadAsset() data = %s, expected %s", data, expectedData)
+		}
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		_, err := updater.DownloadAsset(server.URL + "/download/error")
+		if err == nil {
+			t.Error("DownloadAsset() expected error for server error")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Add `the0 update` command with `--check` and `--yes` flags to update the CLI binary from GitHub Releases
- Add non-blocking startup version check with 7-day cache (`~/.the0/version-check.json`)
- Change `const VERSION` to `var VERSION` for build-time injection via `-ldflags -X main.VERSION=...`
- Add GitHub Actions release workflow (`.github/workflows/release-cli.yml`) triggered on `cli/v*` tags, cross-compiling 5 targets with SHA256 checksums
- Add `linux/arm64` to Makefile release targets (was missing)

## Test plan
- [x] `make build` compiles successfully
- [x] `./bin/the0 --version` shows injected version
- [x] `the0 update --check` reaches GitHub API
- [x] `make release VERSION=1.4.0` cross-compiles all 5 targets with correct version
- [x] All tests pass (`go test ./tests/...`) — 21 new updater sub-tests
- [ ] End-to-end: tag a `cli/v*` release and verify `the0 update` downloads and replaces binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)