### PR TITLE
fix: update customBotId on bot version bump to preserve state

### DIFF
--- a/api/src/bot/__tests__/bot.controller.spec.ts
+++ b/api/src/bot/__tests__/bot.controller.spec.ts
@@ -425,7 +425,7 @@ describe("BotController - Enhanced Tests", () => {
       expect(repository.update).toHaveBeenCalledWith(uid, "test-id", {
         ...updateData,
         config: { ...updateData.config, hasFrontend: false },
-        customBotId: mockCustomBot.id,
+        customBotId: existingBot.customBotId,
       });
     });
 

--- a/api/src/bot/__tests__/bot.service.spec.ts
+++ b/api/src/bot/__tests__/bot.service.spec.ts
@@ -518,11 +518,11 @@ describe("BotService - Enhanced Tests", () => {
       const result = await service.update("test-id", updateData);
 
       expect(result.success).toBe(true);
-      // customBotId should still be set from the validated custom bot
+      // customBotId should be preserved from the existing bot record, not rotated
       expect(repository.update).toHaveBeenCalledWith(uid, "test-id", {
         ...updateData,
         config: { ...updateData.config, hasFrontend: false },
-        customBotId: mockCustomBot.id,
+        customBotId: existingBot.customBotId,
       });
     });
 

--- a/api/src/bot/bot.service.ts
+++ b/api/src/bot/bot.service.ts
@@ -158,13 +158,17 @@ export class BotService {
       );
     }
 
-    // Update customBotId to point to the new version's CustomBot record
+    // Only rotate customBotId when version actually changes
     const newCustomBot = validationResult.data;
     const hasCustomFrontend = newCustomBot.config?.hasFrontend ?? false;
+    const versionChanged =
+      currentVersion && newVersion ? !semver.eq(currentVersion, newVersion) : true;
     const result = await this.botRepository.update(uid, id, {
       ...updateBotDto,
       config: { ...updateBotDto.config, hasFrontend: hasCustomFrontend },
-      customBotId: newCustomBot.id,
+      customBotId: versionChanged
+        ? newCustomBot.id
+        : currentBot.data.customBotId,
     });
 
     if (result.success) {


### PR DESCRIPTION
## Summary

- **Fix:** `bot.service.update()` now passes `customBotId` and `hasFrontend` to the repository, so the DB record points to the new CustomBot version on minor/patch bumps
- **Guard:** Major version bumps (e.g. 1.x → 2.0) are blocked with a clear error — these require `bot delete` + `bot deploy` since state schema may be incompatible
- **Tests:** 6 new/updated tests covering customBotId propagation, hasFrontend flag, major/minor/patch version bump behavior

## Test plan

- [x] `cd api && yarn test` — all 53 tests pass
- [x] `cd api && yarn build` — compiles cleanly
- [ ] Manual: deploy custom bot v1.0.0, create instance, bump to v1.0.1, run `bot update` — verify new frontend/code, state preserved
- [ ] Manual: attempt major bump (1.x → 2.0) via `bot update` — verify rejection message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added version upgrade protection that blocks major version upgrades (requires delete and redeploy) while allowing minor and patch updates.
  * Update flow now derives and persists frontend presence and updated custom bot identifiers when appropriate.

* **Bug Fixes**
  * Ensures configuration merge and validation during updates and surfaces repository update failures.

* **Tests**
  * Added comprehensive tests covering update scenarios, version checks, payload validation, and side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->