### PR TITLE
fix: use UTC dates in interval picker to match log file storage

### DIFF
--- a/frontend/src/components/bot/__tests__/interval-picker.test.tsx
+++ b/frontend/src/components/bot/__tests__/interval-picker.test.tsx
@@ -209,9 +209,9 @@ describe("IntervalPicker", () => {
       // end should be today
       const today = new Date();
       const expectedEnd =
-        String(today.getFullYear()) +
-        String(today.getMonth() + 1).padStart(2, "0") +
-        String(today.getDate()).padStart(2, "0");
+        String(today.getUTCFullYear()) +
+        String(today.getUTCMonth() + 1).padStart(2, "0") +
+        String(today.getUTCDate()).padStart(2, "0");
       expect(result.end).toBe(expectedEnd);
     });
 

--- a/frontend/src/components/bot/interval-picker.tsx
+++ b/frontend/src/components/bot/interval-picker.tsx
@@ -26,9 +26,9 @@ interface IntervalPickerProps {
 }
 
 function formatDate(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, "0");
-  const d = String(date.getDate()).padStart(2, "0");
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(date.getUTCDate()).padStart(2, "0");
   return `${y}${m}${d}`;
 }
 
@@ -56,7 +56,7 @@ export function computeInterval(
     };
   }
   const startDay = new Date(now);
-  startDay.setDate(startDay.getDate() - (preset.days || 1) + 1);
+  startDay.setUTCDate(startDay.getUTCDate() - (preset.days || 1) + 1);
   return {
     type: "range",
     label,


### PR DESCRIPTION
## Summary
- Interval picker used local dates (`getDate`/`getMonth`) but log files are stored by UTC date
- In UTC+ timezones after midnight local, the dashboard requested the next UTC day which had no data
- Switched `formatDate` to use `getUTCFullYear`/`getUTCMonth`/`getUTCDate`

## Test plan
- [x] 560 frontend tests pass
- [x] Frontend build passes
- [x] Verified against production API: local date returns 0 metrics, UTC date returns 12,275

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Interval picker now uses UTC for date calculations, ensuring consistent start/end dates for preset selections and custom ranges across timezones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->