### PR TITLE
Release v1.12.5

### DIFF
--- a/frontend/src/hooks/__tests__/use-bot-events.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-events.test.ts
@@ -181,6 +181,32 @@ describe("useBotEvents", () => {
         }),
       );
     });
+
+    it("should refetch when dateRange prop changes", () => {
+      const { rerender } = renderHook(
+        ({ dateRange }) =>
+          useBotEvents({
+            botId: "bot-123",
+            dateRange,
+          }),
+        {
+          initialProps: {
+            dateRange: { start: "20240101", end: "20240101" },
+          },
+        },
+      );
+
+      // Change dateRange
+      rerender({
+        dateRange: { start: "20240102", end: "20240102" },
+      });
+
+      // Should call setDateRangeFilter with the new range
+      expect(mockSetDateRangeFilter).toHaveBeenCalledWith(
+        "20240102",
+        "20240102",
+      );
+    });
   });
 
   describe("event parsing", () => {

--- a/frontend/src/hooks/use-bot-events.ts
+++ b/frontend/src/hooks/use-bot-events.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, useEffect, useRef } from "react";
 import { useBotLogs } from "./use-bot-logs";
 import {
   BotEvent,
@@ -108,6 +108,16 @@ export function useBotEvents({
     refreshInterval,
     initialQuery,
   });
+
+  // Refetch when dateRange changes
+  const prevDateRange = useRef(dateRange);
+  useEffect(() => {
+    const prev = prevDateRange.current;
+    prevDateRange.current = dateRange;
+    if (!dateRange || !prev) return;
+    if (prev.start === dateRange.start && prev.end === dateRange.end) return;
+    setDateRangeFilter(dateRange.start, dateRange.end);
+  }, [dateRange, setDateRangeFilter]);
 
   // Parse raw logs into events
   // Ensure timestamps are always Date objects for SDK compatibility

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: the0
 description: An open-source algorithmic trading platform for creating, deploying, and managing trading bots
 type: application
-version: 0.7.8
-appVersion: "1.12.4"
+version: 0.7.9
+appVersion: "1.12.5"
 kubeVersion: ">=1.21.0-0"
 keywords:
   - trading
@@ -31,7 +31,7 @@ annotations:
       url: https://discord.gg/g5mp57nK
   artifacthub.io/changes: |
     - kind: fixed
-      description: Use UTC dates in interval picker to match log file storage
+      description: Dashboard refetches metrics when interval picker changes
   artifacthub.io/images: |
     - name: api
       image: ghcr.io/alexanderwanyoike/the0/api


### PR DESCRIPTION
## Summary
- Dashboard now refetches metrics when the interval picker changes
- Previously, changing from 1d to 1h had no effect on the dashboard - it only used the initial dateRange on mount

## Test plan
- [x] New test: "should refetch when dateRange prop changes"
- [x] 561 frontend tests pass
- [x] Frontend build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)