### PR TITLE
Release v1.12.4

### DIFF
--- a/frontend/src/components/bot/__tests__/interval-picker.test.tsx
+++ b/frontend/src/components/bot/__tests__/interval-picker.test.tsx
@@ -209,9 +209,9 @@ describe("IntervalPicker", () => {
       // end should be today
       const today = new Date();
       const expectedEnd =
-        String(today.getFullYear()) +
-        String(today.getMonth() + 1).padStart(2, "0") +
-        String(today.getDate()).padStart(2, "0");
+        String(today.getUTCFullYear()) +
+        String(today.getUTCMonth() + 1).padStart(2, "0") +
+        String(today.getUTCDate()).padStart(2, "0");
       expect(result.end).toBe(expectedEnd);
     });
 

--- a/frontend/src/components/bot/interval-picker.tsx
+++ b/frontend/src/components/bot/interval-picker.tsx
@@ -26,9 +26,9 @@ interface IntervalPickerProps {
 }
 
 function formatDate(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, "0");
-  const d = String(date.getDate()).padStart(2, "0");
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(date.getUTCDate()).padStart(2, "0");
   return `${y}${m}${d}`;
 }
 
@@ -56,7 +56,7 @@ export function computeInterval(
     };
   }
   const startDay = new Date(now);
-  startDay.setDate(startDay.getDate() - (preset.days || 1) + 1);
+  startDay.setUTCDate(startDay.getUTCDate() - (preset.days || 1) + 1);
   return {
     type: "range",
     label,

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: the0
 description: An open-source algorithmic trading platform for creating, deploying, and managing trading bots
 type: application
-version: 0.7.7
-appVersion: "1.12.3"
+version: 0.7.8
+appVersion: "1.12.4"
 kubeVersion: ">=1.21.0-0"
 keywords:
   - trading
@@ -31,7 +31,7 @@ annotations:
       url: https://discord.gg/g5mp57nK
   artifacthub.io/changes: |
     - kind: fixed
-      description: Handle Cloudflare R2 NotFound error code for missing log files
+      description: Use UTC dates in interval picker to match log file storage
   artifacthub.io/images: |
     - name: api
       image: ghcr.io/alexanderwanyoike/the0/api


### PR DESCRIPTION
## Summary
- Fix interval picker using local dates instead of UTC to match log file storage
- In UTC+ timezones after midnight local, dashboards showed empty because they requested the wrong day

## Test plan
- [x] 560 frontend tests pass
- [x] Frontend build passes
- [x] Verified: local date returns 0 metrics, UTC date returns 12,385

🤖 Generated with [Claude Code](https://claude.com/claude-code)