### PR TITLE
Remove hardcoded CLI version fallback

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -11,8 +11,8 @@ import (
 	"the0/internal/logger"
 )
 
-// VERSION is overridden by -ldflags at build time
-var VERSION = "1.3.1"
+// VERSION is set by -ldflags at build time (see Makefile / release-cli.yml)
+var VERSION string
 
 var (
 	verbose bool
@@ -29,7 +29,6 @@ func main() {
   |_| |_||_\___| \___/
 
 the0 CLI - Terminal-based trading bot management`,
-		Version: VERSION,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			// Initialize global logger with verbose setting
 			logger.SetGlobal(logger.New(logger.Config{
@@ -37,6 +36,10 @@ the0 CLI - Terminal-based trading bot management`,
 				NoSpinner: os.Getenv("THE0_NO_SPINNER") != "",
 			}))
 		},
+	}
+
+	if VERSION != "" {
+		rootCmd.Version = VERSION
 	}
 
 	// Add global verbose flag
@@ -50,7 +53,9 @@ the0 CLI - Terminal-based trading bot management`,
 	rootCmd.AddCommand(cmd.NewUpdateCmd(VERSION))
 
 	// Startup version check (non-blocking, cache-based)
-	startupVersionCheck()
+	if VERSION != "" {
+		startupVersionCheck()
+	}
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)


### PR DESCRIPTION
## Summary
- Removed the stale hardcoded `VERSION = "1.3.1"` fallback in `cli/main.go`
- `VERSION` is now a zero-value string, set exclusively via `-ldflags` at build time (release workflow / Makefile)
- When `VERSION` is unset (local `go build` without ldflags), `--version` flag is hidden and startup version checks are skipped

## Test plan
- [x] `go build -ldflags="-X main.VERSION=1.5.0" -o the0 . && ./the0 --version` → `the0 version 1.5.0`
- [x] `go build -o the0 . && ./the0 --help` → no `--version` flag shown
- [x] `make build && ./bin/the0 --version` → `the0 version dev` (Makefile injects `dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Version information is now configured at build time rather than hardcoded, enabling more flexible release management and build-time versioning configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->