### PR TITLE
fix: add MINIO_USE_SSL to bot-controller

### DIFF
--- a/k8s/templates/bot-controller.yaml
+++ b/k8s/templates/bot-controller.yaml
@@ -120,6 +120,8 @@ spec:
                   key: mongo-url
             - name: NATS_URL
               value: {{ include "the0.natsUrl" . | quote }}
+            - name: MINIO_USE_SSL
+              value: {{ include "the0.minioUseSSL" . | quote }}
             - name: MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:

--- a/runtime/cmd/app/main.go
+++ b/runtime/cmd/app/main.go
@@ -46,6 +46,7 @@ var (
 	minioAccessKey string
 	minioSecretKey string
 	minioBucket    string
+	minioUseSSL    bool
 
 	// Runtime image for init containers and sidecars
 	runtimeImage           string
@@ -147,6 +148,7 @@ func main() {
 	// MinIO credentials read from environment only (not CLI flags) for security
 	minioAccessKey = getEnv("MINIO_ACCESS_KEY", "")
 	minioSecretKey = getEnv("MINIO_SECRET_KEY", "")
+	minioUseSSL = getEnv("MINIO_USE_SSL", "false") == "true"
 	rootCmd.AddCommand(controllerCmd)
 
 	// Query server command with flags
@@ -368,6 +370,7 @@ func runController() {
 		MinIOAccessKey:         minioAccessKey,
 		MinIOSecretKey:         minioSecretKey,
 		MinIOBucket:            minioBucket,
+		MinIOUseSSL:            minioUseSSL,
 		RuntimeImage:           runtimeImage,
 		RuntimeImagePullPolicy: runtimeImagePullPolicy,
 		Logger:                 &util.DefaultLogger{},


### PR DESCRIPTION
## Summary
- Add `MINIO_USE_SSL` env var to bot-controller Helm template (was missing, causing HTTP default when connecting to SSL-enabled object storage)
- Wire `minioUseSSL` through controller `main.go` → `ManagerConfig` so the value propagates to spawned bot pods

## Test plan
- [x] Deploy to cluster, verify bot-controller connects to object storage over HTTPS
- [x] Verify scheduled bots can download code without "plain HTTP sent to HTTPS port" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)