### PR TITLE
feat: configurable refresh interval for console and dashboard

### DIFF
--- a/frontend/src/components/bot/__tests__/refresh-selector.test.tsx
+++ b/frontend/src/components/bot/__tests__/refresh-selector.test.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { RefreshSelector } from "../refresh-selector";
+
+describe("RefreshSelector", () => {
+  const mockOnChange = jest.fn();
+
+  beforeEach(() => {
+    mockOnChange.mockClear();
+  });
+
+  it("should render refresh interval options", () => {
+    render(<RefreshSelector value={30000} onChange={mockOnChange} />);
+
+    expect(screen.getByRole("button", { name: /10s/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /30s/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /60s/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /off/i })).toBeInTheDocument();
+  });
+
+  it("should call onChange when option selected", () => {
+    render(<RefreshSelector value={30000} onChange={mockOnChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /10s/i }));
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(mockOnChange).toHaveBeenCalledWith(10000);
+  });
+
+  it("should highlight active option", () => {
+    render(<RefreshSelector value={30000} onChange={mockOnChange} />);
+
+    const activeButton = screen.getByRole("button", { name: /30s/i });
+    const inactiveButton = screen.getByRole("button", { name: /10s/i });
+
+    expect(activeButton.className).toContain("bg-secondary");
+    expect(inactiveButton.className).not.toContain("bg-secondary");
+  });
+
+  it("should highlight Off when value is 0", () => {
+    render(<RefreshSelector value={0} onChange={mockOnChange} />);
+
+    const offButton = screen.getByRole("button", { name: /off/i });
+    expect(offButton.className).toContain("bg-secondary");
+  });
+
+  it("should call onChange with 0 when Off is clicked", () => {
+    render(<RefreshSelector value={30000} onChange={mockOnChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /off/i }));
+
+    expect(mockOnChange).toHaveBeenCalledWith(0);
+  });
+});

