### PR TITLE
fix: dashboard refetches metrics when interval changes

### DIFF
--- a/frontend/src/hooks/__tests__/use-bot-events.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-events.test.ts
@@ -181,6 +181,32 @@ describe("useBotEvents", () => {
         }),
       );
     });
+
+    it("should refetch when dateRange prop changes", () => {
+      const { rerender } = renderHook(
+        ({ dateRange }) =>
+          useBotEvents({
+            botId: "bot-123",
+            dateRange,
+          }),
+        {
+          initialProps: {
+            dateRange: { start: "20240101", end: "20240101" },
+          },
+        },
+      );
+
+      // Change dateRange
+      rerender({
+        dateRange: { start: "20240102", end: "20240102" },
+      });
+
+      // Should call setDateRangeFilter with the new range
+      expect(mockSetDateRangeFilter).toHaveBeenCalledWith(
+        "20240102",
+        "20240102",
+      );
+    });
   });
 
   describe("event parsing", () => {

--- a/frontend/src/hooks/use-bot-events.ts
+++ b/frontend/src/hooks/use-bot-events.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, useEffect, useRef } from "react";
 import { useBotLogs } from "./use-bot-logs";
 import {
   BotEvent,
@@ -108,6 +108,16 @@ export function useBotEvents({
     refreshInterval,
     initialQuery,
   });
+
+  // Refetch when dateRange changes
+  const prevDateRange = useRef(dateRange);
+  useEffect(() => {
+    const prev = prevDateRange.current;
+    prevDateRange.current = dateRange;
+    if (!dateRange || !prev) return;
+    if (prev.start === dateRange.start && prev.end === dateRange.end) return;
+    setDateRangeFilter(dateRange.start, dateRange.end);
+  }, [dateRange, setDateRangeFilter]);
 
   // Parse raw logs into events
   // Ensure timestamps are always Date objects for SDK compatibility


### PR DESCRIPTION
## Summary
- `BotEventsProvider` only used `dateRange` on initial mount
- Changing the interval picker didn't trigger a refetch for dashboard metrics
- Added `useEffect` that calls `setDateRangeFilter` when `dateRange` prop changes

## Test plan
- [x] New test: "should refetch when dateRange prop changes"
- [x] 561 frontend tests pass
- [x] Frontend build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date range filter to properly synchronize when the date range is updated.

* **Tests**
  * Added test coverage validating date range filter updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->