### PR TITLE
fix: resolve auth error in logs endpoints

### DIFF
--- a/api/src/bot/bot.service.ts
+++ b/api/src/bot/bot.service.ts
@@ -121,6 +121,10 @@ export class BotService {
     return this.botRepository.findOne(uid, id);
   }
 
+  findOneByUserId(userId: string, id: string): Promise<Result<Bot, string>> {
+    return this.botRepository.findOne(userId, id);
+  }
+
   async update(
     id: string,
     updateBotDto: UpdateBotDto,

--- a/api/src/logs/logs.service.ts
+++ b/api/src/logs/logs.service.ts
@@ -34,9 +34,12 @@ export class LogsService {
   async getLogs(
     botId: string,
     query: LogsQuery,
+    userId?: string,
   ): Promise<Result<LogEntry[], string>> {
     // Verify bot ownership
-    const botResult = await this.botService.findOne(botId);
+    const uid = userId || (this.botService as any).request?.user?.uid;
+    if (!uid) return Failure("Authentication required");
+    const botResult = await this.botService.findOneByUserId(uid, botId);
     if (!botResult.success) {
       return Failure("Bot not found or access denied");
     }

--- a/api/src/mcp/__tests__/mcp.service.spec.ts
+++ b/api/src/mcp/__tests__/mcp.service.spec.ts
@@ -302,7 +302,7 @@ describe("McpService", () => {
           dateRange: undefined,
           limit: 500,
           offset: 0,
-        });
+        }, "user-123");
       });
     });
 

--- a/api/src/mcp/mcp.service.ts
+++ b/api/src/mcp/mcp.service.ts
@@ -488,12 +488,16 @@ export class McpService {
     }
     // Cap limit to prevent context overflow
     const limit = Math.min(input.limit || 100, 500);
-    const result = await this.logsService.getLogs(input.bot_id, {
-      date: input.date,
-      dateRange: input.date_range,
-      limit,
-      offset: 0,
-    });
+    const result = await this.logsService.getLogs(
+      input.bot_id,
+      {
+        date: input.date,
+        dateRange: input.date_range,
+        limit,
+        offset: 0,
+      },
+      userId
+    );
     if (!result.success) {
       throw new Error(result.error || "Failed to get logs");
     }
@@ -515,11 +519,15 @@ export class McpService {
       (today.getMonth() + 1).toString().padStart(2, "0") +
       today.getDate().toString().padStart(2, "0");
 
-    const result = await this.logsService.getLogs(input.bot_id, {
-      date: todayStr,
-      limit: 100,
-      offset: 0,
-    });
+    const result = await this.logsService.getLogs(
+      input.bot_id,
+      {
+        date: todayStr,
+        limit: 100,
+        offset: 0,
+      },
+      userId
+    );
     if (!result.success) {
       throw new Error(result.error || "Failed to get logs for summary");
     }


### PR DESCRIPTION
## Summary
Resolves the MCP auth error when accessing `logs_get` and `logs_summary` tools.

## Problem
Closes #108
When `McpService` called `logsService.getLogs()`, the `LogsService` was using `BotService.findOne()` which attempts to extract `uid` from the HTTP request scope via `@Inject(REQUEST)`. In the MCP context, this HTTP request context does not exist, causing `Cannot destructure property 'uid' of 'this.request.user' as it is undefined`.

## Solution
1. Updated `LogsService.getLogs()` to accept an optional `userId` parameter.
2. If `userId` is not provided, fallback to the existing HTTP request scope logic (which remains used by `LogsController`).
3. Added `findOneByUserId` to `BotService` to skip request scope when explicitly provided.
4. Updated `McpService` to pass the `userId` through to `getLogs()`.
5. Updated unit tests.

## Testing
- Tests pass: `npx jest src/mcp/__tests__/mcp.service.spec.ts`
- All tests pass: `npx jest`

## Checklist
- [x] Code builds without errors
- [x] Tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented user-scoped log access control to ensure users can only retrieve logs for their own bots, with ownership verification integrated into the log retrieval flow.

* **Tests**
  * Updated test assertions to validate that user-scoped log retrieval is properly invoked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->