--- a/frontend/src/components/bot/__tests__/refresh-selector.test.tsx
+++ b/frontend/src/components/bot/__tests__/refresh-selector.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { RefreshSelector } from "../refresh-selector";
+import { RefreshSelector, shouldHideRefreshSelector } from "../refresh-selector";
 
 describe("RefreshSelector", () => {
   const mockOnChange = jest.fn();
@@ -50,5 +50,48 @@ describe("RefreshSelector", () => {
     fireEvent.click(screen.getByRole("button", { name: /off/i }));
 
     expect(mockOnChange).toHaveBeenCalledWith(0);
+  });
+
+  it("should render nothing when hidden is true", () => {
+    const { container } = render(
+      <RefreshSelector value={30000} onChange={mockOnChange} hidden />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("should render when hidden is false", () => {
+    render(
+      <RefreshSelector value={30000} onChange={mockOnChange} hidden={false} />,
+    );
+    expect(screen.getByRole("button", { name: /30s/i })).toBeInTheDocument();
+  });
+
+  describe("shouldHideRefreshSelector", () => {
+    it("should be visible for scheduled bots regardless of interval", () => {
+      expect(shouldHideRefreshSelector(false, "1d")).toBe(false);
+      expect(shouldHideRefreshSelector(false, "1h")).toBe(false);
+      expect(shouldHideRefreshSelector(false, "live")).toBe(false);
+      expect(shouldHideRefreshSelector(false, "custom")).toBe(false);
+    });
+
+    it("should be hidden for realtime bots in live mode", () => {
+      expect(shouldHideRefreshSelector(true, "live")).toBe(true);
+    });
+
+    it("should be visible for realtime bots with rolling hour presets", () => {
+      expect(shouldHideRefreshSelector(true, "1h")).toBe(false);
+      expect(shouldHideRefreshSelector(true, "6h")).toBe(false);
+    });
+
+    it("should be hidden for realtime bots with day presets", () => {
+      expect(shouldHideRefreshSelector(true, "1d")).toBe(true);
+      expect(shouldHideRefreshSelector(true, "3d")).toBe(true);
+      expect(shouldHideRefreshSelector(true, "7d")).toBe(true);
+      expect(shouldHideRefreshSelector(true, "30d")).toBe(true);
+    });
+
+    it("should be hidden for realtime bots with custom range", () => {
+      expect(shouldHideRefreshSelector(true, "custom")).toBe(true);
+    });
   });
 });

--- a/frontend/src/components/bot/bot-dashboard-loader.tsx
+++ b/frontend/src/components/bot/bot-dashboard-loader.tsx
@@ -100,6 +100,7 @@ interface BotDashboardLoaderProps {
   customBotId: string;
   version?: string;
   dateRange?: { start: string; end: string };
+  refreshInterval?: number;
   className?: string;
 }
 
@@ -115,6 +116,7 @@ export const BotDashboardLoader = React.memo(function BotDashboardLoader({
   customBotId,
   version,
   dateRange,
+  refreshInterval = 30000,
   className,
 }: BotDashboardLoaderProps) {
   const [BotDashboard, setBotDashboard] = useState<DashboardComponent | null>(
@@ -248,8 +250,8 @@ export const BotDashboardLoader = React.memo(function BotDashboardLoader({
     return (
       <BotEventsProvider
         botId={botId}
-        autoRefresh
-        refreshInterval={30000}
+        autoRefresh={refreshInterval > 0}
+        refreshInterval={refreshInterval || undefined}
         dateRange={dateRange}
       >
         <DashboardErrorBoundary>

--- a/frontend/src/components/bot/refresh-selector.tsx
+++ b/frontend/src/components/bot/refresh-selector.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import React from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { RefreshCw } from "lucide-react";
+
+export interface RefreshSelectorProps {
+  value: number; // ms, 0 = off
+  onChange: (ms: number) => void;
+}
+
+const OPTIONS = [
+  { label: "10s", ms: 10000 },
+  { label: "30s", ms: 30000 },
+  { label: "60s", ms: 60000 },
+  { label: "Off", ms: 0 },
+] as const;
+
+export function RefreshSelector({ value, onChange }: RefreshSelectorProps) {
+  return (
+    <div className="flex items-center gap-1">
+      <RefreshCw className="h-3.5 w-3.5 text-muted-foreground mr-1" />
+
+      {OPTIONS.map((option) => (
+        <Button
+          key={option.label}
+          variant={value === option.ms ? "secondary" : "ghost"}
+          size="sm"
+          className={cn(
+            "h-7 px-2.5 text-xs font-mono",
+            value === option.ms &&
+              "bg-secondary text-secondary-foreground",
+          )}
+          onClick={() => onChange(option.ms)}
+        >
+          {option.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/bot/refresh-selector.tsx
+++ b/frontend/src/components/bot/refresh-selector.tsx
@@ -8,6 +8,7 @@ import { RefreshCw } from "lucide-react";
 export interface RefreshSelectorProps {
   value: number; // ms, 0 = off
   onChange: (ms: number) => void;
+  hidden?: boolean;
 }
 
 const OPTIONS = [
@@ -17,16 +18,30 @@ const OPTIONS = [
   { label: "Off", ms: 0 },
 ] as const;
 
-export function RefreshSelector({ value, onChange }: RefreshSelectorProps) {
+const ROLLING_PRESETS = new Set(["1h", "6h"]);
+
+/** Show refresh selector for scheduled bots (always polling) or
+ *  realtime bots on rolling hour presets where data keeps arriving. */
+export function shouldHideRefreshSelector(
+  useStreaming: boolean,
+  intervalLabel: string,
+): boolean {
+  if (!useStreaming) return false;
+  return !ROLLING_PRESETS.has(intervalLabel);
+}
+
+export function RefreshSelector({ value, onChange, hidden }: RefreshSelectorProps) {
+  if (hidden) return null;
   return (
-    <div className="flex items-center gap-1">
-      <RefreshCw className="h-3.5 w-3.5 text-muted-foreground mr-1" />
+    <div className="flex items-center gap-1" role="group" aria-label="Refresh interval">
+      <RefreshCw className="h-3.5 w-3.5 text-muted-foreground mr-1" aria-hidden="true" />
 
       {OPTIONS.map((option) => (
         <Button
           key={option.label}
           variant={value === option.ms ? "secondary" : "ghost"}
           size="sm"
+          aria-pressed={value === option.ms}
           className={cn(
             "h-7 px-2.5 text-xs font-mono",
             value === option.ms &&

--- a/frontend/src/components/dashboard/bot-detail-panel.tsx
+++ b/frontend/src/components/dashboard/bot-detail-panel.tsx
@@ -24,6 +24,7 @@ import {
   LIVE_INTERVAL,
   DEFAULT_INTERVAL,
 } from "@/components/bot/interval-picker";
+import { RefreshSelector } from "@/components/bot/refresh-selector";
 import {
   Dialog,
   DialogContent,
@@ -78,6 +79,9 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
   const mediaQuery = useMediaQuery("(min-width: 1280px)");
   const isMobile = mediaQuery === null ? null : !mediaQuery;
 
+  // Configurable refresh rate for polling (console + dashboard)
+  const [refreshInterval, setRefreshInterval] = useState(30000);
+
   // Console logs: use SSE streaming for realtime bots, REST polling for scheduled.
   const useStreaming = shouldUseLogStreaming(bot);
 
@@ -106,13 +110,13 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
 
   const streamHook = useBotLogsStream({
     botId: useStreaming ? hookBotId : "",
-    refreshInterval: 60 * 1000,
+    refreshInterval: refreshInterval || undefined,
   });
 
   const pollingHook = useBotLogs({
     botId: useStreaming ? "" : hookBotId,
-    autoRefresh: !useStreaming && bot !== null,
-    refreshInterval: 60 * 1000,
+    autoRefresh: !useStreaming && bot !== null && refreshInterval > 0,
+    refreshInterval: refreshInterval || undefined,
   });
 
   const activeHook = useStreaming ? streamHook : pollingHook;
@@ -458,6 +462,8 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
           interval={interval}
           onIntervalChange={handleIntervalChange}
           showLive={useStreaming}
+          refreshInterval={refreshInterval}
+          onRefreshIntervalChange={setRefreshInterval}
         />
         {cliUpdateModal}
       </>
@@ -547,9 +553,10 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
           </div>
         </div>
 
-        {/* Interval Picker */}
-        <div className="px-4 lg:px-6">
+        {/* Interval Picker + Refresh Selector */}
+        <div className="px-4 lg:px-6 flex flex-wrap items-center gap-4">
           <IntervalPicker value={interval} onChange={handleIntervalChange} showLive={useStreaming} />
+          <RefreshSelector value={refreshInterval} onChange={setRefreshInterval} />
         </div>
 
         {/* Main Content - Dashboard and Console side by side */}
@@ -566,6 +573,7 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
                 customBotId={customBotId}
                 version={bot.config.version}
                 dateRange={interval.type === "range" ? { start: interval.start, end: interval.end } : undefined}
+                refreshInterval={refreshInterval}
                 className=""
               />
             ) : (

--- a/frontend/src/components/dashboard/bot-detail-panel.tsx
+++ b/frontend/src/components/dashboard/bot-detail-panel.tsx
@@ -24,7 +24,7 @@ import {
   LIVE_INTERVAL,
   DEFAULT_INTERVAL,
 } from "@/components/bot/interval-picker";
-import { RefreshSelector } from "@/components/bot/refresh-selector";
+import { RefreshSelector, shouldHideRefreshSelector } from "@/components/bot/refresh-selector";
 import {
   Dialog,
   DialogContent,
@@ -110,13 +110,13 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
 
   const streamHook = useBotLogsStream({
     botId: useStreaming ? hookBotId : "",
-    refreshInterval: refreshInterval || undefined,
+    refreshInterval,
   });
 
   const pollingHook = useBotLogs({
     botId: useStreaming ? "" : hookBotId,
     autoRefresh: !useStreaming && bot !== null && refreshInterval > 0,
-    refreshInterval: refreshInterval || undefined,
+    refreshInterval,
   });
 
   const activeHook = useStreaming ? streamHook : pollingHook;
@@ -556,7 +556,7 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
         {/* Interval Picker + Refresh Selector */}
         <div className="px-4 lg:px-6 flex flex-wrap items-center gap-4">
           <IntervalPicker value={interval} onChange={handleIntervalChange} showLive={useStreaming} />
-          <RefreshSelector value={refreshInterval} onChange={setRefreshInterval} />
+          <RefreshSelector value={refreshInterval} onChange={setRefreshInterval} hidden={shouldHideRefreshSelector(useStreaming, interval.label)} />
         </div>
 
         {/* Main Content - Dashboard and Console side by side */}

--- a/frontend/src/components/dashboard/mobile-bot-detail.tsx
+++ b/frontend/src/components/dashboard/mobile-bot-detail.tsx
@@ -20,6 +20,7 @@ import {
   IntervalPicker,
   IntervalValue,
 } from "@/components/bot/interval-picker";
+import { RefreshSelector } from "@/components/bot/refresh-selector";
 import { Bot as ApiBotType } from "@/lib/api/api-client";
 import {
   AlertDialog,
@@ -67,6 +68,8 @@ interface MobileBotDetailProps {
   interval: IntervalValue;
   onIntervalChange: (value: IntervalValue) => void;
   showLive?: boolean;
+  refreshInterval: number;
+  onRefreshIntervalChange: (ms: number) => void;
 }
 
 export function MobileBotDetail({
@@ -97,6 +100,8 @@ export function MobileBotDetail({
   interval,
   onIntervalChange,
   showLive,
+  refreshInterval,
+  onRefreshIntervalChange,
 }: MobileBotDetailProps) {
   const router = useRouter();
 
@@ -128,9 +133,10 @@ export function MobileBotDetail({
         </div>
       </div>
 
-      {/* Interval Picker */}
-      <div className="px-3 py-2 border-b">
+      {/* Interval Picker + Refresh Selector */}
+      <div className="px-3 py-2 border-b space-y-1.5">
         <IntervalPicker value={interval} onChange={onIntervalChange} showLive={showLive} />
+        <RefreshSelector value={refreshInterval} onChange={onRefreshIntervalChange} />
       </div>
 
       {/* Tabbed content */}
@@ -155,6 +161,7 @@ export function MobileBotDetail({
               customBotId={customBotId}
               version={bot.config.version}
               dateRange={{ start: interval.start, end: interval.end }}
+              refreshInterval={refreshInterval}
               className=""
             />
           ) : (

--- a/frontend/src/components/dashboard/mobile-bot-detail.tsx
+++ b/frontend/src/components/dashboard/mobile-bot-detail.tsx
@@ -20,7 +20,7 @@ import {
   IntervalPicker,
   IntervalValue,
 } from "@/components/bot/interval-picker";
-import { RefreshSelector } from "@/components/bot/refresh-selector";
+import { RefreshSelector, shouldHideRefreshSelector } from "@/components/bot/refresh-selector";
 import { Bot as ApiBotType } from "@/lib/api/api-client";
 import {
   AlertDialog,
@@ -136,7 +136,7 @@ export function MobileBotDetail({
       {/* Interval Picker + Refresh Selector */}
       <div className="px-3 py-2 border-b space-y-1.5">
         <IntervalPicker value={interval} onChange={onIntervalChange} showLive={showLive} />
-        <RefreshSelector value={refreshInterval} onChange={onRefreshIntervalChange} />
+        <RefreshSelector value={refreshInterval} onChange={onRefreshIntervalChange} hidden={shouldHideRefreshSelector(!!showLive, interval.label)} />
       </div>
 
       {/* Tabbed content */}

--- a/frontend/src/hooks/__tests__/use-bot-logs-stream.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-logs-stream.test.ts
@@ -614,4 +614,95 @@ describe("useBotLogsStream", () => {
       expect(result.current.logs[1].timestamp).toBe("2026-04-03T10:05:00Z");
     });
   });
+
+  it("should not start polling when refreshInterval is 0 and SSE fails", async () => {
+    jest.useFakeTimers();
+    try {
+      mockAuthFetch.mockImplementation(async (url: string) => {
+        if (typeof url === "string" && url.includes("/stream")) {
+          throw new Error("SSE failed");
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{ date: "20260406", content: "log" }],
+            total: 1,
+            hasMore: false,
+          }),
+        } as any;
+      });
+
+      const { result } = renderHook(() =>
+        useBotLogsStream({ botId: "bot-1", refreshInterval: 0 }),
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(5000);
+      });
+
+      const callsAfterFallback = mockAuthFetch.mock.calls.filter(
+        (call) => typeof call[0] === "string" && !call[0].includes("/stream"),
+      ).length;
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(60000);
+      });
+
+      const callsAfterWait = mockAuthFetch.mock.calls.filter(
+        (call) => typeof call[0] === "string" && !call[0].includes("/stream"),
+      ).length;
+
+      expect(callsAfterWait).toBe(callsAfterFallback);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("should reconfigure polling interval when refreshInterval prop changes", async () => {
+    jest.useFakeTimers();
+    try {
+      // SSE fails, falls back to polling
+      mockAuthFetch.mockImplementation(async (url: string) => {
+        if (typeof url === "string" && url.includes("/stream")) {
+          throw new Error("SSE failed");
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{ date: "20260406", content: "log" }],
+            total: 1,
+            hasMore: false,
+          }),
+        } as any;
+      });
+
+      const { rerender } = renderHook(
+        ({ interval }) =>
+          useBotLogsStream({ botId: "bot-1", refreshInterval: interval }),
+        { initialProps: { interval: 60000 } },
+      );
+
+      // Wait for SSE failure and fallback
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(5000);
+      });
+
+      mockAuthFetch.mockClear();
+
+      // Change refresh interval to 5s
+      rerender({ interval: 5000 });
+
+      // Advance 5s - should poll with new interval
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(5000);
+      });
+
+      const restCalls = mockAuthFetch.mock.calls.filter(
+        (call) => typeof call[0] === "string" && !call[0].includes("/stream"),
+      );
+      expect(restCalls.length).toBeGreaterThan(0);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/frontend/src/hooks/__tests__/use-bot-logs.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-logs.test.ts
@@ -568,4 +568,85 @@ describe("useBotLogs", () => {
     expect(calledUrl).toContain("limit=50");
     expect(calledUrl).toContain("offset=10");
   });
+
+  it("should reconfigure polling when refreshInterval changes", async () => {
+    jest.useFakeTimers();
+    try {
+      mockAuthFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20260406", content: "Log" }],
+          total: 1,
+          hasMore: false,
+        }),
+      } as Response);
+
+      const { rerender } = renderHook(
+        ({ interval }) =>
+          useBotLogs({
+            botId: "bot-1",
+            autoRefresh: true,
+            refreshInterval: interval,
+          }),
+        { initialProps: { interval: 60000 } },
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      mockAuthFetch.mockClear();
+
+      // Change refresh interval to 5000ms
+      rerender({ interval: 5000 });
+
+      // Advance 5 seconds - should fire with new interval
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(5000);
+      });
+
+      // Should have fetched with the new interval
+      expect(mockAuthFetch).toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("should not poll when refreshInterval is 0 (Off)", async () => {
+    jest.useFakeTimers();
+    try {
+      mockAuthFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20260406", content: "Log" }],
+          total: 1,
+          hasMore: false,
+        }),
+      } as Response);
+
+      renderHook(() =>
+        useBotLogs({
+          botId: "bot-1",
+          autoRefresh: true,
+          refreshInterval: 0,
+        }),
+      );
+
+      // Flush initial fetch
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      mockAuthFetch.mockClear();
+
+      // Advance 60 seconds - should NOT poll
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(60000);
+      });
+
+      expect(mockAuthFetch).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/frontend/src/hooks/use-bot-logs-stream.ts
+++ b/frontend/src/hooks/use-bot-logs-stream.ts
@@ -275,7 +275,9 @@ export const useBotLogsStream = ({
 
         // Fall back to REST polling
         fetchLogs();
-        pollingRef.current = setInterval(() => fetchLogs(), refreshInterval);
+        if (refreshInterval > 0) {
+          pollingRef.current = setInterval(() => fetchLogs(), refreshInterval);
+        }
       });
   }, [botId, user, refreshInterval, fetchLogs, stopPolling]);
 
@@ -306,7 +308,9 @@ export const useBotLogsStream = ({
     const fallbackTimer = setTimeout(() => {
       if (!historyReceivedRef.current) {
         fetchLogs();
-        pollingRef.current = setInterval(() => fetchLogs(), refreshInterval);
+        if (refreshInterval > 0) {
+          pollingRef.current = setInterval(() => fetchLogs(), refreshInterval);
+        }
       }
     }, 4000);
 
@@ -314,7 +318,7 @@ export const useBotLogsStream = ({
       clearTimeout(fallbackTimer);
       abortAll();
     };
-  }, [botId, user]);
+  }, [botId, user, refreshInterval]);
 
   // -- Date filter: disconnect SSE, fetch REST, reconnect on clear --
 

--- a/frontend/src/hooks/use-bot-logs.ts
+++ b/frontend/src/hooks/use-bot-logs.ts
@@ -256,7 +256,7 @@ export const useBotLogs = ({
       if (interval) clearInterval(interval);
       abortControllerRef.current?.abort();
     };
-  }, [botId, user]);
+  }, [botId, user, autoRefresh, refreshInterval]);
 
   return {
     logs,


### PR DESCRIPTION
## Summary
- Users can now select polling frequency: 10s / 30s / 60s / Off
- Previously hardcoded at 60s for console and 30s for dashboard
- New `RefreshSelector` component matching interval picker style

## Test plan
- [x] 5 new tests for RefreshSelector component
- [x] 566 tests pass, build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a refresh interval selector (10s, 30s, 60s, Off) in both mobile and desktop bot views; selection is passed to the dashboard loader.

* **Bug Fixes**
  * Auto-refresh now respects the chosen interval, immediately applies changes, and disables polling when Off. Default refresh set to 30s.

* **Tests**
  * Added UI tests for the selector and tests covering polling behavior when intervals change or are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->