### PR TITLE
fix: default interval 1h for scheduled bots

### DIFF
--- a/frontend/src/components/bot/__tests__/interval-picker.test.tsx
+++ b/frontend/src/components/bot/__tests__/interval-picker.test.tsx
@@ -4,6 +4,7 @@ import {
   IntervalPicker,
   LIVE_INTERVAL,
   DEFAULT_DAY_INTERVAL,
+  DEFAULT_INTERVAL,
   computeInterval,
 } from "../interval-picker";
 
@@ -197,6 +198,15 @@ describe("IntervalPicker", () => {
       expect(DEFAULT_DAY_INTERVAL.label).toBe("1d");
       expect(DEFAULT_DAY_INTERVAL.start).toMatch(/^\d{8}$/);
       expect(DEFAULT_DAY_INTERVAL.end).toMatch(/^\d{8}$/);
+    });
+  });
+
+  describe("DEFAULT_INTERVAL constant", () => {
+    it("should be 1h with ISO datetime range", () => {
+      expect(DEFAULT_INTERVAL.label).toBe("1h");
+      // ISO datetime strings contain "T"
+      expect(DEFAULT_INTERVAL.start).toContain("T");
+      expect(DEFAULT_INTERVAL.end).toContain("T");
     });
   });
 

--- a/frontend/src/components/bot/interval-picker.tsx
+++ b/frontend/src/components/bot/interval-picker.tsx
@@ -77,8 +77,10 @@ export const DEFAULT_DAY_INTERVAL: IntervalValue = computeInterval("1d", {
   days: 1,
 });
 
-/** @deprecated Use DEFAULT_DAY_INTERVAL instead */
-export const DEFAULT_INTERVAL: IntervalValue = DEFAULT_DAY_INTERVAL;
+/** Default interval for scheduled bots: last 1 hour */
+export const DEFAULT_INTERVAL: IntervalValue = computeInterval("1h", {
+  hours: 1,
+});
 
 export function IntervalPicker({
   value,

--- a/frontend/src/components/dashboard/bot-detail-panel.tsx
+++ b/frontend/src/components/dashboard/bot-detail-panel.tsx
@@ -22,7 +22,7 @@ import {
   IntervalPicker,
   IntervalValue,
   LIVE_INTERVAL,
-  DEFAULT_DAY_INTERVAL,
+  DEFAULT_INTERVAL,
 } from "@/components/bot/interval-picker";
 import {
   Dialog,
@@ -86,7 +86,7 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
   // Note: bot is null at mount, so useStreaming is initially false. The
   // useEffect below corrects the interval once the bot loads.
   const [interval, setInterval_] = useState<IntervalValue>(
-    useStreaming ? LIVE_INTERVAL : DEFAULT_DAY_INTERVAL,
+    useStreaming ? LIVE_INTERVAL : DEFAULT_INTERVAL,
   );
   const streamingInitialized = useRef(false);
 
@@ -98,7 +98,7 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
   useEffect(() => {
     if (!streamingInitialized.current && bot) {
       streamingInitialized.current = true;
-      setInterval_(useStreaming ? LIVE_INTERVAL : DEFAULT_DAY_INTERVAL);
+      setInterval_(useStreaming ? LIVE_INTERVAL : DEFAULT_INTERVAL);
     }
   }, [useStreaming, bot]);
 


### PR DESCRIPTION
## Summary
- Default interval for scheduled bots changed from 1d to 1h
- 1d loaded too many metrics for active bots, making dashboards slow
- 1h provides a tighter window that loads quickly while showing recent data

## Test plan
- [x] New test: "DEFAULT_INTERVAL should be 1h with ISO datetime range"
- [x] 562 tests pass, build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default time interval for scheduled bots from 1 day to 1 hour, providing more recent data visibility by default.

* **Tests**
  * Added test coverage to validate the default interval configuration and its timestamp values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->