### PR TITLE
Bump Helm chart version to 0.2.0

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -55,6 +55,7 @@ jobs:
         uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_dir: .
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: the0
 description: A distributed trading bot platform with backtesting, bot scheduling, and security analysis
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.5.0"
 kubeVersion: ">=1.21.0-0"
 keywords:


### PR DESCRIPTION
## Summary

- Bump Helm chart `version` from `0.1.0` to `0.2.0` (chart content changed with docker removal)
- Add `skip_existing: true` to chart-releaser workflow as a safety net

Fixes the failing Helm release CI — the old `the0-0.1.0` release already existed, and `gh-pages` needed a valid `index.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)