### PR TITLE
fix: preserve timestamp field when expanding log entries

### DIFF
--- a/frontend/src/hooks/__tests__/use-bot-logs-stream.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-logs-stream.test.ts
@@ -563,4 +563,55 @@ describe("useBotLogsStream", () => {
       );
     });
   });
+
+  it("should preserve timestamp from SSE history events", async () => {
+    const { result } = renderHook(() =>
+      useBotLogsStream({ botId: "bot-1" }),
+    );
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    act(() => {
+      currentMockStream!.controller.push("history", [
+        {
+          date: "2026-04-03T10:00:00Z",
+          content: "Log line 1",
+          timestamp: "2026-04-03T10:00:00Z",
+        },
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.logs).toHaveLength(1);
+      expect(result.current.logs[0].timestamp).toBe("2026-04-03T10:00:00Z");
+    });
+  });
+
+  it("should preserve timestamp from SSE update events", async () => {
+    const { result } = renderHook(() =>
+      useBotLogsStream({ botId: "bot-1" }),
+    );
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    act(() => {
+      currentMockStream!.controller.push("history", [
+        { date: "2026-04-03T10:00:00Z", content: "Initial", timestamp: "2026-04-03T10:00:00Z" },
+      ]);
+    });
+
+    await waitFor(() => expect(result.current.logs).toHaveLength(1));
+
+    act(() => {
+      currentMockStream!.controller.push("update", {
+        content: "New entry",
+        timestamp: "2026-04-03T10:05:00Z",
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.logs).toHaveLength(2);
+      expect(result.current.logs[1].timestamp).toBe("2026-04-03T10:05:00Z");
+    });
+  });
 });

--- a/frontend/src/hooks/__tests__/use-bot-logs.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-logs.test.ts
@@ -261,6 +261,34 @@ describe("useBotLogs", () => {
     expect(result.current.logs[0].content).toBe("Huge 500");
   });
 
+  it("should preserve timestamp field when expanding log entries", async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            date: "20260403",
+            content: "line1\nline2",
+            timestamp: "2026-04-03T10:00:00Z",
+          },
+        ],
+        total: 2,
+        hasMore: false,
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => useBotLogs({ botId: "bot-1" }));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Both expanded lines should carry the original timestamp
+    expect(result.current.logs).toHaveLength(2);
+    expect(result.current.logs[0].timestamp).toBe("2026-04-03T10:00:00Z");
+    expect(result.current.logs[1].timestamp).toBe("2026-04-03T10:00:00Z");
+  });
+
   // ---- Navigation bugs ----
 
   it("should reset state when botId changes", async () => {

--- a/frontend/src/hooks/use-bot-logs-stream.ts
+++ b/frontend/src/hooks/use-bot-logs-stream.ts
@@ -21,6 +21,7 @@ import { useAuth } from "@/contexts/auth-context";
 import { authFetch } from "@/lib/auth-fetch";
 import { useToast } from "@/hooks/use-toast";
 import { LogEntry } from "@/components/bot/console-interface";
+import { expandLogEntries } from "@/lib/log-utils";
 import { validateSSEAuth } from "@/lib/sse/sse-auth";
 
 interface LogsQuery {
@@ -61,17 +62,6 @@ export interface UseBotLogsStreamReturn {
 
 const MAX_LOG_ENTRIES = 2000;
 
-/** Split multi-line log entries into individual LogEntry items. */
-function expandLogEntries(entries: LogEntry[]): LogEntry[] {
-  const expanded: LogEntry[] = [];
-  for (const entry of entries) {
-    const lines = entry.content.split("\n").filter((l) => l.trim() !== "");
-    for (const line of lines) {
-      expanded.push({ date: entry.date, content: line });
-    }
-  }
-  return expanded;
-}
 
 /** Parse a raw SSE message block into event type and data. */
 function parseSSEMessage(msg: string): { eventType: string; data: string } {
@@ -262,7 +252,7 @@ export const useBotLogsStream = ({
                 const parsed: { content: string; timestamp: string } =
                   JSON.parse(data);
                 const entries = expandLogEntries([
-                  { date: parsed.timestamp, content: parsed.content },
+                  { date: parsed.timestamp, content: parsed.content, timestamp: parsed.timestamp },
                 ]);
                 setLogs((prev) =>
                   [...prev, ...entries].slice(-MAX_LOG_ENTRIES),

--- a/frontend/src/hooks/use-bot-logs.ts
+++ b/frontend/src/hooks/use-bot-logs.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useToast } from "@/hooks/use-toast";
 import { LogEntry } from "@/components/bot/console-interface";
+import { expandLogEntries } from "@/lib/log-utils";
 import { useAuth } from "@/contexts/auth-context";
 import { authFetch } from "@/lib/auth-fetch";
 
@@ -96,20 +97,7 @@ export const useBotLogs = ({
 
         const result: LogsResponse = await response.json();
 
-        // Split each log entry's content into individual lines
-        const expandedLogs: LogEntry[] = [];
-        result.data.forEach((logEntry) => {
-          // Split content by newlines and create individual entries
-          const lines = logEntry.content
-            .split("\n")
-            .filter((line) => line.trim() !== "");
-          lines.forEach((line) => {
-            expandedLogs.push({
-              date: logEntry.date,
-              content: line,
-            });
-          });
-        });
+        const expandedLogs = expandLogEntries(result.data);
 
         if (append) {
           setLogs((prev) => {

--- a/frontend/src/lib/log-utils.ts
+++ b/frontend/src/lib/log-utils.ts
@@ -1,0 +1,20 @@
+import { LogEntry } from "@/components/bot/console-interface";
+
+/**
+ * Split multi-line log entries into individual LogEntry items.
+ * Preserves date, content, and timestamp on each expanded line.
+ */
+export function expandLogEntries(entries: LogEntry[]): LogEntry[] {
+  const expanded: LogEntry[] = [];
+  for (const entry of entries) {
+    const lines = entry.content.split("\n").filter((l) => l.trim() !== "");
+    for (const line of lines) {
+      expanded.push({
+        date: entry.date,
+        content: line,
+        timestamp: entry.timestamp,
+      });
+    }
+  }
+  return expanded;
+}


### PR DESCRIPTION
## Summary
- Log expansion in `useBotLogs` dropped the `timestamp` field from API responses
- Console fell back to parsing timestamps from content instead of using the normalized API value

## Test plan
- [x] New test: "should preserve timestamp field when expanding log entries"
- [x] 562 tests pass, build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying multiline bot log expansion and exact timestamp preservation across entries.

* **Bug Fixes**
  * Ensured timestamps are retained on each expanded log line for accurate chronology.

* **Refactor**
  * Centralized multiline log-expansion into a shared utility to unify behavior across log sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->