### PR TITLE
chore: remove NEXT_PUBLIC_API_URL from CLI compose files (#154)

### DIFF
--- a/cli/internal/local/compose_files/docker-compose.dev.yml
+++ b/cli/internal/local/compose_files/docker-compose.dev.yml
@@ -10,7 +10,6 @@ services:
       NODE_ENV: development
       WATCHPACK_POLLING: true
       CHOKIDAR_USEPOLLING: true
-      NEXT_PUBLIC_API_URL: http://localhost:3000
       BOT_API_URL: http://the0-api:3000
       NEXT_PUBLIC_DOCS_URL: http://localhost:3002
       CLI_DOWNLOAD_BASE_URL: https://github.com/your-org/the0-oss/releases/download

--- a/cli/internal/local/compose_files/docker-compose.yml
+++ b/cli/internal/local/compose_files/docker-compose.yml
@@ -333,7 +333,6 @@ services:
       dockerfile: Dockerfile
       args:
         - BUILDKIT_INLINE_CACHE=1
-        - NEXT_PUBLIC_API_URL=http://localhost:3000
         - NEXT_PUBLIC_DOCS_URL=http://localhost:3002
     pull_policy: always
     environment:


### PR DESCRIPTION
## Summary
- Removes the now-unused `NEXT_PUBLIC_API_URL` build arg/env var from CLI Docker Compose files
- Follow-up to the auth proxy PR — the frontend no longer needs this variable since API calls are proxied through Next.js server-side routes

## Changes
- `cli/internal/local/compose_files/docker-compose.yml`: Removed `NEXT_PUBLIC_API_URL` build arg from `the0-frontend` service
- `cli/internal/local/compose_files/docker-compose.dev.yml`: Removed `NEXT_PUBLIC_API_URL` environment variable from `the0-frontend` dev override

## Test plan
- [x] `cd cli && make build` — CLI builds successfully
- [x] `grep -r "NEXT_PUBLIC_API_URL" cli/` — returns zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed API URL environment variable from frontend service configuration in deployment setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->