### PR TITLE
feat: Add external services support to Helm chart

### DIFF
--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -10,6 +10,7 @@ help: ## Show this help message
 RELEASE_NAME ?= the0
 NAMESPACE ?= the0
 CHART_PATH ?= .
+VALUES ?=
 
 # Prerequisites check for general use
 .PHONY: check-deps
@@ -231,17 +232,18 @@ remove-hosts: ## Remove the0.local hostnames from /etc/hosts
 
 # Production deployment (assumes external infrastructure)
 .PHONY: deploy
-deploy: check-deps ## Deploy to production cluster with external infrastructure
+deploy: check-deps ## Deploy to production cluster (use VALUES=examples/aws-production.yaml)
 	@echo "🚀 Deploying to production cluster..."
 	@kubectl create namespace $(NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -
 	@helm upgrade --install $(RELEASE_NAME) $(CHART_PATH) \
-		--namespace $(NAMESPACE) \
-		--set postgresql.enabled=false \
-		--set mongodb.enabled=false \
-		--set nats.enabled=false \
-		--set minio.enabled=false \
-		--set minikube.enabled=false
+		--namespace $(NAMESPACE) --create-namespace \
+		$(if $(VALUES),-f $(VALUES),) \
+		--wait --timeout 5m
 	@echo "✅ Production deployment completed!"
+
+.PHONY: template
+template: ## Render templates locally (use VALUES=examples/aws-production.yaml)
+	@helm template $(RELEASE_NAME) $(CHART_PATH) $(if $(VALUES),-f $(VALUES),)
 
 # Status and logs
 .PHONY: status

--- a/k8s/examples/aws-production.yaml
+++ b/k8s/examples/aws-production.yaml
@@ -1,0 +1,90 @@
+# AWS production configuration
+# Uses RDS (PostgreSQL), DocumentDB (MongoDB-compatible), S3-compatible storage, and managed NATS.
+
+global:
+  imagePullPolicy: Always
+
+postgresql:
+  enabled: false
+  external:
+    host: "the0-db.xxxxxxxxxxxx.us-east-1.rds.amazonaws.com"
+    port: 5432
+    database: the0_oss
+    username: the0admin
+    password: "CHANGEME"
+    sslmode: require
+
+mongodb:
+  enabled: false
+  external:
+    host: "the0-docdb.cluster-xxxxxxxxxxxx.us-east-1.docdb.amazonaws.com"
+    port: 27017
+    username: the0admin
+    password: "CHANGEME"
+    database: bot_runner
+    authSource: admin
+    options: "tls=true&tlsCAFile=/etc/ssl/rds-combined-ca-bundle.pem&retryWrites=false"
+
+nats:
+  enabled: false
+  external:
+    host: "nats.internal.example.com"
+    port: 4222
+
+minio:
+  enabled: false
+  external:
+    endpoint: "s3.amazonaws.com"
+    port: "443"
+    useSSL: "true"
+    accessKey: "AKIAIOSFODNN7EXAMPLE"
+    secretKey: "CHANGEME"
+    region: "us-east-1"
+
+the0Api:
+  replicas: 2
+  image:
+    repository: the0org/the0-api
+    tag: latest
+  env:
+    DATABASE_TYPE: "postgres"
+    MINIO_EXTERNAL_ENDPOINT: "the0-assets.s3.amazonaws.com"
+    STORAGE_PATH: "/app/uploads/custom-bots"
+    CUSTOM_BOTS_BUCKET: "the0-custom-bots"
+    LOG_BUCKET: "the0-bot-logs"
+    BACKTEST_BUCKET: "the0-backtests"
+    NODE_ENV: "production"
+    PORT: "3000"
+    API_BASE_URL: "https://api.the0.dev"
+    FRONTEND_URL: "https://app.the0.dev"
+    JWT_SECRET: "CHANGEME"
+    JWT_EXPIRES_IN: "7d"
+    RUNTIME_QUERY_URL: "http://the0-bot-controller:9477"
+
+the0Frontend:
+  replicas: 2
+  image:
+    repository: the0org/the0-frontend
+    tag: latest
+  env:
+    NEXT_PUBLIC_APP_NAME: "the0"
+    NEXT_PUBLIC_APP_VERSION: "1.0.0"
+    NEXT_BASE_URL: "https://app.the0.dev"
+    NODE_ENV: "production"
+    JWT_SECRET: "CHANGEME"
+
+botController:
+  image:
+    repository: the0org/runtime
+    tag: latest
+  runtimeImage: "the0org/runtime:latest"
+  runtimeImagePullPolicy: "Always"
+
+minikube:
+  enabled: false
+
+externalServices:
+  enabled: false
+
+ingress:
+  enabled: true

--- a/k8s/examples/gcp-production.yaml
+++ b/k8s/examples/gcp-production.yaml
@@ -1,0 +1,84 @@
+# GCP production configuration
+# Uses Cloud SQL (PostgreSQL), MongoDB Atlas, GCS-compatible storage, and managed NATS.
+
+global:
+  imagePullPolicy: Always
+
+postgresql:
+  enabled: false
+  external:
+    host: "10.0.0.3"  # Cloud SQL private IP
+    port: 5432
+    database: the0_oss
+    username: the0admin
+    password: "CHANGEME"
+    sslmode: require
+
+mongodb:
+  enabled: false
+  external:
+    connectionString: "mongodb+srv://the0admin:CHANGEME@the0-cluster.xxxxx.mongodb.net/bot_runner?retryWrites=true&w=majority"
+
+nats:
+  enabled: false
+  external:
+    host: "nats.internal.example.com"
+    port: 4222
+
+minio:
+  enabled: false
+  external:
+    endpoint: "storage.googleapis.com"
+    port: "443"
+    useSSL: "true"
+    accessKey: "GOOGXXXXXXXXXXXXXXXX"
+    secretKey: "CHANGEME"
+    region: "us-central1"
+
+the0Api:
+  replicas: 2
+  image:
+    repository: us-docker.pkg.dev/the0-prod/the0/the0-api
+    tag: latest
+  env:
+    DATABASE_TYPE: "postgres"
+    MINIO_EXTERNAL_ENDPOINT: "storage.googleapis.com/the0-assets"
+    STORAGE_PATH: "/app/uploads/custom-bots"
+    CUSTOM_BOTS_BUCKET: "the0-custom-bots"
+    LOG_BUCKET: "the0-bot-logs"
+    BACKTEST_BUCKET: "the0-backtests"
+    NODE_ENV: "production"
+    PORT: "3000"
+    API_BASE_URL: "https://api.the0.dev"
+    FRONTEND_URL: "https://app.the0.dev"
+    JWT_SECRET: "CHANGEME"
+    JWT_EXPIRES_IN: "7d"
+    RUNTIME_QUERY_URL: "http://the0-bot-controller:9477"
+
+the0Frontend:
+  replicas: 2
+  image:
+    repository: us-docker.pkg.dev/the0-prod/the0/the0-frontend
+    tag: latest
+  env:
+    NEXT_PUBLIC_APP_NAME: "the0"
+    NEXT_PUBLIC_APP_VERSION: "1.0.0"
+    NEXT_BASE_URL: "https://app.the0.dev"
+    NODE_ENV: "production"
+    JWT_SECRET: "CHANGEME"
+
+botController:
+  image:
+    repository: us-docker.pkg.dev/the0-prod/the0/runtime
+    tag: latest
+  runtimeImage: "us-docker.pkg.dev/the0-prod/the0/runtime:latest"
+  runtimeImagePullPolicy: "Always"
+
+minikube:
+  enabled: false
+
+externalServices:
+  enabled: false
+
+ingress:
+  enabled: true

--- a/k8s/examples/minimal-external.yaml
+++ b/k8s/examples/minimal-external.yaml
@@ -1,0 +1,47 @@
+# Minimal external services configuration
+# All infrastructure is managed outside the cluster.
+# Replace placeholder values with your actual connection details.
+
+global:
+  imagePullPolicy: Always
+
+postgresql:
+  enabled: false
+  external:
+    host: "your-postgres-host.example.com"
+    port: 5432
+    database: the0_oss
+    username: the0
+    password: "CHANGEME"
+    sslmode: require
+
+mongodb:
+  enabled: false
+  external:
+    host: "your-mongo-host.example.com"
+    port: 27017
+    username: the0
+    password: "CHANGEME"
+    database: bot_runner
+    authSource: admin
+
+nats:
+  enabled: false
+  external:
+    host: "your-nats-host.example.com"
+    port: 4222
+
+minio:
+  enabled: false
+  external:
+    endpoint: "your-s3-host.example.com"
+    port: "443"
+    useSSL: "true"
+    accessKey: "CHANGEME"
+    secretKey: "CHANGEME"
+
+minikube:
+  enabled: false
+
+externalServices:
+  enabled: false

--- a/k8s/templates/_helpers.tpl
+++ b/k8s/templates/_helpers.tpl
@@ -60,3 +60,115 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+=== Infrastructure Connection Helpers ===
+Resolve internal vs external connection strings for each infrastructure service.
+When <service>.enabled is true, use internal cluster addresses.
+When false, use external.connectionString (if set) or build from external.* fields.
+*/}}
+
+{{/*
+PostgreSQL DATABASE_URL
+*/}}
+{{- define "the0.databaseUrl" -}}
+{{- if .Values.postgresql.enabled -}}
+postgresql://{{ .Values.postgresql.username }}:{{ .Values.postgresql.password }}@{{ include "the0.fullname" . }}-postgres:{{ .Values.postgresql.port }}/{{ .Values.postgresql.database }}?sslmode={{ .Values.postgresql.sslmode }}
+{{- else if .Values.postgresql.external.connectionString -}}
+{{ .Values.postgresql.external.connectionString }}
+{{- else -}}
+postgresql://{{ .Values.postgresql.external.username }}:{{ .Values.postgresql.external.password }}@{{ .Values.postgresql.external.host }}:{{ .Values.postgresql.external.port }}/{{ .Values.postgresql.external.database }}?sslmode={{ .Values.postgresql.external.sslmode }}
+{{- end -}}
+{{- end }}
+
+{{/*
+MongoDB connection URL
+*/}}
+{{- define "the0.mongoUrl" -}}
+{{- if .Values.mongodb.enabled -}}
+mongodb://{{ .Values.mongodb.rootUsername }}:{{ .Values.mongodb.rootPassword }}@{{ include "the0.fullname" . }}-mongo:{{ .Values.mongodb.port }}
+{{- else if .Values.mongodb.external.connectionString -}}
+{{ .Values.mongodb.external.connectionString }}
+{{- else -}}
+mongodb://{{ .Values.mongodb.external.username }}:{{ .Values.mongodb.external.password }}@{{ .Values.mongodb.external.host }}:{{ .Values.mongodb.external.port }}/{{ .Values.mongodb.external.database }}?authSource={{ .Values.mongodb.external.authSource }}{{ with .Values.mongodb.external.options }}&{{ . }}{{ end }}
+{{- end -}}
+{{- end }}
+
+{{/*
+NATS connection URL
+*/}}
+{{- define "the0.natsUrl" -}}
+{{- if .Values.nats.enabled -}}
+nats://{{ include "the0.fullname" . }}-nats:{{ .Values.nats.port }}
+{{- else if .Values.nats.external.url -}}
+{{ .Values.nats.external.url }}
+{{- else -}}
+nats://{{ .Values.nats.external.host }}:{{ .Values.nats.external.port }}
+{{- end -}}
+{{- end }}
+
+{{/*
+MinIO endpoint (host only, no port) — used by the API service
+*/}}
+{{- define "the0.minioEndpoint" -}}
+{{- if .Values.minio.enabled -}}
+{{ include "the0.fullname" . }}-minio
+{{- else -}}
+{{ .Values.minio.external.endpoint }}
+{{- end -}}
+{{- end }}
+
+{{/*
+MinIO endpoint with port (host:port) — used by the bot-controller
+*/}}
+{{- define "the0.minioEndpointWithPort" -}}
+{{- if .Values.minio.enabled -}}
+{{ include "the0.fullname" . }}-minio:{{ .Values.minio.port }}
+{{- else -}}
+{{ .Values.minio.external.endpoint }}:{{ .Values.minio.external.port }}
+{{- end -}}
+{{- end }}
+
+{{/*
+MinIO port
+*/}}
+{{- define "the0.minioPort" -}}
+{{- if .Values.minio.enabled -}}
+{{ .Values.minio.port }}
+{{- else -}}
+{{ .Values.minio.external.port }}
+{{- end -}}
+{{- end }}
+
+{{/*
+MinIO use SSL
+*/}}
+{{- define "the0.minioUseSSL" -}}
+{{- if .Values.minio.enabled -}}
+false
+{{- else -}}
+{{ .Values.minio.external.useSSL }}
+{{- end -}}
+{{- end }}
+
+{{/*
+MinIO access key
+*/}}
+{{- define "the0.minioAccessKey" -}}
+{{- if .Values.minio.enabled -}}
+{{ .Values.minio.accessKey }}
+{{- else -}}
+{{ .Values.minio.external.accessKey }}
+{{- end -}}
+{{- end }}
+
+{{/*
+MinIO secret key
+*/}}
+{{- define "the0.minioSecretKey" -}}
+{{- if .Values.minio.enabled -}}
+{{ .Values.minio.secretKey }}
+{{- else -}}
+{{ .Values.minio.external.secretKey }}
+{{- end -}}
+{{- end }}

