### PR TITLE
Fix rust-sma-crossover build: switch to rustls-tls

### DIFF
--- a/example-bots/rust-sma-crossover/Cargo.toml
+++ b/example-bots/rust-sma-crossover/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/bin/query.rs"
 the0-sdk = "0.3.1"
 
 # HTTP client and JSON
-reqwest = { version = "0.11", features = ["blocking", "json"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 


### PR DESCRIPTION
## Summary
- `native-tls` 0.2.17 fails to compile on latest Rust (`non-exhaustive patterns: Some(Protocol::Tlsv13) not covered`)
- Switch reqwest from default `native-tls` to `rustls-tls` (pure Rust, no OpenSSL dependency)

## Changes
- `example-bots/rust-sma-crossover/Cargo.toml`: Use `default-features = false` and add `rustls-tls` feature

## Test plan
- [ ] `the0 custom-bot deploy` from `rust-sma-crossover` should compile and deploy successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)