### PR TITLE
fix: enable load more for realtime bots on non-live intervals

### DIFF
--- a/frontend/src/components/dashboard/bot-detail-panel.tsx
+++ b/frontend/src/components/dashboard/bot-detail-panel.tsx
@@ -146,9 +146,14 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
   const loadingEarlier = useStreaming ? streamHook.loadingEarlier : undefined;
   const loadEarlierLogs = useStreaming ? streamHook.loadEarlierLogs : undefined;
 
-  // Pagination: only relevant for REST polling (not SSE streaming)
-  const hasMoreLogs = !useStreaming ? pollingHook.hasMore : undefined;
-  const loadMoreLogs = !useStreaming ? pollingHook.loadMore : undefined;
+  // Pagination: available for REST polling and for stream hook's REST mode
+  // (when a realtime bot is viewing a date range)
+  const hasMoreLogs = useStreaming
+    ? streamHook.hasMore || undefined
+    : pollingHook.hasMore || undefined;
+  const loadMoreLogs = useStreaming
+    ? streamHook.loadMore
+    : pollingHook.loadMore;
 
   useEffect(() => {
     const fetchBot = async () => {
@@ -452,7 +457,7 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
           loadEarlierLogs={loadEarlierLogs}
           hasMore={hasMoreLogs}
           loadMore={loadMoreLogs}
-          loadingMore={!useStreaming ? logsLoading : undefined}
+          loadingMore={hasMoreLogs ? logsLoading : undefined}
           isUpdatingEnabled={isUpdatingEnabled}
           isDeleting={isDeleting}
           onToggleEnabled={handleToggleEnabled}
@@ -612,7 +617,7 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
                 onLoadEarlier={loadEarlierLogs}
                 hasMore={hasMoreLogs}
                 loadMore={loadMoreLogs}
-                loadingMore={!useStreaming ? logsLoading : undefined}
+                loadingMore={hasMoreLogs ? logsLoading : undefined}
                 className="h-full"
                 compact
               />

--- a/frontend/src/hooks/__tests__/use-bot-logs-stream.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-logs-stream.test.ts
@@ -661,7 +661,6 @@ describe("useBotLogsStream", () => {
   it("should reconfigure polling interval when refreshInterval prop changes", async () => {
     jest.useFakeTimers();
     try {
-      // SSE fails, falls back to polling
       mockAuthFetch.mockImplementation(async (url: string) => {
         if (typeof url === "string" && url.includes("/stream")) {
           throw new Error("SSE failed");
@@ -682,17 +681,14 @@ describe("useBotLogsStream", () => {
         { initialProps: { interval: 60000 } },
       );
 
-      // Wait for SSE failure and fallback
       await act(async () => {
         await jest.advanceTimersByTimeAsync(5000);
       });
 
       mockAuthFetch.mockClear();
 
-      // Change refresh interval to 5s
       rerender({ interval: 5000 });
 
-      // Advance 5s - should poll with new interval
       await act(async () => {
         await jest.advanceTimersByTimeAsync(5000);
       });
@@ -704,5 +700,305 @@ describe("useBotLogsStream", () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+
+  // ---- Pagination on date range (REST mode) ----
+
+  it("should expose hasMore and loadMore from REST when date range is set", async () => {
+    const { result } = renderHook(() =>
+      useBotLogsStream({ botId: "bot-1" }),
+    );
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/stream")) {
+        currentMockStream = createMockSSEStream();
+        return { ok: true, body: currentMockStream.stream } as any;
+      }
+      const parsedUrl = new URL(url, "http://localhost");
+      const offset = parseInt(parsedUrl.searchParams.get("offset") || "0");
+      if (offset === 0) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{ date: "20240101", content: "Page 1 log" }],
+            total: 2,
+            hasMore: true,
+          }),
+        } as any;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20240101", content: "Page 2 log" }],
+          total: 2,
+          hasMore: false,
+        }),
+      } as any;
+    });
+
+    act(() => {
+      result.current.setDateRangeFilter("20240101", "20240102");
+    });
+
+    await waitFor(() => {
+      expect(result.current.connected).toBe(false);
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    expect(typeof result.current.loadMore).toBe("function");
+
+    await act(async () => {
+      await result.current.loadMore!();
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(false);
+      expect(result.current.logs.length).toBe(2);
+    });
+  });
+
+  it("should not reset hasMore when loading earlier logs via prepend", async () => {
+    const { result } = renderHook(() =>
+      useBotLogsStream({ botId: "bot-1" }),
+    );
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    // Switch to REST with hasMore=true
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/stream")) {
+        currentMockStream = createMockSSEStream();
+        return { ok: true, body: currentMockStream.stream } as any;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20240101", content: "Log" }],
+          total: 5000,
+          hasMore: true,
+        }),
+      } as any;
+    });
+
+    act(() => {
+      result.current.setDateRangeFilter("20240101", "20240102");
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    // Now loadEarlierLogs returns hasMore=false
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/stream")) {
+        currentMockStream = createMockSSEStream();
+        return { ok: true, body: currentMockStream.stream } as any;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20240101", content: "Earlier log" }],
+          total: 1,
+          hasMore: false,
+        }),
+      } as any;
+    });
+
+    await act(async () => {
+      result.current.loadEarlierLogs();
+    });
+
+    await waitFor(() => {
+      expect(result.current.logs.length).toBeGreaterThan(1);
+    });
+
+    // hasMore should still be true - the prepend fetch should not overwrite it
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it("should not allow duplicate loadMore calls while fetch is in-flight", async () => {
+    const { result } = renderHook(() =>
+      useBotLogsStream({ botId: "bot-1" }),
+    );
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    let fetchCount = 0;
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/stream")) {
+        currentMockStream = createMockSSEStream();
+        return { ok: true, body: currentMockStream.stream } as any;
+      }
+      fetchCount++;
+      // Slow response to test duplicate guard
+      await new Promise((r) => setTimeout(r, 50));
+      return {
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20240101", content: `Page ${fetchCount}` }],
+          total: 100,
+          hasMore: true,
+        }),
+      } as any;
+    });
+
+    act(() => {
+      result.current.setDateRangeFilter("20240101", "20240102");
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    fetchCount = 0;
+
+    // Call loadMore twice rapidly
+    act(() => {
+      result.current.loadMore!();
+      result.current.loadMore!();
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    // Should only have fetched once, not twice
+    expect(fetchCount).toBe(1);
+  });
+
+  it("should not advance offset when loadMore fetch fails", async () => {
+    const { result } = renderHook(() =>
+      useBotLogsStream({ botId: "bot-1" }),
+    );
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/stream")) {
+        currentMockStream = createMockSSEStream();
+        return { ok: true, body: currentMockStream.stream } as any;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20240101", content: "Page 1" }],
+          total: 100,
+          hasMore: true,
+        }),
+      } as any;
+    });
+
+    act(() => {
+      result.current.setDateRangeFilter("20240101", "20240102");
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    // Make next fetch fail
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/stream")) {
+        currentMockStream = createMockSSEStream();
+        return { ok: true, body: currentMockStream.stream } as any;
+      }
+      throw new Error("Network error");
+    });
+
+    await act(async () => {
+      await result.current.loadMore!();
+    });
+
+    // hasMore should still be true - offset not advanced
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it("should keep prepended logs when buffer is full", async () => {
+    const { result } = renderHook(() =>
+      useBotLogsStream({ botId: "bot-1" }),
+    );
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    // Fill buffer to MAX_LOG_ENTRIES with history
+    const entries = Array.from({ length: 2000 }, (_, i) => ({
+      date: "2024-01-01T10:00:00Z",
+      content: `Entry ${i}`,
+    }));
+
+    act(() => {
+      currentMockStream!.controller.push("history", entries);
+    });
+
+    await waitFor(() => {
+      expect(result.current.logs).toHaveLength(2000);
+    });
+
+    // Now prepend earlier logs via REST
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/stream")) {
+        currentMockStream = createMockSSEStream();
+        return { ok: true, body: currentMockStream.stream } as any;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20240101", content: "Earlier log" }],
+          total: 1,
+          hasMore: false,
+        }),
+      } as any;
+    });
+
+    await act(async () => {
+      result.current.loadEarlierLogs();
+    });
+
+    await waitFor(() => {
+      // The earlier log should be at the start, not dropped
+      expect(result.current.logs[0].content).toBe("Earlier log");
+    });
+  });
+
+  it("should reset hasMore when reconnecting SSE after clearing date filter", async () => {
+    const { result } = renderHook(() =>
+      useBotLogsStream({ botId: "bot-1" }),
+    );
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/stream")) {
+        currentMockStream = createMockSSEStream();
+        return { ok: true, body: currentMockStream.stream } as any;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20240101", content: "Historical" }],
+          total: 100,
+          hasMore: true,
+        }),
+      } as any;
+    });
+
+    act(() => {
+      result.current.setDateRangeFilter("20240101", "20240102");
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    act(() => {
+      result.current.setDateFilter(null);
+    });
+
+    await waitFor(() => {
+      expect(result.current.connected).toBe(true);
+      expect(result.current.hasMore).toBe(false);
+    });
   });
 });

