### PR TITLE
fix: prevent JSONB double-encoding in postgres.js + Drizzle

### DIFF
--- a/api/src/database/connection.ts
+++ b/api/src/database/connection.ts
@@ -75,6 +75,17 @@ export function getDatabase() {
       idle_timeout: config.pool.idleTimeout,
       connect_timeout: config.pool.connectTimeout,
       max_lifetime: config.pool.maxLifetime,
+      types: {
+        // Fix JSONB double-encoding: Drizzle already calls JSON.stringify() in
+        // mapToDriverValue, so we must stop postgres.js from stringifying again.
+        // See https://github.com/drizzle-team/drizzle-orm/issues/5139
+        json: {
+          to: 114,
+          from: [114, 3802],
+          serialize: (x: any) => x,
+          parse: (x: string) => JSON.parse(x),
+        },
+      },
     });
     dbInstance = drizzle(client, { schema: pgSchema });
 

--- a/api/src/database/migrations/0004_fix_jsonb_double_encoding.sql
+++ b/api/src/database/migrations/0004_fix_jsonb_double_encoding.sql
@@ -1,0 +1,11 @@
+-- Fix JSONB double-encoding caused by postgres.js + Drizzle both calling
+-- JSON.stringify(). Rows where jsonb_typeof() = 'string' are double-encoded
+-- and need one layer of unwrapping via ::text::jsonb.
+
+UPDATE custom_bots
+SET config = config::text::jsonb
+WHERE jsonb_typeof(config) = 'string';
+
+UPDATE bots
+SET config = config::text::jsonb
+WHERE jsonb_typeof(config) = 'string';


### PR DESCRIPTION
## Summary

- Override postgres.js JSON serializer in `connection.ts` to pass values through as-is, since Drizzle already calls `JSON.stringify()` in `mapToDriverValue` — prevents both layers from double-encoding JSONB columns
- Add data migration (`0004_fix_jsonb_double_encoding.sql`) to unwrap existing double-encoded rows in `custom_bots` and `bots` tables

## Context

Known Drizzle + postgres.js bug ([drizzle-orm#5139](https://github.com/drizzle-team/drizzle-orm/issues/5139)). Config values are stored as JSON strings (`"{\"hasFrontend\":true,...}"`) instead of JSON objects (`{"hasFrontend":true,...}`). Drizzle masks this on read by double-parsing, but the stored data is corrupted at the SQL level.

## Post-deploy verification

```sql
-- All should return 'object', not 'string'
SELECT jsonb_typeof(config) FROM custom_bots LIMIT 5;
SELECT jsonb_typeof(config) FROM bots LIMIT 5;

-- Should return 'true', not NULL
SELECT config->>'hasFrontend' FROM custom_bots WHERE config->>'hasFrontend' IS NOT NULL LIMIT 1;
```

## Test plan

- [x] `yarn test` — 53 tests pass
- [x] `yarn build` — compiles clean
- [ ] Run migration on staging, verify `jsonb_typeof` returns `object`
- [ ] Deploy, create a bot with custom frontend, verify dashboard loads
- [ ] Update that bot via CLI, verify dashboard still loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved a JSONB double-encoding issue affecting bot configuration data storage and retrieval. Includes an automatic data migration to correct existing affected records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->