### PR TITLE
Replace raw GitHub install URL with install.the0.dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ the0/
 
 ```bash
 # Install the CLI
-curl -sSL https://raw.githubusercontent.com/alexanderwanyoike/the0/main/scripts/install.sh | sh
+curl -sSL https://install.the0.dev | sh
 
 # Start all services
 the0 local start

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Deploy the0 locally:
 
 ```bash
 # Install the CLI
-curl -sSL https://raw.githubusercontent.com/alexanderwanyoike/the0/main/scripts/install.sh | sh
+curl -sSL https://install.the0.dev | sh
 
 # Start all services
 the0 local start
@@ -91,7 +91,7 @@ The the0 CLI tool provides a local development interface for managing your bots.
 ### Quick Install (Recommended)
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/alexanderwanyoike/the0/main/scripts/install.sh | sh
+curl -sSL https://install.the0.dev | sh
 ```
 
 This detects your OS and architecture, downloads the latest release binary, verifies its checksum, and installs it to `~/.the0/bin/the0`. Make sure `~/.the0/bin` is in your PATH.

--- a/docs/the0-cli/installation.md
+++ b/docs/the0-cli/installation.md
@@ -18,7 +18,7 @@ To deploy bots that use Python or Node.js dependencies, you need Docker installe
 Install with a single command:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/alexanderwanyoike/the0/main/scripts/install.sh | sh
+curl -sSL https://install.the0.dev | sh
 ```
 
 This downloads the latest release binary, verifies its SHA256 checksum, and installs to `~/.the0/bin`. The script automatically configures your PATH.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # the0 CLI installer
-# Usage: curl -sSL https://raw.githubusercontent.com/alexanderwanyoike/the0/main/scripts/install.sh | sh
+# Usage: curl -sSL https://install.the0.dev | sh
 set -eu
 
 GITHUB_REPO="alexanderwanyoike/the0"


### PR DESCRIPTION
## Summary

- Replaced all occurrences of the raw GitHub install URL (`https://raw.githubusercontent.com/alexanderwanyoike/the0/main/scripts/install.sh`) with the new vanity URL (`https://install.the0.dev`)
- Updated across 4 files: `scripts/install.sh`, `README.md`, `CLAUDE.md`, and `docs/the0-cli/installation.md`

## Files Changed

| File | Occurrences |
|------|-------------|
| `scripts/install.sh` | 1 (usage comment) |
| `README.md` | 2 (quick start + CLI installation sections) |
| `CLAUDE.md` | 1 (quick start section) |
| `docs/the0-cli/installation.md` | 1 (quick install section) |

## Test plan

- [ ] Verify `curl -sSL https://install.the0.dev | sh` redirects/serves the install script correctly
- [ ] Confirm no remaining references to the old raw GitHub URL in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation command URLs across all documentation and installer scripts to reference the official the0.dev installer endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->