--- a/frontend/src/hooks/use-bot-logs-stream.ts
+++ b/frontend/src/hooks/use-bot-logs-stream.ts
@@ -58,6 +58,8 @@ export interface UseBotLogsStreamReturn {
   hasEarlierLogs: boolean;
   loadingEarlier: boolean;
   loadEarlierLogs: () => void;
+  /** Load more paginated results (only available in REST mode, i.e. when a date filter is active) */
+  loadMore?: () => Promise<void>;
 }
 
 const MAX_LOG_ENTRIES = 2000;
@@ -87,6 +89,7 @@ export const useBotLogsStream = ({
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
   const [hasEarlierLogs, setHasEarlierLogs] = useState(false);
   const [loadingEarlier, setLoadingEarlier] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
   const [query, setQuery] = useState<LogsQuery>(initialQuery);
   const [totalSeen, setTotalSeen] = useState(0);
 
@@ -98,6 +101,7 @@ export const useBotLogsStream = ({
   const pollingRef = useRef<NodeJS.Timeout | null>(null);
   const dateFilterActiveRef = useRef(false);
   const historyReceivedRef = useRef(false);
+  const loadingMoreRef = useRef(false);
 
   // -- Cleanup helpers --
 
@@ -119,7 +123,7 @@ export const useBotLogsStream = ({
   // -- REST fetch (for fallback, date filters, load-earlier) --
 
   const fetchLogs = useCallback(
-    async (params?: Partial<LogsQuery>, append = false) => {
+    async (params?: Partial<LogsQuery>, merge: false | "prepend" | "append" = false) => {
       if (!botId || !user) return;
 
       restAbortRef.current?.abort();
@@ -129,7 +133,7 @@ export const useBotLogsStream = ({
       const effectiveQuery = { ...query, ...params };
 
       try {
-        if (!append) setLoading(true);
+        if (!merge) setLoading(true);
         setError(null);
 
         const searchParams = new URLSearchParams();
@@ -160,21 +164,30 @@ export const useBotLogsStream = ({
         const result: LogsResponse = await response.json();
         const expanded = expandLogEntries(result.data);
 
-        if (append) {
+        if (merge) {
           setLogs((prev) => {
-            // Deduplicate: earlier logs may overlap with entries already in the buffer
             const existingKeys = new Set(
               prev.map((l) => `${l.date}|${l.content}`),
             );
             const unique = expanded.filter(
               (l) => !existingKeys.has(`${l.date}|${l.content}`),
             );
-            const combined = [...unique, ...prev];
-            return combined.slice(0, MAX_LOG_ENTRIES);
+            const combined = merge === "prepend"
+              ? [...unique, ...prev]
+              : [...prev, ...unique];
+            // Prepend keeps the front (earlier logs), append keeps the tail (latest)
+            return merge === "prepend"
+              ? combined.slice(0, MAX_LOG_ENTRIES)
+              : combined.slice(-MAX_LOG_ENTRIES);
           });
         } else {
           setLogs(expanded.slice(-MAX_LOG_ENTRIES));
           setHasEarlierLogs(expanded.length >= MAX_LOG_ENTRIES);
+        }
+        // Only update forward pagination state on non-prepend fetches.
+        // Prepend (loadEarlierLogs) has its own hasMore semantics.
+        if (merge !== "prepend") {
+          setHasMore(result.hasMore);
         }
         setTotalSeen(result.total);
         setLastUpdate(new Date());
@@ -298,6 +311,7 @@ export const useBotLogsStream = ({
     setLastUpdate(null);
     setHasEarlierLogs(false);
     setLoadingEarlier(false);
+    setHasMore(false);
     setQuery(initialQuery);
     dateFilterActiveRef.current = false;
     historyReceivedRef.current = false;
@@ -340,6 +354,10 @@ export const useBotLogsStream = ({
         setConnected(false);
         fetchLogs(updatedQuery);
       } else {
+        // Reconnecting to SSE - abort any in-flight REST request and reset
+        restAbortRef.current?.abort();
+        restAbortRef.current = null;
+        setHasMore(false);
         connectSSE();
       }
     },
@@ -378,9 +396,29 @@ export const useBotLogsStream = ({
     const date =
       query.date ||
       new Date().toISOString().slice(0, 10).replace(/-/g, "");
-    await fetchLogs({ date, limit: 1000, offset: 0 }, true);
+    await fetchLogs({ date, limit: 1000, offset: 0 }, "prepend");
     setHasEarlierLogs(false);
   }, [botId, user, loadingEarlier, fetchLogs, query.date]);
+
+  // -- Load more (pagination for REST date-range fetches) --
+
+  const loadMore = useCallback(async () => {
+    if (loadingMoreRef.current || !hasMore || !botId || !user) return;
+    loadingMoreRef.current = true;
+
+    const nextQuery = {
+      ...query,
+      offset: (query.offset || 0) + (query.limit || 100),
+    };
+
+    try {
+      await fetchLogs(nextQuery, "append");
+      // Only advance offset after successful fetch
+      setQuery(nextQuery);
+    } finally {
+      loadingMoreRef.current = false;
+    }
+  }, [hasMore, botId, user, query, fetchLogs]);
 
   // -- Refresh: reconnect or re-fetch depending on mode --
 
@@ -419,7 +457,7 @@ export const useBotLogsStream = ({
     logs,
     loading,
     error,
-    hasMore: false,
+    hasMore,
     total: totalSeen,
     refresh,
     exportLogs,
@@ -430,5 +468,6 @@ export const useBotLogsStream = ({
     hasEarlierLogs,
     loadingEarlier,
     loadEarlierLogs,
+    loadMore: hasMore ? loadMore : undefined,
   };
 };


### PR DESCRIPTION
## Summary
- useBotLogsStream now exposes hasMore and loadMore from REST fetches when a date filter is active
- Previously hardcoded hasMore: false, hiding pagination on historical ranges
- Console shows load more footer for realtime bots browsing history

## Test plan
- [x] New test: "should expose hasMore and loadMore from REST when date range is set"
- [x] New test: "should reset hasMore when reconnecting SSE after clearing date filter"
- [x] 563 tests pass, build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed incremental "load more" pagination for REST log views (loadMore available only when additional pages exist)

* **Bug Fixes**
  * Loading indicators now reflect actual pagination availability instead of streaming mode
  * Consistent pagination behavior between streaming and REST log modes

* **Tests**
  * Added unit tests covering REST pagination and SSE reconnection when clearing date filters
<!-- end of auto-generated comment: release notes by coderabbit.ai -->