### PR TITLE
Remove hardcoded CLI version fallback

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -50,7 +50,9 @@ the0 CLI - Terminal-based trading bot management`,
 	rootCmd.AddCommand(cmd.NewBotCmd())
 	rootCmd.AddCommand(cmd.NewAuthCmd())
 	rootCmd.AddCommand(cmd.NewLocalCmd())
-	rootCmd.AddCommand(cmd.NewUpdateCmd(VERSION))
+	if VERSION != "" {
+		rootCmd.AddCommand(cmd.NewUpdateCmd(VERSION))
+	}
 
 	// Startup version check (non-blocking, cache-based)
 	if VERSION != "" {


### PR DESCRIPTION
## Summary
- Removed stale hardcoded `VERSION = "1.3.1"` fallback from `cli/main.go`
- `VERSION` is now only set via `-ldflags` at build time (release workflow / Makefile)
- When `VERSION` is unset, `--version` flag is hidden and startup version checks are skipped — no more misleading version output

## Test plan
- [x] `go build -ldflags="-X main.VERSION=1.5.0" -o the0 . && ./the0 --version` → `the0 version 1.5.0`
- [x] `go build -o the0 . && ./the0 --help` → no `--version` flag
- [x] `make build && ./bin/the0 --version` → `the0 version dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved version information handling with build-time configuration support.
  * Version-related features are now conditionally available based on build configuration, enabling more flexible deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->