### PR TITLE
Guard update command when VERSION is empty

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -50,7 +50,9 @@ the0 CLI - Terminal-based trading bot management`,
 	rootCmd.AddCommand(cmd.NewBotCmd())
 	rootCmd.AddCommand(cmd.NewAuthCmd())
 	rootCmd.AddCommand(cmd.NewLocalCmd())
-	rootCmd.AddCommand(cmd.NewUpdateCmd(VERSION))
+	if VERSION != "" {
+		rootCmd.AddCommand(cmd.NewUpdateCmd(VERSION))
+	}
 
 	// Startup version check (non-blocking, cache-based)
 	if VERSION != "" {


### PR DESCRIPTION
## Summary
- Wraps `rootCmd.AddCommand(cmd.NewUpdateCmd(VERSION))` in a `VERSION != ""` guard
- Fixes `ParseVersion("")` crash when CLI is built without ldflags
- Addresses CodeRabbit feedback on PR #131

## Test plan
- [x] `go build -o the0 . && ./the0 update` → `unknown command "update"` (no crash)
- [x] `go build -ldflags="-X main.VERSION=1.5.0" -o the0 . && ./the0 update --check` → works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * The update command is now conditionally registered based on version configuration, making it unavailable when version information is not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->