### PR TITLE
fix: prevent console refresh loop on interval change

### DIFF
--- a/frontend/src/hooks/__tests__/use-bot-logs.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-logs.test.ts
@@ -406,6 +406,116 @@ describe("useBotLogs", () => {
     expect(result.current.error).toBeNull();
   });
 
+  it("should not trigger extra fetches when date filter changes during auto-refresh", async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ date: "20260401", content: "Log" }],
+        total: 1,
+        hasMore: false,
+      }),
+    } as Response);
+
+    const { result } = renderHook(() =>
+      useBotLogs({
+        botId: "bot-1",
+        autoRefresh: true,
+        refreshInterval: 60000,
+      }),
+    );
+
+    // Wait for initial fetch to complete
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const callsAfterInit = mockAuthFetch.mock.calls.length;
+
+    // Change the date range filter
+    act(() => {
+      result.current.setDateRangeFilter("20260401", "20260403");
+    });
+
+    // Wait for the filter-triggered fetch to settle
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Brief pause to catch any spurious extra fetches
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    const callsAfterFilter = mockAuthFetch.mock.calls.length;
+    // Expect exactly one additional fetch from the filter change, not multiple
+    expect(callsAfterFilter - callsAfterInit).toBe(1);
+  });
+
+  it("should use latest query when polling interval fires after filter change", async () => {
+    // This tests the stale closure bug: the polling interval captures fetchLogs
+    // at setup time. If fetchLogs changes (because query changed), the interval
+    // should still call the latest version, not the stale one.
+    jest.useFakeTimers();
+    try {
+      mockAuthFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20260401", content: "Log" }],
+          total: 1,
+          hasMore: false,
+        }),
+      } as Response);
+
+      const { result } = renderHook(() =>
+        useBotLogs({
+          botId: "bot-1",
+          autoRefresh: true,
+          refreshInterval: 5000,
+        }),
+      );
+
+      // Flush initial fetch
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Change date range filter - this updates the query state and calls fetchLogs
+      await act(async () => {
+        result.current.setDateRangeFilter("20260401", "20260403");
+      });
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Clear call history so we can inspect what the next interval tick sends
+      mockAuthFetch.mockClear();
+
+      // Advance past the polling interval so it fires
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(5000);
+      });
+
+      // The polling fetch should have fired
+      expect(mockAuthFetch).toHaveBeenCalled();
+
+      // The polling fetch should use the UPDATED date range, not the original query.
+      // If the closure is stale, it will use the default query (today's date, no dateRange).
+      const pollingUrl = mockAuthFetch.mock.calls[0][0] as string;
+      expect(pollingUrl).toContain("dateRange=20260401-20260403");
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   // ---- Existing tests ----
 
   it("should build correct URL with query parameters", async () => {

--- a/frontend/src/hooks/use-bot-logs.ts
+++ b/frontend/src/hooks/use-bot-logs.ts
@@ -46,6 +46,9 @@ export const useBotLogs = ({
   const { toast } = useToast();
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
+  // Ref to always hold the latest fetchLogs so the polling interval
+  // never calls a stale closure after query/filter changes.
+  const fetchLogsRef = useRef<typeof fetchLogs>(null!);
 
   const fetchLogs = useCallback(
     async (queryParams: LogsQuery = query, append: boolean = false) => {
@@ -153,6 +156,7 @@ export const useBotLogs = ({
     },
     [botId, query, toast, user],
   );
+  fetchLogsRef.current = fetchLogs;
 
   // Load more logs (pagination)
   const loadMore = useCallback(async () => {
@@ -255,7 +259,9 @@ export const useBotLogs = ({
 
     let interval: NodeJS.Timeout | null = null;
     if (autoRefresh && refreshInterval > 0) {
-      interval = setInterval(() => fetchLogs(), refreshInterval);
+      // Use the ref so the interval always calls the latest fetchLogs
+      // without needing to recreate the timer on every query change.
+      interval = setInterval(() => fetchLogsRef.current(), refreshInterval);
     }
 
     return () => {


### PR DESCRIPTION
## Summary
- Polling interval captured stale fetchLogs closure
- Changing filters caused the interval to use old query params
- Now uses a ref to always call the latest fetchLogs

## Test plan
- [x] New test: "should not trigger extra fetches when date filter changes"
- [x] New test: "should use latest query when polling interval fires after filter change"
- [x] 563 tests pass, build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-refresh polling now uses the latest date-range filter when the date range is changed during an active refresh cycle.

* **Tests**
  * Added unit tests verifying auto-refresh handles dynamic date-filter changes and that subsequent polling uses updated query parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->