--- a/k8s/templates/bot-controller.yaml
+++ b/k8s/templates/bot-controller.yaml
@@ -102,21 +102,28 @@ spec:
           args:
             - "--namespace={{ .Release.Namespace }}"
             - "--reconcile-interval={{ .Values.botController.reconcileInterval }}"
-            - "--minio-endpoint={{ .Values.botController.minio.endpoint }}"
+            - "--minio-endpoint={{ include "the0.minioEndpointWithPort" . }}"
             - "--minio-bucket={{ .Values.botController.minio.bucket }}"
             - "--runtime-image={{ .Values.botController.runtimeImage }}"
             - "--runtime-image-pull-policy={{ .Values.botController.runtimeImagePullPolicy }}"
           env:
-            # Namespace for bot pods
             - name: NAMESPACE
               value: {{ .Release.Namespace | quote }}
-            # MinIO configuration for bot code storage
             - name: MINIO_ENDPOINT
-              value: {{ .Values.botController.minio.endpoint | quote }}
+              value: {{ include "the0.minioEndpointWithPort" . | quote }}
             - name: MINIO_BUCKET
               value: {{ .Values.botController.minio.bucket | quote }}
-            # User-defined environment variables (supports value or valueFrom)
-            {{- toYaml .Values.botController.env | nindent 12 }}
+            - name: MONGO_URI
+              value: {{ include "the0.mongoUrl" . | quote }}
+            - name: NATS_URL
+              value: {{ include "the0.natsUrl" . | quote }}
+            - name: MINIO_ACCESS_KEY
+              value: {{ include "the0.minioAccessKey" . | quote }}
+            - name: MINIO_SECRET_KEY
+              value: {{ include "the0.minioSecretKey" . | quote }}
+            {{- with .Values.botController.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: health
               containerPort: 8080

--- a/k8s/templates/minio.yaml
+++ b/k8s/templates/minio.yaml
@@ -61,9 +61,9 @@ spec:
               protocol: TCP
           env:
             - name: MINIO_ROOT_USER
-              value: "the0admin"
+              value: {{ .Values.minio.accessKey | quote }}
             - name: MINIO_ROOT_PASSWORD
-              value: "the0password"
+              value: {{ .Values.minio.secretKey | quote }}
           livenessProbe:
             httpGet:
               path: /minio/health/live

--- a/k8s/templates/mongo.yaml
+++ b/k8s/templates/mongo.yaml
@@ -48,11 +48,11 @@ spec:
               protocol: TCP
           env:
             - name: MONGO_INITDB_ROOT_USERNAME
-              value: "root"
+              value: {{ .Values.mongodb.rootUsername | quote }}
             - name: MONGO_INITDB_ROOT_PASSWORD
-              value: "the0_mongo_password"
+              value: {{ .Values.mongodb.rootPassword | quote }}
             - name: MONGO_INITDB_DATABASE
-              value: "bot_runner"
+              value: {{ .Values.mongodb.database | quote }}
           livenessProbe:
             exec:
               command:

--- a/k8s/templates/postgres.yaml
+++ b/k8s/templates/postgres.yaml
@@ -48,17 +48,17 @@ spec:
               protocol: TCP
           env:
             - name: POSTGRES_DB
-              value: "the0_oss"
+              value: {{ .Values.postgresql.database | quote }}
             - name: POSTGRES_USER
-              value: "the0"
+              value: {{ .Values.postgresql.username | quote }}
             - name: POSTGRES_PASSWORD
-              value: "the0_password"
+              value: {{ .Values.postgresql.password | quote }}
           livenessProbe:
             exec:
               command:
                 - /bin/sh
                 - -c
-                - pg_isready -U the0 -d the0_oss
+                - pg_isready -U {{ .Values.postgresql.username }} -d {{ .Values.postgresql.database }}
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
@@ -67,7 +67,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - pg_isready -U the0 -d the0_oss
+                - pg_isready -U {{ .Values.postgresql.username }} -d {{ .Values.postgresql.database }}
             initialDelaySeconds: 5
             periodSeconds: 5
             timeoutSeconds: 3

--- a/k8s/templates/the0-api.yaml
+++ b/k8s/templates/the0-api.yaml
@@ -50,6 +50,20 @@ spec:
               containerPort: {{ .Values.the0Api.port }}
               protocol: TCP
           env:
+            - name: DATABASE_URL
+              value: {{ include "the0.databaseUrl" . | quote }}
+            - name: NATS_URLS
+              value: {{ include "the0.natsUrl" . | quote }}
+            - name: MINIO_ENDPOINT
+              value: {{ include "the0.minioEndpoint" . | quote }}
+            - name: MINIO_PORT
+              value: {{ include "the0.minioPort" . | quote }}
+            - name: MINIO_USE_SSL
+              value: {{ include "the0.minioUseSSL" . | quote }}
+            - name: MINIO_ACCESS_KEY
+              value: {{ include "the0.minioAccessKey" . | quote }}
+            - name: MINIO_SECRET_KEY
+              value: {{ include "the0.minioSecretKey" . | quote }}
             {{- range $key, $value := .Values.the0Api.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -17,6 +17,10 @@ postgresql:
   enabled: true
   image: postgres:15-alpine
   port: 5432
+  database: the0_oss
+  username: the0
+  password: the0_password
+  sslmode: disable
   persistence:
     enabled: true
     size: 10Gi
@@ -27,11 +31,25 @@ postgresql:
     limits:
       memory: 512Mi
       cpu: 500m
+  external:
+    host: ""
+    port: 5432
+    database: the0_oss
+    username: ""
+    password: ""
+    sslmode: require
+    connectionString: ""  # overrides individual fields if set
+    # existingSecret:
+    #   name: ""
+    #   key: "DATABASE_URL"
 
 mongodb:
   enabled: true
   image: mongo:7-jammy
   port: 27017
+  rootUsername: root
+  rootPassword: the0_mongo_password
+  database: bot_runner
   persistence:
     enabled: true
     size: 10Gi
@@ -42,6 +60,18 @@ mongodb:
     limits:
       memory: 512Mi
       cpu: 500m
+  external:
+    host: ""
+    port: 27017
+    username: ""
+    password: ""
+    database: bot_runner
+    authSource: admin
+    options: ""
+    connectionString: ""  # overrides individual fields if set
+    # existingSecret:
+    #   name: ""
+    #   key: "MONGO_URI"
 
 nats:
   enabled: true
@@ -58,6 +88,10 @@ nats:
     limits:
       memory: 256Mi
       cpu: 200m
+  external:
+    host: ""
+    port: 4222
+    url: ""  # overrides host:port if set
 
 minio:
   enabled: true
@@ -76,6 +110,13 @@ minio:
     limits:
       memory: 512Mi
       cpu: 500m
+  external:
+    endpoint: ""
+    port: "443"
+    useSSL: "true"
+    accessKey: ""
+    secretKey: ""
+    region: ""
 
 # Application Services
 
@@ -92,36 +133,19 @@ the0Api:
   #   tag: latest
   port: 3000
   env:
-    # Database configuration
-    DATABASE_URL: "postgresql://the0:the0_password@the0-postgres:5432/the0_oss?sslmode=disable"
+    # Application configuration
     DATABASE_TYPE: "postgres"
-    
-    # NATS configuration
-    NATS_URLS: "nats://the0-nats:4222"
-    
-    # MinIO configuration
-    MINIO_ENDPOINT: "the0-minio"
     MINIO_EXTERNAL_ENDPOINT: "minio.the0.local:30002"
-    MINIO_PORT: "9000"
-    MINIO_USE_SSL: "false"
-    MINIO_ACCESS_KEY: "the0admin" 
-    MINIO_SECRET_KEY: "the0password"
-    
-    # Storage configuration
     STORAGE_PATH: "/app/uploads/custom-bots"
     CUSTOM_BOTS_BUCKET: "custom-bots"
     LOG_BUCKET: "bot-logs"
     BACKTEST_BUCKET: "backtests"
-    
-    # Application configuration
     NODE_ENV: "development"
     PORT: "3000"
     API_BASE_URL: "http://the0-api:3000"
     FRONTEND_URL: "http://the0.local:30001"
     JWT_SECRET: "your-jwt-secret-key"
     JWT_EXPIRES_IN: "7d"
-
-    # Bot query service (K8s bot-controller)
     RUNTIME_QUERY_URL: "http://the0-bot-controller:9477"
   resources:
     requests:
@@ -202,37 +226,17 @@ botController:
   # Environment variables for the controller
   # Each entry supports standard K8s env syntax: value, valueFrom, secretKeyRef, etc.
   # For production, use secretKeyRef to reference Sealed Secrets
-  env:
-    # MongoDB connection string
-    - name: MONGO_URI
-      value: "mongodb://root:the0_mongo_password@the0-mongo:27017"
-    # NATS connection for syncing bots from API
-    - name: NATS_URL
-      value: "nats://the0-nats:4222"
-    # MinIO credentials for image builder
-    - name: MINIO_ACCESS_KEY
-      value: "the0admin"
-    - name: MINIO_SECRET_KEY
-      value: "the0password"
-    # Example: Using secretKeyRef for production (uncomment and modify):
-    # - name: MONGO_URI
-    #   valueFrom:
-    #     secretKeyRef:
-    #       name: the0-secrets  # Your Sealed Secret name
-    #       key: MONGO_URI
-    # - name: MINIO_ACCESS_KEY
-    #   valueFrom:
-    #     secretKeyRef:
-    #       name: the0-secrets
-    #       key: MINIO_ACCESS_KEY
-    # - name: MINIO_SECRET_KEY
-    #   valueFrom:
-    #     secretKeyRef:
-    #       name: the0-secrets
-    #       key: MINIO_SECRET_KEY
+  # Additional environment variables (supports standard K8s env syntax)
+  # For production, use secretKeyRef to reference Sealed Secrets:
+  # env:
+  #   - name: MONGO_URI
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: the0-secrets
+  #         key: MONGO_URI
+  env: []
   # MinIO configuration for bot code storage
   minio:
-    endpoint: "the0-minio:9000"
     bucket: "custom-bots"
   resources:
     requests:


### PR DESCRIPTION
## Summary

- Add `external` configuration blocks to all infrastructure services (PostgreSQL, MongoDB, NATS, MinIO) in `values.yaml`
- Add 9 helper templates in `_helpers.tpl` that resolve internal vs external connection strings based on `<service>.enabled`
- Replace hardcoded credentials in infra templates (`postgres.yaml`, `mongo.yaml`, `minio.yaml`) with `.Values` references
- Generate infra env vars via helpers in `the0-api.yaml` and `bot-controller.yaml` instead of hardcoding in `values.yaml`
- Add 3 example value files: `minimal-external.yaml`, `aws-production.yaml`, `gcp-production.yaml`
- Add `VALUES` variable and `template` target to Makefile

## Test plan

- [x] `helm lint .` passes with default values
- [x] `helm lint . -f examples/aws-production.yaml` passes
- [x] `helm lint . -f examples/gcp-production.yaml` passes
- [x] `helm template the0 .` — default output matches pre-change connection strings
- [x] `helm template the0 . --set postgresql.enabled=false --set postgresql.external.host=my-rds.aws.com` — DATABASE_URL uses external host
- [x] `helm template the0 . -f examples/minimal-external.yaml` — all infra env vars use external config
- [x] `connectionString` override works (tested via GCP example with MongoDB Atlas)
- [x] Infra deployments not rendered when services disabled (4 vs 8 deployments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)