### PR TITLE
fix: replace console.log with structured pino logger in API startup

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -54,6 +54,7 @@
     "multer": "^2.0.1",
     "nats": "^2.29.3",
     "nestjs-pino": "^4.5.0",
+    "pino": "^9.6.0",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,15 +1,17 @@
 import { ValidationPipe } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
 import { Logger } from "nestjs-pino";
+import pino from "pino";
 import { AppModule } from "./app.module";
 import { runMigrations } from "./database/migrate";
 
+const bootstrapLogger = pino({ name: "bootstrap" });
+
 async function bootstrap() {
   // Run database migrations before starting the application
-  // Note: migrations run before NestJS app is created, so we use console here
-  console.log("Running database migrations...");
+  bootstrapLogger.info("Running database migrations...");
   await runMigrations();
-  console.log("Database migrations completed");
+  bootstrapLogger.info("Database migrations completed");
 
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
 
@@ -39,6 +41,6 @@ async function bootstrap() {
 }
 
 bootstrap().catch((error) => {
-  console.error("Failed to start the0 API:", error);
+  bootstrapLogger.error({ err: error }, "Failed to start the0 API");
   process.exit(1);
 });


### PR DESCRIPTION
## What

Replaces `console.log` and `console.error` in `api/src/main.ts` with a standalone `pino` logger instance for the bootstrap phase.

## Why

Startup messages (`Running database migrations...`, `Database migrations completed`, and the fatal error handler) were using `console.log`/`console.error`, producing unstructured plain text. The rest of the API emits structured JSON via `nestjs-pino`. This inconsistency breaks log aggregation in tools like Datadog, Loki, or CloudWatch.

## Changes

- Added `pino` as a direct dependency in `api/package.json`
- Created a `bootstrapLogger` instance with `{ name: "bootstrap" }` for pre-NestJS logging
- Replaced all `console.log`/`console.error` calls in bootstrap with structured equivalents

All log output is now consistent structured JSON.

Closes #194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced application startup and error logging infrastructure for improved observability and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->