### PR TITLE
Release v1.13.0: console polish, API log sort, R2 multipart leak fix

### DIFF
--- a/api/src/logs/__tests__/logs.controller.spec.ts
+++ b/api/src/logs/__tests__/logs.controller.spec.ts
@@ -66,7 +66,7 @@ describe("LogsController", () => {
       expect(result.hasMore).toBe(false);
       expect(mockLogsService.getLogs).toHaveBeenCalledWith(
         "bot-123",
-        { date: undefined, dateRange: undefined, limit: 100, offset: 0 },
+        { date: undefined, dateRange: undefined, limit: 100, offset: 0, sort: "desc" },
         "user123",
       );
     });
@@ -113,6 +113,7 @@ describe("LogsController", () => {
           limit: 100,
           offset: 0,
           type: "metrics",
+          sort: "desc",
         },
         "user123",
       );
@@ -194,6 +195,7 @@ describe("LogsController", () => {
           limit: 50,
           offset: 0,
           type: "all",
+          sort: "desc",
         },
         "user123",
       );

--- a/api/src/logs/__tests__/logs.service.spec.ts
+++ b/api/src/logs/__tests__/logs.service.spec.ts
@@ -181,6 +181,7 @@ describe("LogsService", () => {
         dateRange: "20260401-20260402",
         limit: 3,
         offset: 5,
+        sort: "asc",
       });
 
       expect(result.success).toBe(true);
@@ -230,6 +231,7 @@ describe("LogsService", () => {
         limit: 10,
         offset: 1,
         type: "metrics",
+        sort: "asc",
       });
 
       expect(result.success).toBe(true);
@@ -366,6 +368,7 @@ describe("LogsService", () => {
         dateRange: "20260401-20260402",
         limit: 4,
         offset: 0,
+        sort: "asc",
       });
 
       expect(result.success).toBe(true);
@@ -387,6 +390,7 @@ describe("LogsService", () => {
         dateRange: "20260401-20260402",
         limit: 2,
         offset: 1,
+        sort: "asc",
       });
 
       expect(result.success).toBe(true);
@@ -710,6 +714,7 @@ describe("LogsService", () => {
         dateRange: "20260401-20260402",
         limit: 10,
         offset: 0,
+        sort: "asc",
       });
 
       expect(result.success).toBe(true);
@@ -736,6 +741,7 @@ describe("LogsService", () => {
         limit: 10,
         offset: 0,
         type: "metrics",
+        sort: "asc",
       });
 
       expect(result.success).toBe(true);
@@ -862,6 +868,7 @@ describe("LogsService", () => {
         dateRange: "2026-04-03T10:00:00Z--2026-04-03T11:00:00Z",
         limit: 100,
         offset: 0,
+        sort: "asc",
       });
 
       expect(result.success).toBe(true);
@@ -884,6 +891,7 @@ describe("LogsService", () => {
         dateRange: "20260401-20260403",
         limit: 100,
         offset: 0,
+        sort: "asc",
       });
 
       expect(result.success).toBe(true);
@@ -911,6 +919,7 @@ describe("LogsService", () => {
         dateRange: "2026-04-02T23:00:00Z--2026-04-03T01:00:00Z",
         limit: 100,
         offset: 0,
+        sort: "asc",
       });
 
       expect(result.success).toBe(true);
@@ -933,6 +942,7 @@ describe("LogsService", () => {
         dateRange: "2026-04-03T10:00:00Z--2026-04-03T11:00:00Z",
         limit: 100,
         offset: 0,
+        sort: "asc",
       });
 
       expect(result.success).toBe(true);
@@ -971,6 +981,121 @@ describe("LogsService", () => {
       expect(result.success).toBe(true);
       expect(result.data!.entries).toHaveLength(1);
       expect(result.data!.entries[0].content).toBe("mid-morning");
+    });
+  });
+
+  describe("getLogs - sort parameter", () => {
+    it("should return newest-first by default for single date (tail path)", async () => {
+      const lines = Array.from(
+        { length: 10 },
+        (_, i) => `{"timestamp":"2026-04-01T${String(i).padStart(2, "0")}:00:00Z","message":"line-${i}"}`,
+      ).join("\n") + "\n";
+
+      mockMinioClient.statObject.mockResolvedValue({ size: 100 });
+      mockMinioClient.getObject.mockResolvedValue(stringStream(lines));
+
+      const result = await service.getLogs("bot-1", {
+        date: "20260401",
+        limit: 5,
+        offset: 0,
+        sort: "desc",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data!.entries).toHaveLength(5);
+      // Tail already returns newest-first; sort=desc should keep that order
+      expect(result.data!.entries[0].content).toBe("line-5");
+      expect(result.data!.entries[4].content).toBe("line-9");
+    });
+
+    it("should return oldest-first when sort=asc for single date", async () => {
+      const lines = Array.from(
+        { length: 10 },
+        (_, i) => `{"timestamp":"2026-04-01T${String(i).padStart(2, "0")}:00:00Z","message":"line-${i}"}`,
+      ).join("\n") + "\n";
+
+      mockMinioClient.statObject.mockResolvedValue({ size: 100 });
+      mockMinioClient.getObject.mockResolvedValue(stringStream(lines));
+
+      const result = await service.getLogs("bot-1", {
+        date: "20260401",
+        limit: 5,
+        offset: 0,
+        sort: "asc",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data!.entries).toHaveLength(5);
+      // sort=asc on tail path: reverse the newest-first to oldest-first
+      expect(result.data!.entries[0].content).toBe("line-9");
+      expect(result.data!.entries[4].content).toBe("line-5");
+    });
+
+    it("should return newest-first for date range when sort=desc", async () => {
+      const day1 = '{"msg":"d1-l1"}\n{"msg":"d1-l2"}\n{"msg":"d1-l3"}';
+      const day2 = '{"msg":"d2-l1"}\n{"msg":"d2-l2"}\n{"msg":"d2-l3"}';
+
+      mockMinioClient.getObject
+        .mockResolvedValueOnce(stringStream(day1))
+        .mockResolvedValueOnce(stringStream(day2));
+
+      const result = await service.getLogs("bot-1", {
+        dateRange: "20260401-20260402",
+        limit: 6,
+        offset: 0,
+        sort: "desc",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data!.entries).toHaveLength(6);
+      // Reversed: newest (d2-l3) first, oldest (d1-l1) last
+      expect(result.data!.entries[0].content).toContain("d2-l3");
+      expect(result.data!.entries[5].content).toContain("d1-l1");
+    });
+
+    it("should handle offset with sort=desc on date range", async () => {
+      // 6 entries total, sort=desc, offset=2, limit=2
+      // desc order: d2-l3, d2-l2, d2-l1, d1-l3, d1-l2, d1-l1
+      // offset=2 skips first 2, returns d2-l1 and d1-l3
+      const day1 = '{"msg":"d1-l1"}\n{"msg":"d1-l2"}\n{"msg":"d1-l3"}';
+      const day2 = '{"msg":"d2-l1"}\n{"msg":"d2-l2"}\n{"msg":"d2-l3"}';
+
+      mockMinioClient.getObject
+        .mockResolvedValueOnce(stringStream(day1))
+        .mockResolvedValueOnce(stringStream(day2));
+
+      const result = await service.getLogs("bot-1", {
+        dateRange: "20260401-20260402",
+        limit: 2,
+        offset: 2,
+        sort: "desc",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data!.entries).toHaveLength(2);
+      expect(result.data!.entries[0].content).toContain("d2-l1");
+      expect(result.data!.entries[1].content).toContain("d1-l3");
+    });
+
+    it("should default to desc when sort is not specified", async () => {
+      const day1 = '{"msg":"d1-l1"}\n{"msg":"d1-l2"}';
+      const day2 = '{"msg":"d2-l1"}\n{"msg":"d2-l2"}';
+
+      mockMinioClient.getObject
+        .mockResolvedValueOnce(stringStream(day1))
+        .mockResolvedValueOnce(stringStream(day2));
+
+      const result = await service.getLogs("bot-1", {
+        dateRange: "20260401-20260402",
+        limit: 10,
+        offset: 0,
+        // no sort specified
+      });
+
+      expect(result.success).toBe(true);
+      // Should default to desc (newest-first)
+      expect(result.data!.entries[0].content).toContain("d2-l2");
+      expect(result.data!.entries[3].content).toContain("d1-l1");
     });
   });
 

--- a/api/src/logs/dto/get-logs-query.dto.ts
+++ b/api/src/logs/dto/get-logs-query.dto.ts
@@ -27,4 +27,9 @@ export class GetLogsQueryDto {
   @IsString()
   @IsIn(["all", "metrics"])
   type?: "all" | "metrics";
+
+  @IsOptional()
+  @IsString()
+  @IsIn(["asc", "desc"])
+  sort?: "asc" | "desc";
 }

--- a/api/src/logs/logs.controller.ts
+++ b/api/src/logs/logs.controller.ts
@@ -75,6 +75,7 @@ export class LogsController {
       limit: query.limit || 100,
       offset: query.offset || 0,
       type: query.type,
+      sort: query.sort || "desc",
     }, user.uid);
 
     if (!result.success) {

--- a/api/src/logs/logs.service.ts
+++ b/api/src/logs/logs.service.ts
@@ -14,6 +14,7 @@ export interface LogsQuery {
   limit: number;
   offset: number;
   type?: "all" | "metrics";
+  sort?: "asc" | "desc";
   // Parsed datetime bounds (set by parseDateQuery for datetime ranges)
   startTime?: Date;
   endTime?: Date;
@@ -69,17 +70,34 @@ export class LogsService {
     try {
       const entries: LogEntry[] = [];
 
+      const sortOrder = query.sort || "desc";
+
       if (dates.length === 1 && query.type !== "metrics" && !query.startTime) {
-        // Single date, non-metrics: tail for latest entries
+        // Single date, non-metrics: tail for latest entries (returns newest-first)
         const logPath = `logs/${botId}/${dates[0]}.log`;
         await this.tailFilteredLogs(logPath, dates[0], query, entries);
+        if (sortOrder === "asc") entries.reverse();
       } else {
-        // Multi-date or metrics: stream from start, chronological
+        // Multi-date or metrics: stream from start (returns oldest-first)
         const skipped = { count: 0 };
-        for (const date of dates) {
-          const logPath = `logs/${botId}/${date}.log`;
-          await this.streamFilteredLogs(logPath, date, query, entries, skipped);
-          if (query.type !== "metrics" && entries.length >= query.limit) break;
+        if (sortOrder === "desc" && query.type !== "metrics") {
+          // For desc on the stream path, read all entries without offset/limit,
+          // reverse to newest-first, then apply offset and limit
+          const unboundedQuery = { ...query, offset: 0, limit: Infinity };
+          for (const date of dates) {
+            const logPath = `logs/${botId}/${date}.log`;
+            await this.streamFilteredLogs(logPath, date, unboundedQuery, entries, skipped);
+          }
+          entries.reverse();
+          entries.splice(0, query.offset);
+          if (entries.length > query.limit) entries.length = query.limit;
+        } else {
+          for (const date of dates) {
+            const logPath = `logs/${botId}/${date}.log`;
+            await this.streamFilteredLogs(logPath, date, query, entries, skipped);
+            if (query.type !== "metrics" && entries.length >= query.limit) break;
+          }
+          if (sortOrder === "desc") entries.reverse();
         }
       }
 

--- a/api/src/logs/logs.service.ts
+++ b/api/src/logs/logs.service.ts
@@ -81,12 +81,15 @@ export class LogsService {
         // Multi-date or metrics: stream from start (returns oldest-first)
         const skipped = { count: 0 };
         if (sortOrder === "desc" && query.type !== "metrics") {
-          // For desc on the stream path, read all entries without offset/limit,
-          // reverse to newest-first, then apply offset and limit
-          const unboundedQuery = { ...query, offset: 0, limit: Infinity };
+          // For desc on the stream path, read entries in chronological order,
+          // reverse to newest-first, then apply offset and limit.
+          // Cap total reads to prevent memory exhaustion on huge ranges.
+          const maxRead = Math.max(query.offset + query.limit, 10000);
+          const cappedQuery = { ...query, offset: 0, limit: maxRead };
           for (const date of dates) {
             const logPath = `logs/${botId}/${date}.log`;
-            await this.streamFilteredLogs(logPath, date, unboundedQuery, entries, skipped);
+            await this.streamFilteredLogs(logPath, date, cappedQuery, entries, skipped);
+            if (entries.length >= maxRead) break;
           }
           entries.reverse();
           entries.splice(0, query.offset);

--- a/frontend/src/components/bot/__tests__/console-interface.test.tsx
+++ b/frontend/src/components/bot/__tests__/console-interface.test.tsx
@@ -500,8 +500,7 @@ describe("ConsoleInterface", () => {
       );
 
       // Toggle to oldest-first (newestFirst=false)
-      const buttons = screen.getAllByRole("button");
-      const sortButton = buttons[2]; // refresh=1, sort=2
+      const sortButton = screen.getByRole("button", { name: /Newest first|Oldest first/i });
       await user.click(sortButton); // now newestFirst=false
 
       const container = screen.getByTestId("virtuoso-container");
@@ -526,8 +525,7 @@ describe("ConsoleInterface", () => {
       );
 
       // Toggle to oldest-first
-      const buttons = screen.getAllByRole("button");
-      const sortButton = buttons[2];
+      const sortButton = screen.getByRole("button", { name: /Newest first|Oldest first/i });
       await user.click(sortButton); // now newestFirst=false
 
       const container = screen.getByTestId("virtuoso-container");

--- a/frontend/src/components/bot/__tests__/console-interface.test.tsx
+++ b/frontend/src/components/bot/__tests__/console-interface.test.tsx
@@ -483,34 +483,26 @@ describe("ConsoleInterface", () => {
   });
 
   describe("followOutput behavior", () => {
-    it("should disable followOutput when not connected even in oldest-first mode", async () => {
-      const user = userEvent.setup();
+    it("should disable followOutput when not connected even with sort=asc", () => {
       const logs: LogEntry[] = [
         { date: "2024-01-01", content: "[2024-01-01 10:00:00] INFO: Test log" },
       ];
 
-      // Render with connected=false (viewing historical/REST data)
       render(
         <ConsoleInterface
           {...defaultProps}
           logs={logs}
           connected={false}
           lastUpdate={new Date()}
+          sort="asc"
         />,
       );
 
-      // Toggle to oldest-first (newestFirst=false)
-      const sortButton = screen.getByRole("button", { name: /Newest first|Oldest first/i });
-      await user.click(sortButton); // now newestFirst=false
-
       const container = screen.getByTestId("virtuoso-container");
-      // Even with newestFirst=false and autoScroll=true, followOutput should
-      // be false because we're NOT connected (viewing historical data)
       expect(container.getAttribute("data-follow-output")).toBe("false");
     });
 
-    it("should enable followOutput only when connected in oldest-first mode", async () => {
-      const user = userEvent.setup();
+    it("should enable followOutput when connected with sort=asc", () => {
       const logs: LogEntry[] = [
         { date: "2024-01-01", content: "[2024-01-01 10:00:00] INFO: Test log" },
       ];
@@ -521,16 +513,31 @@ describe("ConsoleInterface", () => {
           logs={logs}
           connected={true}
           lastUpdate={new Date()}
+          sort="asc"
         />,
       );
 
-      // Toggle to oldest-first
-      const sortButton = screen.getByRole("button", { name: /Newest first|Oldest first/i });
-      await user.click(sortButton); // now newestFirst=false
+      const container = screen.getByTestId("virtuoso-container");
+      expect(container.getAttribute("data-follow-output")).toBe("smooth");
+    });
+
+    it("should disable followOutput when sort=desc even if connected", () => {
+      const logs: LogEntry[] = [
+        { date: "2024-01-01", content: "[2024-01-01 10:00:00] INFO: Test log" },
+      ];
+
+      render(
+        <ConsoleInterface
+          {...defaultProps}
+          logs={logs}
+          connected={true}
+          lastUpdate={new Date()}
+          sort="desc"
+        />,
+      );
 
       const container = screen.getByTestId("virtuoso-container");
-      // With connected=true, newestFirst=false, autoScroll=true => followOutput="smooth"
-      expect(container.getAttribute("data-follow-output")).toBe("smooth");
+      expect(container.getAttribute("data-follow-output")).toBe("false");
     });
   });
 
@@ -751,17 +758,16 @@ describe("ConsoleInterface", () => {
       }));
     }
 
-    it("should not create new array reference when logs are appended in newest-first mode", () => {
+    it("should render logs in received order without client-side reversal", () => {
       const initialLogs = makeLogs(100);
       const { rerender } = render(
         <ConsoleInterface {...defaultProps} logs={initialLogs} />,
       );
 
-      // Default is newest-first. The first rendered item should be last log reversed.
+      // No reversal: item 0 = first log in the array
       const firstItem = screen.getByTestId("log-item-0");
       expect(firstItem).toBeInTheDocument();
-      // Reversed: item 0 in display = last log from the original array
-      expect(firstItem.textContent).toContain("message 99");
+      expect(firstItem.textContent).toContain("message 0");
 
       // Append 10 more logs
       const appendedLogs = [...initialLogs, ...makeLogs(10, "New")];
@@ -769,10 +775,9 @@ describe("ConsoleInterface", () => {
         <ConsoleInterface {...defaultProps} logs={appendedLogs} />,
       );
 
-      // After appending, newest log should be first displayed item
+      // First item unchanged, new items at the end
       const updatedFirstItem = screen.getByTestId("log-item-0");
-      expect(updatedFirstItem).toBeInTheDocument();
-      expect(updatedFirstItem.textContent).toContain("New message 9");
+      expect(updatedFirstItem.textContent).toContain("message 0");
 
       // All 110 items should be rendered
       expect(screen.getByTestId("log-item-109")).toBeInTheDocument();

--- a/frontend/src/components/bot/__tests__/console-interface.test.tsx
+++ b/frontend/src/components/bot/__tests__/console-interface.test.tsx
@@ -19,7 +19,7 @@ jest.mock("react-virtuoso", () => ({
       }: any,
       ref: any,
     ) => (
-      <div data-testid="virtuoso-container" data-overscan={overscan} className={className}>
+      <div data-testid="virtuoso-container" data-overscan={overscan} data-follow-output={String(followOutput)} className={className}>
         {components?.Header && <components.Header />}
         {data?.map((item: any, index: number) => (
           <div key={index} data-testid={`log-item-${index}`}>{itemContent(index, item)}</div>
@@ -479,6 +479,60 @@ describe("ConsoleInterface", () => {
         />,
       );
       expect(screen.getByText("Polling")).toBeInTheDocument();
+    });
+  });
+
+  describe("followOutput behavior", () => {
+    it("should disable followOutput when not connected even in oldest-first mode", async () => {
+      const user = userEvent.setup();
+      const logs: LogEntry[] = [
+        { date: "2024-01-01", content: "[2024-01-01 10:00:00] INFO: Test log" },
+      ];
+
+      // Render with connected=false (viewing historical/REST data)
+      render(
+        <ConsoleInterface
+          {...defaultProps}
+          logs={logs}
+          connected={false}
+          lastUpdate={new Date()}
+        />,
+      );
+
+      // Toggle to oldest-first (newestFirst=false)
+      const buttons = screen.getAllByRole("button");
+      const sortButton = buttons[2]; // refresh=1, sort=2
+      await user.click(sortButton); // now newestFirst=false
+
+      const container = screen.getByTestId("virtuoso-container");
+      // Even with newestFirst=false and autoScroll=true, followOutput should
+      // be false because we're NOT connected (viewing historical data)
+      expect(container.getAttribute("data-follow-output")).toBe("false");
+    });
+
+    it("should enable followOutput only when connected in oldest-first mode", async () => {
+      const user = userEvent.setup();
+      const logs: LogEntry[] = [
+        { date: "2024-01-01", content: "[2024-01-01 10:00:00] INFO: Test log" },
+      ];
+
+      render(
+        <ConsoleInterface
+          {...defaultProps}
+          logs={logs}
+          connected={true}
+          lastUpdate={new Date()}
+        />,
+      );
+
+      // Toggle to oldest-first
+      const buttons = screen.getAllByRole("button");
+      const sortButton = buttons[2];
+      await user.click(sortButton); // now newestFirst=false
+
+      const container = screen.getByTestId("virtuoso-container");
+      // With connected=true, newestFirst=false, autoScroll=true => followOutput="smooth"
+      expect(container.getAttribute("data-follow-output")).toBe("smooth");
     });
   });
 

--- a/frontend/src/components/bot/__tests__/interval-picker.test.tsx
+++ b/frontend/src/components/bot/__tests__/interval-picker.test.tsx
@@ -4,6 +4,7 @@ import {
   IntervalPicker,
   LIVE_INTERVAL,
   DEFAULT_DAY_INTERVAL,
+  DEFAULT_INTERVAL,
   computeInterval,
 } from "../interval-picker";
 
@@ -197,6 +198,15 @@ describe("IntervalPicker", () => {
       expect(DEFAULT_DAY_INTERVAL.label).toBe("1d");
       expect(DEFAULT_DAY_INTERVAL.start).toMatch(/^\d{8}$/);
       expect(DEFAULT_DAY_INTERVAL.end).toMatch(/^\d{8}$/);
+    });
+  });
+
+  describe("DEFAULT_INTERVAL constant", () => {
+    it("should be 1h with ISO datetime range", () => {
+      expect(DEFAULT_INTERVAL.label).toBe("1h");
+      // ISO datetime strings contain "T"
+      expect(DEFAULT_INTERVAL.start).toContain("T");
+      expect(DEFAULT_INTERVAL.end).toContain("T");
     });
   });
 

--- a/frontend/src/components/bot/__tests__/refresh-selector.test.tsx
+++ b/frontend/src/components/bot/__tests__/refresh-selector.test.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { RefreshSelector } from "../refresh-selector";
+
+describe("RefreshSelector", () => {
+  const mockOnChange = jest.fn();
+
+  beforeEach(() => {
+    mockOnChange.mockClear();
+  });
+
+  it("should render refresh interval options", () => {
+    render(<RefreshSelector value={30000} onChange={mockOnChange} />);
+
+    expect(screen.getByRole("button", { name: /10s/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /30s/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /60s/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /off/i })).toBeInTheDocument();
+  });
+
+  it("should call onChange when option selected", () => {
+    render(<RefreshSelector value={30000} onChange={mockOnChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /10s/i }));
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(mockOnChange).toHaveBeenCalledWith(10000);
+  });
+
+  it("should highlight active option", () => {
+    render(<RefreshSelector value={30000} onChange={mockOnChange} />);
+
+    const activeButton = screen.getByRole("button", { name: /30s/i });
+    const inactiveButton = screen.getByRole("button", { name: /10s/i });
+
+    expect(activeButton.className).toContain("bg-secondary");
+    expect(inactiveButton.className).not.toContain("bg-secondary");
+  });
+
+  it("should highlight Off when value is 0", () => {
+    render(<RefreshSelector value={0} onChange={mockOnChange} />);
+
+    const offButton = screen.getByRole("button", { name: /off/i });
+    expect(offButton.className).toContain("bg-secondary");
+  });
+
+  it("should call onChange with 0 when Off is clicked", () => {
+    render(<RefreshSelector value={30000} onChange={mockOnChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /off/i }));
+
+    expect(mockOnChange).toHaveBeenCalledWith(0);
+  });
+});

--- a/frontend/src/components/bot/__tests__/refresh-selector.test.tsx
+++ b/frontend/src/components/bot/__tests__/refresh-selector.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { RefreshSelector } from "../refresh-selector";
+import { RefreshSelector, shouldHideRefreshSelector } from "../refresh-selector";
 
 describe("RefreshSelector", () => {
   const mockOnChange = jest.fn();
@@ -50,5 +50,48 @@ describe("RefreshSelector", () => {
     fireEvent.click(screen.getByRole("button", { name: /off/i }));
 
     expect(mockOnChange).toHaveBeenCalledWith(0);
+  });
+
+  it("should render nothing when hidden is true", () => {
+    const { container } = render(
+      <RefreshSelector value={30000} onChange={mockOnChange} hidden />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("should render when hidden is false", () => {
+    render(
+      <RefreshSelector value={30000} onChange={mockOnChange} hidden={false} />,
+    );
+    expect(screen.getByRole("button", { name: /30s/i })).toBeInTheDocument();
+  });
+
+  describe("shouldHideRefreshSelector", () => {
+    it("should be visible for scheduled bots regardless of interval", () => {
+      expect(shouldHideRefreshSelector(false, "1d")).toBe(false);
+      expect(shouldHideRefreshSelector(false, "1h")).toBe(false);
+      expect(shouldHideRefreshSelector(false, "live")).toBe(false);
+      expect(shouldHideRefreshSelector(false, "custom")).toBe(false);
+    });
+
+    it("should be hidden for realtime bots in live mode", () => {
+      expect(shouldHideRefreshSelector(true, "live")).toBe(true);
+    });
+
+    it("should be visible for realtime bots with rolling hour presets", () => {
+      expect(shouldHideRefreshSelector(true, "1h")).toBe(false);
+      expect(shouldHideRefreshSelector(true, "6h")).toBe(false);
+    });
+
+    it("should be hidden for realtime bots with day presets", () => {
+      expect(shouldHideRefreshSelector(true, "1d")).toBe(true);
+      expect(shouldHideRefreshSelector(true, "3d")).toBe(true);
+      expect(shouldHideRefreshSelector(true, "7d")).toBe(true);
+      expect(shouldHideRefreshSelector(true, "30d")).toBe(true);
+    });
+
+    it("should be hidden for realtime bots with custom range", () => {
+      expect(shouldHideRefreshSelector(true, "custom")).toBe(true);
+    });
   });
 });

--- a/frontend/src/components/bot/bot-dashboard-loader.tsx
+++ b/frontend/src/components/bot/bot-dashboard-loader.tsx
@@ -100,6 +100,7 @@ interface BotDashboardLoaderProps {
   customBotId: string;
   version?: string;
   dateRange?: { start: string; end: string };
+  refreshInterval?: number;
   className?: string;
 }
 
@@ -115,6 +116,7 @@ export const BotDashboardLoader = React.memo(function BotDashboardLoader({
   customBotId,
   version,
   dateRange,
+  refreshInterval = 30000,
   className,
 }: BotDashboardLoaderProps) {
   const [BotDashboard, setBotDashboard] = useState<DashboardComponent | null>(
@@ -248,8 +250,8 @@ export const BotDashboardLoader = React.memo(function BotDashboardLoader({
     return (
       <BotEventsProvider
         botId={botId}
-        autoRefresh
-        refreshInterval={30000}
+        autoRefresh={refreshInterval > 0}
+        refreshInterval={refreshInterval || undefined}
         dateRange={dateRange}
       >
         <DashboardErrorBoundary>

--- a/frontend/src/components/bot/console-interface.test.tsx
+++ b/frontend/src/components/bot/console-interface.test.tsx
@@ -492,7 +492,7 @@ describe("ConsoleInterface", () => {
       return buttons.find((btn) => btn.querySelector(".lucide-arrow-down-up"));
     };
 
-    it("defaults to newest-first order (reversed)", () => {
+    it("displays logs in received order (no client-side reversal)", () => {
       const logs: LogEntry[] = [
         { date: "20251227", content: "First log" },
         { date: "20251227", content: "Second log" },
@@ -503,70 +503,68 @@ describe("ConsoleInterface", () => {
 
       const container = screen.getByTestId("virtuoso-container");
       const items = container.querySelectorAll(":scope > div");
-      // In newest-first mode, Third log should appear before First log
-      const texts = Array.from(items).map((el) => el.textContent);
-      const thirdIdx = texts.findIndex((t) => t?.includes("Third log"));
-      const firstIdx = texts.findIndex((t) => t?.includes("First log"));
-      expect(thirdIdx).toBeLessThan(firstIdx);
-    });
-
-    it("toggles to oldest-first (chronological) when clicked", () => {
-      const logs: LogEntry[] = [
-        { date: "20251227", content: "First log" },
-        { date: "20251227", content: "Second log" },
-        { date: "20251227", content: "Third log" },
-      ];
-
-      render(<ConsoleInterface {...defaultProps} logs={logs} />);
-
-      const sortButton = findSortToggle();
-      expect(sortButton).toBeDefined();
-      fireEvent.click(sortButton!);
-
-      const container = screen.getByTestId("virtuoso-container");
-      const items = container.querySelectorAll(":scope > div");
       const texts = Array.from(items).map((el) => el.textContent);
       const firstIdx = texts.findIndex((t) => t?.includes("First log"));
       const thirdIdx = texts.findIndex((t) => t?.includes("Third log"));
-      // In oldest-first mode, First log should appear before Third log
+      // Logs displayed in the order received from the API (no reversal)
       expect(firstIdx).toBeLessThan(thirdIdx);
     });
 
-    it("toggles back to newest-first on second click", () => {
-      const logs: LogEntry[] = [
-        { date: "20251227", content: "First log" },
-        { date: "20251227", content: "Third log" },
-      ];
+    it("calls onSortChange when sort toggle is clicked", () => {
+      const onSortChange = jest.fn();
 
-      render(<ConsoleInterface {...defaultProps} logs={logs} />);
-
-      const sortButton = findSortToggle()!;
-
-      // First click: switch to oldest-first
-      fireEvent.click(sortButton);
-      // Second click: switch back to newest-first
-      fireEvent.click(sortButton);
-
-      const container = screen.getByTestId("virtuoso-container");
-      const items = container.querySelectorAll(":scope > div");
-      const texts = Array.from(items).map((el) => el.textContent);
-      const thirdIdx = texts.findIndex((t) => t?.includes("Third log"));
-      const firstIdx = texts.findIndex((t) => t?.includes("First log"));
-      expect(thirdIdx).toBeLessThan(firstIdx);
-    });
-
-    it("has correct tooltip for sort order", () => {
       render(
         <ConsoleInterface
           {...defaultProps}
           logs={[{ date: "20251227", content: "Log" }]}
+          sort="desc"
+          onSortChange={onSortChange}
+        />,
+      );
+
+      const sortButton = findSortToggle()!;
+      fireEvent.click(sortButton);
+
+      expect(onSortChange).toHaveBeenCalledWith("asc");
+    });
+
+    it("calls onSortChange with desc when currently asc", () => {
+      const onSortChange = jest.fn();
+
+      render(
+        <ConsoleInterface
+          {...defaultProps}
+          logs={[{ date: "20251227", content: "Log" }]}
+          sort="asc"
+          onSortChange={onSortChange}
+        />,
+      );
+
+      const sortButton = findSortToggle()!;
+      fireEvent.click(sortButton);
+
+      expect(onSortChange).toHaveBeenCalledWith("desc");
+    });
+
+    it("has correct tooltip for sort order", () => {
+      const { rerender } = render(
+        <ConsoleInterface
+          {...defaultProps}
+          logs={[{ date: "20251227", content: "Log" }]}
+          sort="desc"
         />,
       );
 
       const sortButton = findSortToggle()!;
       expect(sortButton).toHaveAttribute("title", "Newest first");
 
-      fireEvent.click(sortButton);
+      rerender(
+        <ConsoleInterface
+          {...defaultProps}
+          logs={[{ date: "20251227", content: "Log" }]}
+          sort="asc"
+        />,
+      );
       expect(sortButton).toHaveAttribute("title", "Oldest first");
     });
 

--- a/frontend/src/components/bot/console-interface.tsx
+++ b/frontend/src/components/bot/console-interface.tsx
@@ -474,11 +474,14 @@ export const ConsoleInterface: React.FC<ConsoleInterfaceProps> = ({
     return newestFirst ? [...filteredLogs].reverse() : filteredLogs;
   }, [filteredLogs, newestFirst]);
 
-  // In newest-first mode, auto-scroll to top when new logs arrive
+  // In newest-first mode, auto-scroll to top when new logs arrive from
+  // live polling/SSE. Only scrolls when the user is already at the top
+  // so loading more historical data doesn't jolt them back.
   useEffect(() => {
     if (
       newestFirst &&
       autoScroll &&
+      isUserAtTop &&
       displayLogs.length > prevLogCountRef.current
     ) {
       virtuosoRef.current?.scrollToIndex({ index: 0, behavior: "smooth" });
@@ -738,13 +741,13 @@ export const ConsoleInterface: React.FC<ConsoleInterfaceProps> = ({
             ref={virtuosoRef}
             data={displayLogs}
             overscan={50}
-            followOutput={!newestFirst && autoScroll ? "smooth" : false}
+            followOutput={connected && !newestFirst && autoScroll ? "smooth" : false}
             atBottomStateChange={(atBottom) => setIsUserAtBottom(atBottom)}
             atTopStateChange={(atTop) => setIsUserAtTop(atTop)}
             itemContent={(index, log) => (
               <SmartLogEntry log={log} index={index} />
             )}
-            endReached={hasMore && loadMore ? loadMore : undefined}
+            endReached={undefined}
             components={{
               Header:
                 hasEarlierLogs && onLoadEarlier && !searchQuery

--- a/frontend/src/components/bot/console-interface.tsx
+++ b/frontend/src/components/bot/console-interface.tsx
@@ -86,6 +86,10 @@ interface ConsoleInterfaceProps {
   loadMore?: () => void;
   /** Whether more logs are currently being loaded */
   loadingMore?: boolean;
+  /** Current sort order from the API */
+  sort?: "asc" | "desc";
+  /** Callback when user toggles sort order */
+  onSortChange?: (sort: "asc" | "desc") => void;
 }
 
 const LOG_LEVEL_COLORS = {
@@ -445,10 +449,11 @@ export const ConsoleInterface: React.FC<ConsoleInterfaceProps> = ({
   hasMore,
   loadMore,
   loadingMore,
+  sort = "desc",
+  onSortChange,
 }) => {
   const [searchQuery, setSearchQuery] = useState("");
   const [autoScroll, setAutoScroll] = useState(true);
-  const [newestFirst, setNewestFirst] = useState(true);
   const [selectedDate, setSelectedDate] = useState<string>("");
   const [dateRange, setDateRange] = useState<{ start: string; end: string }>({
     start: "",
@@ -456,38 +461,17 @@ export const ConsoleInterface: React.FC<ConsoleInterfaceProps> = ({
   });
   const [showFilters, setShowFilters] = useState(false);
   const [isUserAtBottom, setIsUserAtBottom] = useState(true);
-  const [isUserAtTop, setIsUserAtTop] = useState(true);
-  const prevLogCountRef = useRef(0);
 
   const virtuosoRef = useRef<VirtuosoHandle>(null);
 
-  // Step 1: filter logs (only recomputes when logs or searchQuery change)
-  const filteredLogs = useMemo(() => {
+  // Filter logs (only recomputes when logs or searchQuery change)
+  // No reversal needed - the API returns data in the requested sort order
+  const displayLogs = useMemo(() => {
     if (searchQuery === "") return logs;
     return logs.filter((log) =>
       log.content.toLowerCase().includes(searchQuery.toLowerCase()),
     );
   }, [logs, searchQuery]);
-
-  // Step 2: reverse for display order (recomputes when filteredLogs or newestFirst change)
-  const displayLogs = useMemo(() => {
-    return newestFirst ? [...filteredLogs].reverse() : filteredLogs;
-  }, [filteredLogs, newestFirst]);
-
-  // In newest-first mode, auto-scroll to top when new logs arrive from
-  // live polling/SSE. Only scrolls when the user is already at the top
-  // so loading more historical data doesn't jolt them back.
-  useEffect(() => {
-    if (
-      newestFirst &&
-      autoScroll &&
-      isUserAtTop &&
-      displayLogs.length > prevLogCountRef.current
-    ) {
-      virtuosoRef.current?.scrollToIndex({ index: 0, behavior: "smooth" });
-    }
-    prevLogCountRef.current = displayLogs.length;
-  }, [displayLogs.length, newestFirst, autoScroll, isUserAtTop]);
 
   const handleDateChange = useCallback(
     (value: string) => {
@@ -605,15 +589,15 @@ export const ConsoleInterface: React.FC<ConsoleInterfaceProps> = ({
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => setNewestFirst(!newestFirst)}
-              title={newestFirst ? "Newest first" : "Oldest first"}
+              onClick={() => onSortChange?.(sort === "desc" ? "asc" : "desc")}
+              title={sort === "desc" ? "Newest first" : "Oldest first"}
               className={cn(
                 "text-green-600 dark:text-green-400 hover:bg-green-100 dark:hover:bg-green-950/30 hover:text-green-700 dark:hover:text-green-300",
                 compact && "h-7 w-7 p-0",
               )}
             >
               <ArrowDownUp
-                className={cn("h-4 w-4", newestFirst && "rotate-180")}
+                className={cn("h-4 w-4", sort === "desc" && "rotate-180")}
               />
             </Button>
             <Button
@@ -741,9 +725,8 @@ export const ConsoleInterface: React.FC<ConsoleInterfaceProps> = ({
             ref={virtuosoRef}
             data={displayLogs}
             overscan={50}
-            followOutput={connected && !newestFirst && autoScroll ? "smooth" : false}
+            followOutput={connected && sort === "asc" && autoScroll ? "smooth" : false}
             atBottomStateChange={(atBottom) => setIsUserAtBottom(atBottom)}
-            atTopStateChange={(atTop) => setIsUserAtTop(atTop)}
             itemContent={(index, log) => (
               <SmartLogEntry log={log} index={index} />
             )}

--- a/frontend/src/components/bot/interval-picker.tsx
+++ b/frontend/src/components/bot/interval-picker.tsx
@@ -77,8 +77,10 @@ export const DEFAULT_DAY_INTERVAL: IntervalValue = computeInterval("1d", {
   days: 1,
 });
 
-/** @deprecated Use DEFAULT_DAY_INTERVAL instead */
-export const DEFAULT_INTERVAL: IntervalValue = DEFAULT_DAY_INTERVAL;
+/** Default interval for scheduled bots: last 1 hour */
+export const DEFAULT_INTERVAL: IntervalValue = computeInterval("1h", {
+  hours: 1,
+});
 
 export function IntervalPicker({
   value,

--- a/frontend/src/components/bot/refresh-selector.tsx
+++ b/frontend/src/components/bot/refresh-selector.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import React from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { RefreshCw } from "lucide-react";
+
+export interface RefreshSelectorProps {
+  value: number; // ms, 0 = off
+  onChange: (ms: number) => void;
+}
+
+const OPTIONS = [
+  { label: "10s", ms: 10000 },
+  { label: "30s", ms: 30000 },
+  { label: "60s", ms: 60000 },
+  { label: "Off", ms: 0 },
+] as const;
+
+export function RefreshSelector({ value, onChange }: RefreshSelectorProps) {
+  return (
+    <div className="flex items-center gap-1">
+      <RefreshCw className="h-3.5 w-3.5 text-muted-foreground mr-1" />
+
+      {OPTIONS.map((option) => (
+        <Button
+          key={option.label}
+          variant={value === option.ms ? "secondary" : "ghost"}
+          size="sm"
+          className={cn(
+            "h-7 px-2.5 text-xs font-mono",
+            value === option.ms &&
+              "bg-secondary text-secondary-foreground",
+          )}
+          onClick={() => onChange(option.ms)}
+        >
+          {option.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/bot/refresh-selector.tsx
+++ b/frontend/src/components/bot/refresh-selector.tsx
@@ -8,6 +8,7 @@ import { RefreshCw } from "lucide-react";
 export interface RefreshSelectorProps {
   value: number; // ms, 0 = off
   onChange: (ms: number) => void;
+  hidden?: boolean;
 }
 
 const OPTIONS = [
@@ -17,16 +18,30 @@ const OPTIONS = [
   { label: "Off", ms: 0 },
 ] as const;
 
-export function RefreshSelector({ value, onChange }: RefreshSelectorProps) {
+const ROLLING_PRESETS = new Set(["1h", "6h"]);
+
+/** Show refresh selector for scheduled bots (always polling) or
+ *  realtime bots on rolling hour presets where data keeps arriving. */
+export function shouldHideRefreshSelector(
+  useStreaming: boolean,
+  intervalLabel: string,
+): boolean {
+  if (!useStreaming) return false;
+  return !ROLLING_PRESETS.has(intervalLabel);
+}
+
+export function RefreshSelector({ value, onChange, hidden }: RefreshSelectorProps) {
+  if (hidden) return null;
   return (
-    <div className="flex items-center gap-1">
-      <RefreshCw className="h-3.5 w-3.5 text-muted-foreground mr-1" />
+    <div className="flex items-center gap-1" role="group" aria-label="Refresh interval">
+      <RefreshCw className="h-3.5 w-3.5 text-muted-foreground mr-1" aria-hidden="true" />
 
       {OPTIONS.map((option) => (
         <Button
           key={option.label}
           variant={value === option.ms ? "secondary" : "ghost"}
           size="sm"
+          aria-pressed={value === option.ms}
           className={cn(
             "h-7 px-2.5 text-xs font-mono",
             value === option.ms &&

--- a/frontend/src/components/dashboard/bot-detail-panel.tsx
+++ b/frontend/src/components/dashboard/bot-detail-panel.tsx
@@ -22,7 +22,7 @@ import {
   IntervalPicker,
   IntervalValue,
   LIVE_INTERVAL,
-  DEFAULT_DAY_INTERVAL,
+  DEFAULT_INTERVAL,
 } from "@/components/bot/interval-picker";
 import {
   Dialog,
@@ -86,7 +86,7 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
   // Note: bot is null at mount, so useStreaming is initially false. The
   // useEffect below corrects the interval once the bot loads.
   const [interval, setInterval_] = useState<IntervalValue>(
-    useStreaming ? LIVE_INTERVAL : DEFAULT_DAY_INTERVAL,
+    useStreaming ? LIVE_INTERVAL : DEFAULT_INTERVAL,
   );
   const streamingInitialized = useRef(false);
 
@@ -98,7 +98,7 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
   useEffect(() => {
     if (!streamingInitialized.current && bot) {
       streamingInitialized.current = true;
-      setInterval_(useStreaming ? LIVE_INTERVAL : DEFAULT_DAY_INTERVAL);
+      setInterval_(useStreaming ? LIVE_INTERVAL : DEFAULT_INTERVAL);
     }
   }, [useStreaming, bot]);
 

--- a/frontend/src/components/dashboard/bot-detail-panel.tsx
+++ b/frontend/src/components/dashboard/bot-detail-panel.tsx
@@ -24,6 +24,7 @@ import {
   LIVE_INTERVAL,
   DEFAULT_INTERVAL,
 } from "@/components/bot/interval-picker";
+import { RefreshSelector } from "@/components/bot/refresh-selector";
 import {
   Dialog,
   DialogContent,
@@ -78,6 +79,9 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
   const mediaQuery = useMediaQuery("(min-width: 1280px)");
   const isMobile = mediaQuery === null ? null : !mediaQuery;
 
+  // Configurable refresh rate for polling (console + dashboard)
+  const [refreshInterval, setRefreshInterval] = useState(30000);
+
   // Console logs: use SSE streaming for realtime bots, REST polling for scheduled.
   const useStreaming = shouldUseLogStreaming(bot);
 
@@ -106,13 +110,13 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
 
   const streamHook = useBotLogsStream({
     botId: useStreaming ? hookBotId : "",
-    refreshInterval: 60 * 1000,
+    refreshInterval: refreshInterval || undefined,
   });
 
   const pollingHook = useBotLogs({
     botId: useStreaming ? "" : hookBotId,
-    autoRefresh: !useStreaming && bot !== null,
-    refreshInterval: 60 * 1000,
+    autoRefresh: !useStreaming && bot !== null && refreshInterval > 0,
+    refreshInterval: refreshInterval || undefined,
   });
 
   const activeHook = useStreaming ? streamHook : pollingHook;
@@ -458,6 +462,8 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
           interval={interval}
           onIntervalChange={handleIntervalChange}
           showLive={useStreaming}
+          refreshInterval={refreshInterval}
+          onRefreshIntervalChange={setRefreshInterval}
         />
         {cliUpdateModal}
       </>
@@ -547,9 +553,10 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
           </div>
         </div>
 
-        {/* Interval Picker */}
-        <div className="px-4 lg:px-6">
+        {/* Interval Picker + Refresh Selector */}
+        <div className="px-4 lg:px-6 flex flex-wrap items-center gap-4">
           <IntervalPicker value={interval} onChange={handleIntervalChange} showLive={useStreaming} />
+          <RefreshSelector value={refreshInterval} onChange={setRefreshInterval} />
         </div>
 
         {/* Main Content - Dashboard and Console side by side */}
@@ -566,6 +573,7 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
                 customBotId={customBotId}
                 version={bot.config.version}
                 dateRange={interval.type === "range" ? { start: interval.start, end: interval.end } : undefined}
+                refreshInterval={refreshInterval}
                 className=""
               />
             ) : (

--- a/frontend/src/components/dashboard/bot-detail-panel.tsx
+++ b/frontend/src/components/dashboard/bot-detail-panel.tsx
@@ -81,6 +81,8 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
 
   // Configurable refresh rate for polling (console + dashboard)
   const [refreshInterval, setRefreshInterval] = useState(30000);
+  // Sort order for console logs (API-side sorting)
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
 
   // Console logs: use SSE streaming for realtime bots, REST polling for scheduled.
   const useStreaming = shouldUseLogStreaming(bot);
@@ -469,6 +471,8 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
           showLive={useStreaming}
           refreshInterval={refreshInterval}
           onRefreshIntervalChange={setRefreshInterval}
+          sort={sortOrder}
+          onSortChange={(s) => { setSortOrder(s); activeHook.updateQuery({ sort: s }); }}
         />
         {cliUpdateModal}
       </>
@@ -618,6 +622,8 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
                 hasMore={hasMoreLogs}
                 loadMore={loadMoreLogs}
                 loadingMore={hasMoreLogs ? logsLoading : undefined}
+                sort={sortOrder}
+                onSortChange={(s) => { setSortOrder(s); activeHook.updateQuery({ sort: s }); }}
                 className="h-full"
                 compact
               />

--- a/frontend/src/components/dashboard/bot-detail-panel.tsx
+++ b/frontend/src/components/dashboard/bot-detail-panel.tsx
@@ -24,7 +24,7 @@ import {
   LIVE_INTERVAL,
   DEFAULT_INTERVAL,
 } from "@/components/bot/interval-picker";
-import { RefreshSelector } from "@/components/bot/refresh-selector";
+import { RefreshSelector, shouldHideRefreshSelector } from "@/components/bot/refresh-selector";
 import {
   Dialog,
   DialogContent,
@@ -110,13 +110,13 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
 
   const streamHook = useBotLogsStream({
     botId: useStreaming ? hookBotId : "",
-    refreshInterval: refreshInterval || undefined,
+    refreshInterval,
   });
 
   const pollingHook = useBotLogs({
     botId: useStreaming ? "" : hookBotId,
     autoRefresh: !useStreaming && bot !== null && refreshInterval > 0,
-    refreshInterval: refreshInterval || undefined,
+    refreshInterval,
   });
 
   const activeHook = useStreaming ? streamHook : pollingHook;
@@ -556,7 +556,7 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
         {/* Interval Picker + Refresh Selector */}
         <div className="px-4 lg:px-6 flex flex-wrap items-center gap-4">
           <IntervalPicker value={interval} onChange={handleIntervalChange} showLive={useStreaming} />
-          <RefreshSelector value={refreshInterval} onChange={setRefreshInterval} />
+          <RefreshSelector value={refreshInterval} onChange={setRefreshInterval} hidden={shouldHideRefreshSelector(useStreaming, interval.label)} />
         </div>
 
         {/* Main Content - Dashboard and Console side by side */}

--- a/frontend/src/components/dashboard/bot-detail-panel.tsx
+++ b/frontend/src/components/dashboard/bot-detail-panel.tsx
@@ -146,9 +146,14 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
   const loadingEarlier = useStreaming ? streamHook.loadingEarlier : undefined;
   const loadEarlierLogs = useStreaming ? streamHook.loadEarlierLogs : undefined;
 
-  // Pagination: only relevant for REST polling (not SSE streaming)
-  const hasMoreLogs = !useStreaming ? pollingHook.hasMore : undefined;
-  const loadMoreLogs = !useStreaming ? pollingHook.loadMore : undefined;
+  // Pagination: available for REST polling and for stream hook's REST mode
+  // (when a realtime bot is viewing a date range)
+  const hasMoreLogs = useStreaming
+    ? streamHook.hasMore || undefined
+    : pollingHook.hasMore || undefined;
+  const loadMoreLogs = useStreaming
+    ? streamHook.loadMore
+    : pollingHook.loadMore;
 
   useEffect(() => {
     const fetchBot = async () => {
@@ -452,7 +457,7 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
           loadEarlierLogs={loadEarlierLogs}
           hasMore={hasMoreLogs}
           loadMore={loadMoreLogs}
-          loadingMore={!useStreaming ? logsLoading : undefined}
+          loadingMore={hasMoreLogs ? logsLoading : undefined}
           isUpdatingEnabled={isUpdatingEnabled}
           isDeleting={isDeleting}
           onToggleEnabled={handleToggleEnabled}
@@ -612,7 +617,7 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
                 onLoadEarlier={loadEarlierLogs}
                 hasMore={hasMoreLogs}
                 loadMore={loadMoreLogs}
-                loadingMore={!useStreaming ? logsLoading : undefined}
+                loadingMore={hasMoreLogs ? logsLoading : undefined}
                 className="h-full"
                 compact
               />

--- a/frontend/src/components/dashboard/mobile-bot-detail.tsx
+++ b/frontend/src/components/dashboard/mobile-bot-detail.tsx
@@ -20,6 +20,7 @@ import {
   IntervalPicker,
   IntervalValue,
 } from "@/components/bot/interval-picker";
+import { RefreshSelector } from "@/components/bot/refresh-selector";
 import { Bot as ApiBotType } from "@/lib/api/api-client";
 import {
   AlertDialog,
@@ -67,6 +68,8 @@ interface MobileBotDetailProps {
   interval: IntervalValue;
   onIntervalChange: (value: IntervalValue) => void;
   showLive?: boolean;
+  refreshInterval: number;
+  onRefreshIntervalChange: (ms: number) => void;
 }
 
 export function MobileBotDetail({
@@ -97,6 +100,8 @@ export function MobileBotDetail({
   interval,
   onIntervalChange,
   showLive,
+  refreshInterval,
+  onRefreshIntervalChange,
 }: MobileBotDetailProps) {
   const router = useRouter();
 
@@ -128,9 +133,10 @@ export function MobileBotDetail({
         </div>
       </div>
 
-      {/* Interval Picker */}
-      <div className="px-3 py-2 border-b">
+      {/* Interval Picker + Refresh Selector */}
+      <div className="px-3 py-2 border-b space-y-1.5">
         <IntervalPicker value={interval} onChange={onIntervalChange} showLive={showLive} />
+        <RefreshSelector value={refreshInterval} onChange={onRefreshIntervalChange} />
       </div>
 
       {/* Tabbed content */}
@@ -155,6 +161,7 @@ export function MobileBotDetail({
               customBotId={customBotId}
               version={bot.config.version}
               dateRange={{ start: interval.start, end: interval.end }}
+              refreshInterval={refreshInterval}
               className=""
             />
           ) : (

--- a/frontend/src/components/dashboard/mobile-bot-detail.tsx
+++ b/frontend/src/components/dashboard/mobile-bot-detail.tsx
@@ -20,7 +20,7 @@ import {
   IntervalPicker,
   IntervalValue,
 } from "@/components/bot/interval-picker";
-import { RefreshSelector } from "@/components/bot/refresh-selector";
+import { RefreshSelector, shouldHideRefreshSelector } from "@/components/bot/refresh-selector";
 import { Bot as ApiBotType } from "@/lib/api/api-client";
 import {
   AlertDialog,
@@ -136,7 +136,7 @@ export function MobileBotDetail({
       {/* Interval Picker + Refresh Selector */}
       <div className="px-3 py-2 border-b space-y-1.5">
         <IntervalPicker value={interval} onChange={onIntervalChange} showLive={showLive} />
-        <RefreshSelector value={refreshInterval} onChange={onRefreshIntervalChange} />
+        <RefreshSelector value={refreshInterval} onChange={onRefreshIntervalChange} hidden={shouldHideRefreshSelector(!!showLive, interval.label)} />
       </div>
 
       {/* Tabbed content */}

--- a/frontend/src/components/dashboard/mobile-bot-detail.tsx
+++ b/frontend/src/components/dashboard/mobile-bot-detail.tsx
@@ -70,6 +70,8 @@ interface MobileBotDetailProps {
   showLive?: boolean;
   refreshInterval: number;
   onRefreshIntervalChange: (ms: number) => void;
+  sort?: "asc" | "desc";
+  onSortChange?: (sort: "asc" | "desc") => void;
 }
 
 export function MobileBotDetail({
@@ -102,6 +104,8 @@ export function MobileBotDetail({
   showLive,
   refreshInterval,
   onRefreshIntervalChange,
+  sort,
+  onSortChange,
 }: MobileBotDetailProps) {
   const router = useRouter();
 
@@ -188,6 +192,8 @@ export function MobileBotDetail({
             hasMore={hasMore}
             loadMore={loadMore}
             loadingMore={loadingMore}
+            sort={sort}
+            onSortChange={onSortChange}
             className="h-full"
             compact
           />

--- a/frontend/src/hooks/__tests__/use-bot-logs-stream.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-logs-stream.test.ts
@@ -563,4 +563,55 @@ describe("useBotLogsStream", () => {
       );
     });
   });
+
+  it("should preserve timestamp from SSE history events", async () => {
+    const { result } = renderHook(() =>
+      useBotLogsStream({ botId: "bot-1" }),
+    );
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    act(() => {
+      currentMockStream!.controller.push("history", [
+        {
+          date: "2026-04-03T10:00:00Z",
+          content: "Log line 1",
+          timestamp: "2026-04-03T10:00:00Z",
+        },
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.logs).toHaveLength(1);
+      expect(result.current.logs[0].timestamp).toBe("2026-04-03T10:00:00Z");
+    });
+  });
+
+  it("should preserve timestamp from SSE update events", async () => {
+    const { result } = renderHook(() =>
+      useBotLogsStream({ botId: "bot-1" }),
+    );
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    act(() => {
+      currentMockStream!.controller.push("history", [
+        { date: "2026-04-03T10:00:00Z", content: "Initial", timestamp: "2026-04-03T10:00:00Z" },
+      ]);
+    });
+
+    await waitFor(() => expect(result.current.logs).toHaveLength(1));
+
+    act(() => {
+      currentMockStream!.controller.push("update", {
+        content: "New entry",
+        timestamp: "2026-04-03T10:05:00Z",
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.logs).toHaveLength(2);
+      expect(result.current.logs[1].timestamp).toBe("2026-04-03T10:05:00Z");
+    });
+  });
 });

--- a/frontend/src/hooks/__tests__/use-bot-logs-stream.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-logs-stream.test.ts
@@ -614,4 +614,95 @@ describe("useBotLogsStream", () => {
       expect(result.current.logs[1].timestamp).toBe("2026-04-03T10:05:00Z");
     });
   });
+
+  it("should not start polling when refreshInterval is 0 and SSE fails", async () => {
+    jest.useFakeTimers();
+    try {
+      mockAuthFetch.mockImplementation(async (url: string) => {
+        if (typeof url === "string" && url.includes("/stream")) {
+          throw new Error("SSE failed");
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{ date: "20260406", content: "log" }],
+            total: 1,
+            hasMore: false,
+          }),
+        } as any;
+      });
+
+      const { result } = renderHook(() =>
+        useBotLogsStream({ botId: "bot-1", refreshInterval: 0 }),
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(5000);
+      });
+
+      const callsAfterFallback = mockAuthFetch.mock.calls.filter(
+        (call) => typeof call[0] === "string" && !call[0].includes("/stream"),
+      ).length;
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(60000);
+      });
+
+      const callsAfterWait = mockAuthFetch.mock.calls.filter(
+        (call) => typeof call[0] === "string" && !call[0].includes("/stream"),
+      ).length;
+
+      expect(callsAfterWait).toBe(callsAfterFallback);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("should reconfigure polling interval when refreshInterval prop changes", async () => {
+    jest.useFakeTimers();
+    try {
+      // SSE fails, falls back to polling
+      mockAuthFetch.mockImplementation(async (url: string) => {
+        if (typeof url === "string" && url.includes("/stream")) {
+          throw new Error("SSE failed");
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{ date: "20260406", content: "log" }],
+            total: 1,
+            hasMore: false,
+          }),
+        } as any;
+      });
+
+      const { rerender } = renderHook(
+        ({ interval }) =>
+          useBotLogsStream({ botId: "bot-1", refreshInterval: interval }),
+        { initialProps: { interval: 60000 } },
+      );
+
+      // Wait for SSE failure and fallback
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(5000);
+      });
+
+      mockAuthFetch.mockClear();
+
+      // Change refresh interval to 5s
+      rerender({ interval: 5000 });
+
+      // Advance 5s - should poll with new interval
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(5000);
+      });
+
+      const restCalls = mockAuthFetch.mock.calls.filter(
+        (call) => typeof call[0] === "string" && !call[0].includes("/stream"),
+      );
+      expect(restCalls.length).toBeGreaterThan(0);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/frontend/src/hooks/__tests__/use-bot-logs-stream.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-logs-stream.test.ts
@@ -661,7 +661,6 @@ describe("useBotLogsStream", () => {
   it("should reconfigure polling interval when refreshInterval prop changes", async () => {
     jest.useFakeTimers();
     try {
-      // SSE fails, falls back to polling
       mockAuthFetch.mockImplementation(async (url: string) => {
         if (typeof url === "string" && url.includes("/stream")) {
           throw new Error("SSE failed");
@@ -682,17 +681,14 @@ describe("useBotLogsStream", () => {
         { initialProps: { interval: 60000 } },
       );
 
-      // Wait for SSE failure and fallback
       await act(async () => {
         await jest.advanceTimersByTimeAsync(5000);
       });
 
       mockAuthFetch.mockClear();
 
-      // Change refresh interval to 5s
       rerender({ interval: 5000 });
 
-      // Advance 5s - should poll with new interval
       await act(async () => {
         await jest.advanceTimersByTimeAsync(5000);
       });
@@ -704,5 +700,305 @@ describe("useBotLogsStream", () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+
+  // ---- Pagination on date range (REST mode) ----
+
+  it("should expose hasMore and loadMore from REST when date range is set", async () => {
+    const { result } = renderHook(() =>
+      useBotLogsStream({ botId: "bot-1" }),
+    );
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/stream")) {
+        currentMockStream = createMockSSEStream();
+        return { ok: true, body: currentMockStream.stream } as any;
+      }
+      const parsedUrl = new URL(url, "http://localhost");
+      const offset = parseInt(parsedUrl.searchParams.get("offset") || "0");
+      if (offset === 0) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{ date: "20240101", content: "Page 1 log" }],
+            total: 2,
+            hasMore: true,
+          }),
+        } as any;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20240101", content: "Page 2 log" }],
+          total: 2,
+          hasMore: false,
+        }),
+      } as any;
+    });
+
+    act(() => {
+      result.current.setDateRangeFilter("20240101", "20240102");
+    });
+
+    await waitFor(() => {
+      expect(result.current.connected).toBe(false);
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    expect(typeof result.current.loadMore).toBe("function");
+
+    await act(async () => {
+      await result.current.loadMore!();
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(false);
+      expect(result.current.logs.length).toBe(2);
+    });
+  });
+
+  it("should not reset hasMore when loading earlier logs via prepend", async () => {
+    const { result } = renderHook(() =>
+      useBotLogsStream({ botId: "bot-1" }),
+    );
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    // Switch to REST with hasMore=true
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/stream")) {
+        currentMockStream = createMockSSEStream();
+        return { ok: true, body: currentMockStream.stream } as any;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20240101", content: "Log" }],
+          total: 5000,
+          hasMore: true,
+        }),
+      } as any;
+    });
+
+    act(() => {
+      result.current.setDateRangeFilter("20240101", "20240102");
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    // Now loadEarlierLogs returns hasMore=false
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/stream")) {
+        currentMockStream = createMockSSEStream();
+        return { ok: true, body: currentMockStream.stream } as any;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20240101", content: "Earlier log" }],
+          total: 1,
+          hasMore: false,
+        }),
+      } as any;
+    });
+
+    await act(async () => {
+      result.current.loadEarlierLogs();
+    });
+
+    await waitFor(() => {
+      expect(result.current.logs.length).toBeGreaterThan(1);
+    });
+
+    // hasMore should still be true - the prepend fetch should not overwrite it
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it("should not allow duplicate loadMore calls while fetch is in-flight", async () => {
+    const { result } = renderHook(() =>
+      useBotLogsStream({ botId: "bot-1" }),
+    );
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    let fetchCount = 0;
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/stream")) {
+        currentMockStream = createMockSSEStream();
+        return { ok: true, body: currentMockStream.stream } as any;
+      }
+      fetchCount++;
+      // Slow response to test duplicate guard
+      await new Promise((r) => setTimeout(r, 50));
+      return {
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20240101", content: `Page ${fetchCount}` }],
+          total: 100,
+          hasMore: true,
+        }),
+      } as any;
+    });
+
+    act(() => {
+      result.current.setDateRangeFilter("20240101", "20240102");
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    fetchCount = 0;
+
+    // Call loadMore twice rapidly
+    act(() => {
+      result.current.loadMore!();
+      result.current.loadMore!();
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    // Should only have fetched once, not twice
+    expect(fetchCount).toBe(1);
+  });
+
+  it("should not advance offset when loadMore fetch fails", async () => {
+    const { result } = renderHook(() =>
+      useBotLogsStream({ botId: "bot-1" }),
+    );
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/stream")) {
+        currentMockStream = createMockSSEStream();
+        return { ok: true, body: currentMockStream.stream } as any;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20240101", content: "Page 1" }],
+          total: 100,
+          hasMore: true,
+        }),
+      } as any;
+    });
+
+    act(() => {
+      result.current.setDateRangeFilter("20240101", "20240102");
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    // Make next fetch fail
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/stream")) {
+        currentMockStream = createMockSSEStream();
+        return { ok: true, body: currentMockStream.stream } as any;
+      }
+      throw new Error("Network error");
+    });
+
+    await act(async () => {
+      await result.current.loadMore!();
+    });
+
+    // hasMore should still be true - offset not advanced
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it("should keep prepended logs when buffer is full", async () => {
+    const { result } = renderHook(() =>
+      useBotLogsStream({ botId: "bot-1" }),
+    );
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    // Fill buffer to MAX_LOG_ENTRIES with history
+    const entries = Array.from({ length: 2000 }, (_, i) => ({
+      date: "2024-01-01T10:00:00Z",
+      content: `Entry ${i}`,
+    }));
+
+    act(() => {
+      currentMockStream!.controller.push("history", entries);
+    });
+
+    await waitFor(() => {
+      expect(result.current.logs).toHaveLength(2000);
+    });
+
+    // Now prepend earlier logs via REST
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/stream")) {
+        currentMockStream = createMockSSEStream();
+        return { ok: true, body: currentMockStream.stream } as any;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20240101", content: "Earlier log" }],
+          total: 1,
+          hasMore: false,
+        }),
+      } as any;
+    });
+
+    await act(async () => {
+      result.current.loadEarlierLogs();
+    });
+
+    await waitFor(() => {
+      // The earlier log should be at the start, not dropped
+      expect(result.current.logs[0].content).toBe("Earlier log");
+    });
+  });
+
+  it("should reset hasMore when reconnecting SSE after clearing date filter", async () => {
+    const { result } = renderHook(() =>
+      useBotLogsStream({ botId: "bot-1" }),
+    );
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    mockAuthFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/stream")) {
+        currentMockStream = createMockSSEStream();
+        return { ok: true, body: currentMockStream.stream } as any;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20240101", content: "Historical" }],
+          total: 100,
+          hasMore: true,
+        }),
+      } as any;
+    });
+
+    act(() => {
+      result.current.setDateRangeFilter("20240101", "20240102");
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    act(() => {
+      result.current.setDateFilter(null);
+    });
+
+    await waitFor(() => {
+      expect(result.current.connected).toBe(true);
+      expect(result.current.hasMore).toBe(false);
+    });
   });
 });

--- a/frontend/src/hooks/__tests__/use-bot-logs-stream.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-logs-stream.test.ts
@@ -346,8 +346,8 @@ describe("useBotLogsStream", () => {
 
     await waitFor(() => expect(result.current.connected).toBe(true));
 
-    // Send 2500 entries (over 2000 cap)
-    const entries = Array.from({ length: 2500 }, (_, i) => ({
+    // Send 12000 entries (over 10000 cap)
+    const entries = Array.from({ length: 12000 }, (_, i) => ({
       date: "2024-01-01T10:00:00Z",
       content: `Entry ${i}`,
     }));
@@ -357,7 +357,7 @@ describe("useBotLogsStream", () => {
     });
 
     await waitFor(() => {
-      expect(result.current.logs.length).toBeLessThanOrEqual(2000);
+      expect(result.current.logs.length).toBeLessThanOrEqual(10000);
       expect(result.current.hasEarlierLogs).toBe(true);
     });
   });
@@ -370,7 +370,7 @@ describe("useBotLogsStream", () => {
     await waitFor(() => expect(result.current.connected).toBe(true));
 
     // Fill to cap with history
-    const entries = Array.from({ length: 2000 }, (_, i) => ({
+    const entries = Array.from({ length: 10000 }, (_, i) => ({
       date: "2024-01-01T10:00:00Z",
       content: `Entry ${i}`,
     }));
@@ -379,7 +379,7 @@ describe("useBotLogsStream", () => {
       currentMockStream!.controller.push("history", entries);
     });
 
-    await waitFor(() => expect(result.current.logs).toHaveLength(2000));
+    await waitFor(() => expect(result.current.logs).toHaveLength(10000));
 
     // Push one more update
     act(() => {
@@ -390,7 +390,7 @@ describe("useBotLogsStream", () => {
     });
 
     await waitFor(() => {
-      expect(result.current.logs.length).toBeLessThanOrEqual(2000);
+      expect(result.current.logs.length).toBeLessThanOrEqual(10000);
       expect(result.current.logs[result.current.logs.length - 1].content).toBe(
         "New entry",
       );
@@ -656,6 +656,47 @@ describe("useBotLogsStream", () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+
+  it("should not reconnect SSE when refreshInterval changes", async () => {
+    const { result, rerender } = renderHook(
+      ({ interval }) =>
+        useBotLogsStream({ botId: "bot-1", refreshInterval: interval }),
+      { initialProps: { interval: 30000 } },
+    );
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    // Push some history via SSE
+    act(() => {
+      currentMockStream!.controller.push("history", [
+        { date: "2024-01-01T10:00:00Z", content: "SSE log" },
+      ]);
+    });
+
+    await waitFor(() => expect(result.current.logs).toHaveLength(1));
+
+    // Count how many times authFetch was called for the /stream endpoint
+    const streamCallsBefore = mockAuthFetch.mock.calls.filter(
+      (call) => typeof call[0] === "string" && call[0].includes("/stream"),
+    ).length;
+
+    // Change refreshInterval - should NOT cause SSE reconnection
+    rerender({ interval: 10000 });
+
+    // Wait a bit for any potential reconnection
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    const streamCallsAfter = mockAuthFetch.mock.calls.filter(
+      (call) => typeof call[0] === "string" && call[0].includes("/stream"),
+    ).length;
+
+    // SSE should NOT have reconnected (no new stream calls)
+    expect(streamCallsAfter).toBe(streamCallsBefore);
+    // Should still be connected
+    expect(result.current.connected).toBe(true);
   });
 
   it("should reconfigure polling interval when refreshInterval prop changes", async () => {

--- a/frontend/src/hooks/__tests__/use-bot-logs.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-logs.test.ts
@@ -186,8 +186,8 @@ describe("useBotLogs", () => {
   });
 
   it("should cap logs at MAX_LOG_ENTRIES when loadMore accumulates too many", async () => {
-    // Initial fetch returns 1500 entries
-    const initialLogs = Array.from({ length: 1500 }, (_, i) => ({
+    // Initial fetch returns 8000 entries
+    const initialLogs = Array.from({ length: 8000 }, (_, i) => ({
       date: "2024-01-01",
       content: `Line ${i}`,
     }));
@@ -196,47 +196,47 @@ describe("useBotLogs", () => {
         ok: true,
         json: async () => ({
           data: initialLogs,
-          total: 2100,
+          total: 11000,
           hasMore: true,
         }),
       } as Response)
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
-          data: Array.from({ length: 600 }, (_, i) => ({
+          data: Array.from({ length: 3000 }, (_, i) => ({
             date: "2024-01-01",
             content: `Extra ${i}`,
           })),
-          total: 2100,
+          total: 11000,
           hasMore: false,
         }),
       } as Response);
 
     const { result } = renderHook(() =>
-      useBotLogs({ botId: "bot-1", initialQuery: { limit: 1500, offset: 0 } }),
+      useBotLogs({ botId: "bot-1", initialQuery: { limit: 8000, offset: 0 } }),
     );
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.logs).toHaveLength(1500);
+    expect(result.current.logs).toHaveLength(8000);
 
     await act(async () => {
       await result.current.loadMore();
     });
 
-    // Should be capped at 2000, oldest trimmed
-    expect(result.current.logs).toHaveLength(2000);
-    // First entry should be Line 100 (100 oldest trimmed from 1500 + 600 = 2100)
-    expect(result.current.logs[0].content).toBe("Line 100");
+    // Should be capped at 10000, oldest trimmed (8000 + 3000 = 11000 -> 10000)
+    expect(result.current.logs).toHaveLength(10000);
+    // First entry should be Line 1000 (1000 oldest trimmed from 11000 -> 10000)
+    expect(result.current.logs[0].content).toBe("Line 1000");
     expect(result.current.logs[result.current.logs.length - 1].content).toBe(
-      "Extra 599",
+      "Extra 2999",
     );
   });
 
   it("should cap logs on initial fetch if response is very large", async () => {
-    const hugeLogs = Array.from({ length: 2500 }, (_, i) => ({
+    const hugeLogs = Array.from({ length: 12000 }, (_, i) => ({
       date: "2024-01-01",
       content: `Huge ${i}`,
     }));
@@ -244,21 +244,22 @@ describe("useBotLogs", () => {
       ok: true,
       json: async () => ({
         data: hugeLogs,
-        total: 2500,
+        total: 12000,
         hasMore: false,
       }),
     } as Response);
 
     const { result } = renderHook(() =>
-      useBotLogs({ botId: "bot-1", initialQuery: { limit: 3000, offset: 0 } }),
+      useBotLogs({ botId: "bot-1", initialQuery: { limit: 15000, offset: 0 } }),
     );
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.logs).toHaveLength(2000);
-    expect(result.current.logs[0].content).toBe("Huge 500");
+    // Capped at 10000 (MAX_LOG_ENTRIES), oldest trimmed
+    expect(result.current.logs).toHaveLength(10000);
+    expect(result.current.logs[0].content).toBe("Huge 2000");
   });
 
   it("should preserve timestamp field when expanding log entries", async () => {
@@ -539,6 +540,154 @@ describe("useBotLogs", () => {
       // If the closure is stale, it will use the default query (today's date, no dateRange).
       const pollingUrl = mockAuthFetch.mock.calls[0][0] as string;
       expect(pollingUrl).toContain("dateRange=20260401-20260403");
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  // ---- Load more with full buffer ----
+
+  it("should grow buffer past 2000 when loadMore appends", async () => {
+    // Initial fetch fills to exactly 2000 entries (old MAX_LOG_ENTRIES)
+    const initialLogs = Array.from({ length: 2000 }, (_, i) => ({
+      date: "2024-01-01",
+      content: `Line ${i}`,
+    }));
+    mockAuthFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: initialLogs,
+          total: 4000,
+          hasMore: true,
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: Array.from({ length: 2000 }, (_, i) => ({
+            date: "2024-01-01",
+            content: `Extra ${i}`,
+          })),
+          total: 4000,
+          hasMore: false,
+        }),
+      } as Response);
+
+    const { result } = renderHook(() =>
+      useBotLogs({ botId: "bot-1", initialQuery: { limit: 2000, offset: 0 } }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.logs).toHaveLength(2000);
+    expect(result.current.hasMore).toBe(true);
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    // After loadMore, buffer should grow beyond 2000
+    expect(result.current.logs.length).toBeGreaterThan(2000);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it("should advance offset on consecutive loadMore calls", async () => {
+    let callCount = 0;
+    mockAuthFetch.mockImplementation(async () => {
+      callCount++;
+      return {
+        ok: true,
+        json: async () => ({
+          data: [{ date: "2024-01-01", content: `Page ${callCount}` }],
+          total: 10,
+          hasMore: true,
+        }),
+      } as Response;
+    });
+
+    const { result } = renderHook(() =>
+      useBotLogs({ botId: "bot-1", initialQuery: { limit: 1, offset: 0 } }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // First loadMore: offset should be 1
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    const firstLoadMoreUrl = mockAuthFetch.mock.calls[1][0] as string;
+    expect(firstLoadMoreUrl).toContain("offset=1");
+
+    // Second loadMore: offset should be 2 (not 1 again)
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    const secondLoadMoreUrl = mockAuthFetch.mock.calls[2][0] as string;
+    expect(secondLoadMoreUrl).toContain("offset=2");
+  });
+
+  it("should not overwrite paginated data when auto-refresh fires", async () => {
+    jest.useFakeTimers();
+    try {
+      mockAuthFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ date: "2024-01-01", content: "Page 1" }],
+          total: 2,
+          hasMore: true,
+        }),
+      } as Response);
+
+      const { result } = renderHook(() =>
+        useBotLogs({
+          botId: "bot-1",
+          autoRefresh: true,
+          refreshInterval: 5000,
+          initialQuery: { limit: 1, offset: 0 },
+        }),
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.logs).toHaveLength(1);
+      expect(result.current.logs[0].content).toBe("Page 1");
+
+      // loadMore appends page 2
+      mockAuthFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ date: "2024-01-01", content: "Page 2" }],
+          total: 2,
+          hasMore: false,
+        }),
+      } as Response);
+
+      await act(async () => {
+        await result.current.loadMore();
+      });
+
+      expect(result.current.logs).toHaveLength(2);
+
+      // Auto-refresh fires - should NOT overwrite paginated data
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(5000);
+      });
+
+      // Both pages should still be present
+      expect(result.current.logs.length).toBe(2);
     } finally {
       jest.useRealTimers();
     }

--- a/frontend/src/hooks/__tests__/use-bot-logs.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-logs.test.ts
@@ -406,6 +406,116 @@ describe("useBotLogs", () => {
     expect(result.current.error).toBeNull();
   });
 
+  it("should not trigger extra fetches when date filter changes during auto-refresh", async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ date: "20260401", content: "Log" }],
+        total: 1,
+        hasMore: false,
+      }),
+    } as Response);
+
+    const { result } = renderHook(() =>
+      useBotLogs({
+        botId: "bot-1",
+        autoRefresh: true,
+        refreshInterval: 60000,
+      }),
+    );
+
+    // Wait for initial fetch to complete
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const callsAfterInit = mockAuthFetch.mock.calls.length;
+
+    // Change the date range filter
+    act(() => {
+      result.current.setDateRangeFilter("20260401", "20260403");
+    });
+
+    // Wait for the filter-triggered fetch to settle
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Brief pause to catch any spurious extra fetches
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    const callsAfterFilter = mockAuthFetch.mock.calls.length;
+    // Expect exactly one additional fetch from the filter change, not multiple
+    expect(callsAfterFilter - callsAfterInit).toBe(1);
+  });
+
+  it("should use latest query when polling interval fires after filter change", async () => {
+    // This tests the stale closure bug: the polling interval captures fetchLogs
+    // at setup time. If fetchLogs changes (because query changed), the interval
+    // should still call the latest version, not the stale one.
+    jest.useFakeTimers();
+    try {
+      mockAuthFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20260401", content: "Log" }],
+          total: 1,
+          hasMore: false,
+        }),
+      } as Response);
+
+      const { result } = renderHook(() =>
+        useBotLogs({
+          botId: "bot-1",
+          autoRefresh: true,
+          refreshInterval: 5000,
+        }),
+      );
+
+      // Flush initial fetch
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Change date range filter - this updates the query state and calls fetchLogs
+      await act(async () => {
+        result.current.setDateRangeFilter("20260401", "20260403");
+      });
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Clear call history so we can inspect what the next interval tick sends
+      mockAuthFetch.mockClear();
+
+      // Advance past the polling interval so it fires
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(5000);
+      });
+
+      // The polling fetch should have fired
+      expect(mockAuthFetch).toHaveBeenCalled();
+
+      // The polling fetch should use the UPDATED date range, not the original query.
+      // If the closure is stale, it will use the default query (today's date, no dateRange).
+      const pollingUrl = mockAuthFetch.mock.calls[0][0] as string;
+      expect(pollingUrl).toContain("dateRange=20260401-20260403");
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   // ---- Existing tests ----
 
   it("should build correct URL with query parameters", async () => {

--- a/frontend/src/hooks/__tests__/use-bot-logs.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-logs.test.ts
@@ -568,4 +568,85 @@ describe("useBotLogs", () => {
     expect(calledUrl).toContain("limit=50");
     expect(calledUrl).toContain("offset=10");
   });
+
+  it("should reconfigure polling when refreshInterval changes", async () => {
+    jest.useFakeTimers();
+    try {
+      mockAuthFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20260406", content: "Log" }],
+          total: 1,
+          hasMore: false,
+        }),
+      } as Response);
+
+      const { rerender } = renderHook(
+        ({ interval }) =>
+          useBotLogs({
+            botId: "bot-1",
+            autoRefresh: true,
+            refreshInterval: interval,
+          }),
+        { initialProps: { interval: 60000 } },
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      mockAuthFetch.mockClear();
+
+      // Change refresh interval to 5000ms
+      rerender({ interval: 5000 });
+
+      // Advance 5 seconds - should fire with new interval
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(5000);
+      });
+
+      // Should have fetched with the new interval
+      expect(mockAuthFetch).toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("should not poll when refreshInterval is 0 (Off)", async () => {
+    jest.useFakeTimers();
+    try {
+      mockAuthFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ date: "20260406", content: "Log" }],
+          total: 1,
+          hasMore: false,
+        }),
+      } as Response);
+
+      renderHook(() =>
+        useBotLogs({
+          botId: "bot-1",
+          autoRefresh: true,
+          refreshInterval: 0,
+        }),
+      );
+
+      // Flush initial fetch
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      mockAuthFetch.mockClear();
+
+      // Advance 60 seconds - should NOT poll
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(60000);
+      });
+
+      expect(mockAuthFetch).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/frontend/src/hooks/__tests__/use-bot-logs.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-logs.test.ts
@@ -718,6 +718,48 @@ describe("useBotLogs", () => {
     expect(calledUrl).toContain("offset=10");
   });
 
+  it("should include sort=desc in URL by default", async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [], total: 0, hasMore: false }),
+    } as Response);
+
+    renderHook(() => useBotLogs({ botId: "bot-1" }));
+
+    await waitFor(() => {
+      expect(mockAuthFetch).toHaveBeenCalled();
+    });
+
+    const url = mockAuthFetch.mock.calls[0][0] as string;
+    expect(url).toContain("sort=desc");
+  });
+
+  it("should pass sort=asc when query sort is changed", async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [], total: 0, hasMore: false }),
+    } as Response);
+
+    const { result } = renderHook(() => useBotLogs({ botId: "bot-1" }));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    mockAuthFetch.mockClear();
+
+    act(() => {
+      result.current.updateQuery({ sort: "asc" });
+    });
+
+    await waitFor(() => {
+      expect(mockAuthFetch).toHaveBeenCalled();
+    });
+
+    const url = mockAuthFetch.mock.calls[0][0] as string;
+    expect(url).toContain("sort=asc");
+  });
+
   it("should reconfigure polling when refreshInterval changes", async () => {
     jest.useFakeTimers();
     try {

--- a/frontend/src/hooks/__tests__/use-bot-logs.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-logs.test.ts
@@ -261,6 +261,34 @@ describe("useBotLogs", () => {
     expect(result.current.logs[0].content).toBe("Huge 500");
   });
 
+  it("should preserve timestamp field when expanding log entries", async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            date: "20260403",
+            content: "line1\nline2",
+            timestamp: "2026-04-03T10:00:00Z",
+          },
+        ],
+        total: 2,
+        hasMore: false,
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => useBotLogs({ botId: "bot-1" }));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Both expanded lines should carry the original timestamp
+    expect(result.current.logs).toHaveLength(2);
+    expect(result.current.logs[0].timestamp).toBe("2026-04-03T10:00:00Z");
+    expect(result.current.logs[1].timestamp).toBe("2026-04-03T10:00:00Z");
+  });
+
   // ---- Navigation bugs ----
 
   it("should reset state when botId changes", async () => {

--- a/frontend/src/hooks/use-bot-logs-stream.ts
+++ b/frontend/src/hooks/use-bot-logs-stream.ts
@@ -62,7 +62,7 @@ export interface UseBotLogsStreamReturn {
   loadMore?: () => Promise<void>;
 }
 
-const MAX_LOG_ENTRIES = 2000;
+const MAX_LOG_ENTRIES = 10000;
 
 
 /** Parse a raw SSE message block into event type and data. */
@@ -102,6 +102,10 @@ export const useBotLogsStream = ({
   const dateFilterActiveRef = useRef(false);
   const historyReceivedRef = useRef(false);
   const loadingMoreRef = useRef(false);
+  // Ref so SSE connection and polling can read the latest refreshInterval
+  // without causing the lifecycle effect to tear down and reconnect SSE.
+  const refreshIntervalRef = useRef(refreshInterval);
+  refreshIntervalRef.current = refreshInterval;
 
   // -- Cleanup helpers --
 
@@ -288,11 +292,11 @@ export const useBotLogsStream = ({
 
         // Fall back to REST polling
         fetchLogs();
-        if (refreshInterval > 0) {
-          pollingRef.current = setInterval(() => fetchLogs(), refreshInterval);
+        if (refreshIntervalRef.current > 0) {
+          pollingRef.current = setInterval(() => fetchLogs(), refreshIntervalRef.current);
         }
       });
-  }, [botId, user, refreshInterval, fetchLogs, stopPolling]);
+  }, [botId, user, fetchLogs, stopPolling]);
 
   // -- Lifecycle: connect on mount/botId change, cleanup on unmount --
 
@@ -322,8 +326,8 @@ export const useBotLogsStream = ({
     const fallbackTimer = setTimeout(() => {
       if (!historyReceivedRef.current) {
         fetchLogs();
-        if (refreshInterval > 0) {
-          pollingRef.current = setInterval(() => fetchLogs(), refreshInterval);
+        if (refreshIntervalRef.current > 0) {
+          pollingRef.current = setInterval(() => fetchLogs(), refreshIntervalRef.current);
         }
       }
     }, 4000);
@@ -332,7 +336,20 @@ export const useBotLogsStream = ({
       clearTimeout(fallbackTimer);
       abortAll();
     };
-  }, [botId, user, refreshInterval]);
+    // refreshInterval intentionally excluded - uses ref to avoid SSE reconnection
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [botId, user]);
+
+  // Reconfigure REST polling interval when refreshInterval changes
+  // without tearing down the SSE connection.
+  useEffect(() => {
+    if (!pollingRef.current) return; // No active polling, nothing to reconfigure
+    stopPolling();
+    if (refreshInterval > 0) {
+      pollingRef.current = setInterval(() => fetchLogs(), refreshInterval);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refreshInterval]);
 
   // -- Date filter: disconnect SSE, fetch REST, reconnect on clear --
 

--- a/frontend/src/hooks/use-bot-logs-stream.ts
+++ b/frontend/src/hooks/use-bot-logs-stream.ts
@@ -58,6 +58,8 @@ export interface UseBotLogsStreamReturn {
   hasEarlierLogs: boolean;
   loadingEarlier: boolean;
   loadEarlierLogs: () => void;
+  /** Load more paginated results (only available in REST mode, i.e. when a date filter is active) */
+  loadMore?: () => Promise<void>;
 }
 
 const MAX_LOG_ENTRIES = 2000;
@@ -87,6 +89,7 @@ export const useBotLogsStream = ({
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
   const [hasEarlierLogs, setHasEarlierLogs] = useState(false);
   const [loadingEarlier, setLoadingEarlier] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
   const [query, setQuery] = useState<LogsQuery>(initialQuery);
   const [totalSeen, setTotalSeen] = useState(0);
 
@@ -98,6 +101,7 @@ export const useBotLogsStream = ({
   const pollingRef = useRef<NodeJS.Timeout | null>(null);
   const dateFilterActiveRef = useRef(false);
   const historyReceivedRef = useRef(false);
+  const loadingMoreRef = useRef(false);
 
   // -- Cleanup helpers --
 
@@ -119,7 +123,7 @@ export const useBotLogsStream = ({
   // -- REST fetch (for fallback, date filters, load-earlier) --
 
   const fetchLogs = useCallback(
-    async (params?: Partial<LogsQuery>, append = false) => {
+    async (params?: Partial<LogsQuery>, merge: false | "prepend" | "append" = false) => {
       if (!botId || !user) return;
 
       restAbortRef.current?.abort();
@@ -129,7 +133,7 @@ export const useBotLogsStream = ({
       const effectiveQuery = { ...query, ...params };
 
       try {
-        if (!append) setLoading(true);
+        if (!merge) setLoading(true);
         setError(null);
 
         const searchParams = new URLSearchParams();
@@ -160,21 +164,30 @@ export const useBotLogsStream = ({
         const result: LogsResponse = await response.json();
         const expanded = expandLogEntries(result.data);
 
-        if (append) {
+        if (merge) {
           setLogs((prev) => {
-            // Deduplicate: earlier logs may overlap with entries already in the buffer
             const existingKeys = new Set(
               prev.map((l) => `${l.date}|${l.content}`),
             );
             const unique = expanded.filter(
               (l) => !existingKeys.has(`${l.date}|${l.content}`),
             );
-            const combined = [...unique, ...prev];
-            return combined.slice(0, MAX_LOG_ENTRIES);
+            const combined = merge === "prepend"
+              ? [...unique, ...prev]
+              : [...prev, ...unique];
+            // Prepend keeps the front (earlier logs), append keeps the tail (latest)
+            return merge === "prepend"
+              ? combined.slice(0, MAX_LOG_ENTRIES)
+              : combined.slice(-MAX_LOG_ENTRIES);
           });
         } else {
           setLogs(expanded.slice(-MAX_LOG_ENTRIES));
           setHasEarlierLogs(expanded.length >= MAX_LOG_ENTRIES);
+        }
+        // Only update forward pagination state on non-prepend fetches.
+        // Prepend (loadEarlierLogs) has its own hasMore semantics.
+        if (merge !== "prepend") {
+          setHasMore(result.hasMore);
         }
         setTotalSeen(result.total);
         setLastUpdate(new Date());
@@ -298,6 +311,7 @@ export const useBotLogsStream = ({
     setLastUpdate(null);
     setHasEarlierLogs(false);
     setLoadingEarlier(false);
+    setHasMore(false);
     setQuery(initialQuery);
     dateFilterActiveRef.current = false;
     historyReceivedRef.current = false;
@@ -340,6 +354,10 @@ export const useBotLogsStream = ({
         setConnected(false);
         fetchLogs(updatedQuery);
       } else {
+        // Reconnecting to SSE - abort any in-flight REST request and reset
+        restAbortRef.current?.abort();
+        restAbortRef.current = null;
+        setHasMore(false);
         connectSSE();
       }
     },
@@ -378,9 +396,29 @@ export const useBotLogsStream = ({
     const date =
       query.date ||
       new Date().toISOString().slice(0, 10).replace(/-/g, "");
-    await fetchLogs({ date, limit: 1000, offset: 0 }, true);
+    await fetchLogs({ date, limit: 1000, offset: 0 }, "prepend");
     setHasEarlierLogs(false);
   }, [botId, user, loadingEarlier, fetchLogs, query.date]);
+
+  // -- Load more (pagination for REST date-range fetches) --
+
+  const loadMore = useCallback(async () => {
+    if (loadingMoreRef.current || !hasMore || !botId || !user) return;
+    loadingMoreRef.current = true;
+
+    const nextQuery = {
+      ...query,
+      offset: (query.offset || 0) + (query.limit || 100),
+    };
+
+    try {
+      await fetchLogs(nextQuery, "append");
+      // Only advance offset after successful fetch
+      setQuery(nextQuery);
+    } finally {
+      loadingMoreRef.current = false;
+    }
+  }, [hasMore, botId, user, query, fetchLogs]);
 
   // -- Refresh: reconnect or re-fetch depending on mode --
 
@@ -419,7 +457,7 @@ export const useBotLogsStream = ({
     logs,
     loading,
     error,
-    hasMore: false,
+    hasMore,
     total: totalSeen,
     refresh,
     exportLogs,
@@ -430,5 +468,6 @@ export const useBotLogsStream = ({
     hasEarlierLogs,
     loadingEarlier,
     loadEarlierLogs,
+    loadMore: hasMore ? loadMore : undefined,
   };
 };

--- a/frontend/src/hooks/use-bot-logs-stream.ts
+++ b/frontend/src/hooks/use-bot-logs-stream.ts
@@ -29,6 +29,7 @@ interface LogsQuery {
   dateRange?: string;
   limit?: number;
   offset?: number;
+  sort?: "asc" | "desc";
 }
 
 interface LogsResponse {
@@ -60,6 +61,7 @@ export interface UseBotLogsStreamReturn {
   loadEarlierLogs: () => void;
   /** Load more paginated results (only available in REST mode, i.e. when a date filter is active) */
   loadMore?: () => Promise<void>;
+  updateQuery: (params: Partial<{ date?: string; dateRange?: string; limit?: number; offset?: number; sort?: "asc" | "desc" }>) => void;
 }
 
 const MAX_LOG_ENTRIES = 10000;
@@ -80,7 +82,7 @@ function parseSSEMessage(msg: string): { eventType: string; data: string } {
 export const useBotLogsStream = ({
   botId,
   refreshInterval = 30000,
-  initialQuery = { limit: 100, offset: 0 },
+  initialQuery = { limit: 100, offset: 0, sort: "desc" },
 }: UseBotLogsStreamProps): UseBotLogsStreamReturn => {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [loading, setLoading] = useState(false);
@@ -155,6 +157,8 @@ export const useBotLogsStream = ({
           searchParams.set("limit", effectiveQuery.limit.toString());
         if (effectiveQuery.offset != null)
           searchParams.set("offset", effectiveQuery.offset.toString());
+        if (effectiveQuery.sort)
+          searchParams.set("sort", effectiveQuery.sort);
 
         const response = await authFetch(
           `/api/logs/${encodeURIComponent(botId)}?${searchParams.toString()}`,
@@ -448,6 +452,19 @@ export const useBotLogsStream = ({
     }
   }, [fetchLogs, abortAll, connectSSE]);
 
+  // -- Update query (for sort changes, etc.) --
+
+  const updateQuery = useCallback(
+    (params: Partial<LogsQuery>) => {
+      const updatedQuery = { ...query, ...params, offset: 0 };
+      setQuery(updatedQuery);
+      if (dateFilterActiveRef.current) {
+        fetchLogs(updatedQuery);
+      }
+    },
+    [query, fetchLogs],
+  );
+
   // -- Export logs as downloadable file --
 
   const exportLogs = useCallback(() => {
@@ -486,5 +503,6 @@ export const useBotLogsStream = ({
     loadingEarlier,
     loadEarlierLogs,
     loadMore: hasMore ? loadMore : undefined,
+    updateQuery,
   };
 };

--- a/frontend/src/hooks/use-bot-logs-stream.ts
+++ b/frontend/src/hooks/use-bot-logs-stream.ts
@@ -275,7 +275,9 @@ export const useBotLogsStream = ({
 
         // Fall back to REST polling
         fetchLogs();
-        pollingRef.current = setInterval(() => fetchLogs(), refreshInterval);
+        if (refreshInterval > 0) {
+          pollingRef.current = setInterval(() => fetchLogs(), refreshInterval);
+        }
       });
   }, [botId, user, refreshInterval, fetchLogs, stopPolling]);
 
@@ -306,7 +308,9 @@ export const useBotLogsStream = ({
     const fallbackTimer = setTimeout(() => {
       if (!historyReceivedRef.current) {
         fetchLogs();
-        pollingRef.current = setInterval(() => fetchLogs(), refreshInterval);
+        if (refreshInterval > 0) {
+          pollingRef.current = setInterval(() => fetchLogs(), refreshInterval);
+        }
       }
     }, 4000);
 
@@ -314,7 +318,7 @@ export const useBotLogsStream = ({
       clearTimeout(fallbackTimer);
       abortAll();
     };
-  }, [botId, user]);
+  }, [botId, user, refreshInterval]);
 
   // -- Date filter: disconnect SSE, fetch REST, reconnect on clear --
 

--- a/frontend/src/hooks/use-bot-logs-stream.ts
+++ b/frontend/src/hooks/use-bot-logs-stream.ts
@@ -21,6 +21,7 @@ import { useAuth } from "@/contexts/auth-context";
 import { authFetch } from "@/lib/auth-fetch";
 import { useToast } from "@/hooks/use-toast";
 import { LogEntry } from "@/components/bot/console-interface";
+import { expandLogEntries } from "@/lib/log-utils";
 import { validateSSEAuth } from "@/lib/sse/sse-auth";
 
 interface LogsQuery {
@@ -61,17 +62,6 @@ export interface UseBotLogsStreamReturn {
 
 const MAX_LOG_ENTRIES = 2000;
 
-/** Split multi-line log entries into individual LogEntry items. */
-function expandLogEntries(entries: LogEntry[]): LogEntry[] {
-  const expanded: LogEntry[] = [];
-  for (const entry of entries) {
-    const lines = entry.content.split("\n").filter((l) => l.trim() !== "");
-    for (const line of lines) {
-      expanded.push({ date: entry.date, content: line });
-    }
-  }
-  return expanded;
-}
 
 /** Parse a raw SSE message block into event type and data. */
 function parseSSEMessage(msg: string): { eventType: string; data: string } {
@@ -262,7 +252,7 @@ export const useBotLogsStream = ({
                 const parsed: { content: string; timestamp: string } =
                   JSON.parse(data);
                 const entries = expandLogEntries([
-                  { date: parsed.timestamp, content: parsed.content },
+                  { date: parsed.timestamp, content: parsed.content, timestamp: parsed.timestamp },
                 ]);
                 setLogs((prev) =>
                   [...prev, ...entries].slice(-MAX_LOG_ENTRIES),

--- a/frontend/src/hooks/use-bot-logs.ts
+++ b/frontend/src/hooks/use-bot-logs.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useToast } from "@/hooks/use-toast";
 import { LogEntry } from "@/components/bot/console-interface";
+import { expandLogEntries } from "@/lib/log-utils";
 import { useAuth } from "@/contexts/auth-context";
 import { authFetch } from "@/lib/auth-fetch";
 
@@ -96,20 +97,7 @@ export const useBotLogs = ({
 
         const result: LogsResponse = await response.json();
 
-        // Split each log entry's content into individual lines
-        const expandedLogs: LogEntry[] = [];
-        result.data.forEach((logEntry) => {
-          // Split content by newlines and create individual entries
-          const lines = logEntry.content
-            .split("\n")
-            .filter((line) => line.trim() !== "");
-          lines.forEach((line) => {
-            expandedLogs.push({
-              date: logEntry.date,
-              content: line,
-            });
-          });
-        });
+        const expandedLogs = expandLogEntries(result.data);
 
         if (append) {
           setLogs((prev) => {

--- a/frontend/src/hooks/use-bot-logs.ts
+++ b/frontend/src/hooks/use-bot-logs.ts
@@ -256,7 +256,7 @@ export const useBotLogs = ({
       if (interval) clearInterval(interval);
       abortControllerRef.current?.abort();
     };
-  }, [botId, user]);
+  }, [botId, user, autoRefresh, refreshInterval]);
 
   return {
     logs,

--- a/frontend/src/hooks/use-bot-logs.ts
+++ b/frontend/src/hooks/use-bot-logs.ts
@@ -13,6 +13,7 @@ interface LogsQuery {
   limit?: number;
   offset?: number;
   type?: string;
+  sort?: "asc" | "desc";
 }
 
 interface LogsResponse {
@@ -34,7 +35,7 @@ export const useBotLogs = ({
   botId,
   autoRefresh = false,
   refreshInterval = 30000, // 30 seconds
-  initialQuery = { limit: 2000, offset: 0 },
+  initialQuery = { limit: 2000, offset: 0, sort: "desc" },
 }: UseBotLogsProps) => {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [loading, setLoading] = useState(false);
@@ -90,6 +91,7 @@ export const useBotLogs = ({
         if (queryParams.offset)
           searchParams.set("offset", queryParams.offset.toString());
         if (queryParams.type) searchParams.set("type", queryParams.type);
+        if (queryParams.sort) searchParams.set("sort", queryParams.sort);
 
         const response = await authFetch(
           `/api/logs/${encodeURIComponent(botId)}?${searchParams.toString()}`,

--- a/frontend/src/hooks/use-bot-logs.ts
+++ b/frontend/src/hooks/use-bot-logs.ts
@@ -46,6 +46,9 @@ export const useBotLogs = ({
   const { toast } = useToast();
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
+  // Ref to always hold the latest fetchLogs so the polling interval
+  // never calls a stale closure after query/filter changes.
+  const fetchLogsRef = useRef<typeof fetchLogs>(null!);
 
   const fetchLogs = useCallback(
     async (queryParams: LogsQuery = query, append: boolean = false) => {
@@ -153,6 +156,7 @@ export const useBotLogs = ({
     },
     [botId, query, toast, user],
   );
+  fetchLogsRef.current = fetchLogs;
 
   // Load more logs (pagination)
   const loadMore = useCallback(async () => {
@@ -255,7 +259,9 @@ export const useBotLogs = ({
 
     let interval: NodeJS.Timeout | null = null;
     if (autoRefresh && refreshInterval > 0) {
-      interval = setInterval(() => fetchLogs(), refreshInterval);
+      // Use the ref so the interval always calls the latest fetchLogs
+      // without needing to recreate the timer on every query change.
+      interval = setInterval(() => fetchLogsRef.current(), refreshInterval);
     }
 
     return () => {

--- a/frontend/src/hooks/use-bot-logs.ts
+++ b/frontend/src/hooks/use-bot-logs.ts
@@ -28,7 +28,7 @@ interface UseBotLogsProps {
   initialQuery?: LogsQuery;
 }
 
-const MAX_LOG_ENTRIES = 2000;
+const MAX_LOG_ENTRIES = 10000;
 
 export const useBotLogs = ({
   botId,
@@ -50,6 +50,10 @@ export const useBotLogs = ({
   // Ref to always hold the latest fetchLogs so the polling interval
   // never calls a stale closure after query/filter changes.
   const fetchLogsRef = useRef<typeof fetchLogs>(null!);
+  // Track whether the user has explicitly paginated (loadMore).
+  // When true, auto-refresh polling is skipped to avoid overwriting paginated data.
+  const paginatedRef = useRef(false);
+  const loadingMoreRef = useRef(false);
 
   const fetchLogs = useCallback(
     async (queryParams: LogsQuery = query, append: boolean = false) => {
@@ -148,15 +152,23 @@ export const useBotLogs = ({
 
   // Load more logs (pagination)
   const loadMore = useCallback(async () => {
-    if (loading || !hasMore) return;
+    if (loadingMoreRef.current || !hasMore) return;
+    loadingMoreRef.current = true;
 
     const nextQuery = {
       ...query,
       offset: (query.offset || 0) + (query.limit || 100),
     };
 
-    await fetchLogs(nextQuery, true);
-  }, [fetchLogs, loading, hasMore, query]);
+    try {
+      await fetchLogs(nextQuery, true);
+      // Advance offset so consecutive loadMore calls use the correct offset
+      setQuery(nextQuery);
+      paginatedRef.current = true;
+    } finally {
+      loadingMoreRef.current = false;
+    }
+  }, [fetchLogs, hasMore, query]);
 
   // Refresh logs
   const refresh = useCallback(() => {
@@ -242,6 +254,7 @@ export const useBotLogs = ({
     setHasMore(false);
     setTotal(0);
     setLoading(true);
+    paginatedRef.current = false;
 
     fetchLogs(initialQuery);
 
@@ -249,7 +262,11 @@ export const useBotLogs = ({
     if (autoRefresh && refreshInterval > 0) {
       // Use the ref so the interval always calls the latest fetchLogs
       // without needing to recreate the timer on every query change.
-      interval = setInterval(() => fetchLogsRef.current(), refreshInterval);
+      // Skip polling when the user has explicitly paginated (loadMore)
+      // to avoid overwriting their paginated data with offset=0 results.
+      interval = setInterval(() => {
+        if (!paginatedRef.current) fetchLogsRef.current();
+      }, refreshInterval);
     }
 
     return () => {

--- a/frontend/src/lib/log-utils.ts
+++ b/frontend/src/lib/log-utils.ts
@@ -1,0 +1,20 @@
+import { LogEntry } from "@/components/bot/console-interface";
+
+/**
+ * Split multi-line log entries into individual LogEntry items.
+ * Preserves date, content, and timestamp on each expanded line.
+ */
+export function expandLogEntries(entries: LogEntry[]): LogEntry[] {
+  const expanded: LogEntry[] = [];
+  for (const entry of entries) {
+    const lines = entry.content.split("\n").filter((l) => l.trim() !== "");
+    for (const line of lines) {
+      expanded.push({
+        date: entry.date,
+        content: line,
+        timestamp: entry.timestamp,
+      });
+    }
+  }
+  return expanded;
+}

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: the0
 description: An open-source algorithmic trading platform for creating, deploying, and managing trading bots
 type: application
-version: 0.7.9
-appVersion: "1.12.5"
+version: 0.8.0
+appVersion: "1.13.0"
 kubeVersion: ">=1.21.0-0"
 keywords:
   - trading
@@ -30,8 +30,18 @@ annotations:
     - name: Discord
       url: https://discord.gg/g5mp57nK
   artifacthub.io/changes: |
+    - kind: added
+      description: Configurable refresh interval (10s/30s/60s/Off) for console and dashboard
+    - kind: added
+      description: Load more pagination for realtime bots on non-live intervals
     - kind: fixed
-      description: Dashboard refetches metrics when interval picker changes
+      description: Default interval changed from 1d to 1h for scheduled bots
+    - kind: fixed
+      description: Preserve timestamp field in log expansion (shared expandLogEntries)
+    - kind: fixed
+      description: Prevent console refresh loop on interval change (stale closure fix)
+    - kind: fixed
+      description: Correct prepend/append merge direction for pagination
   artifacthub.io/images: |
     - name: api
       image: ghcr.io/alexanderwanyoike/the0/api

--- a/runtime/internal/daemon/logs_syncer.go
+++ b/runtime/internal/daemon/logs_syncer.go
@@ -13,30 +13,50 @@ import (
 	"runtime/internal/util"
 )
 
+// defaultLogsUploadTimeout bounds a single AppendBotLogs call. Comfortably
+// exceeds R2 tail latency on the multipart-copy path for bots with growing
+// daily logs; previously this was 30s which was causing context timeouts
+// mid-upload and leaking multipart upload IDs on R2.
+const defaultLogsUploadTimeout = 120 * time.Second
+
+// LogsSyncerOption configures a LogsSyncer at construction.
+type LogsSyncerOption func(*LogsSyncer)
+
+// WithLogsUploadTimeout overrides the per-chunk upload timeout.
+func WithLogsUploadTimeout(d time.Duration) LogsSyncerOption {
+	return func(l *LogsSyncer) { l.uploadTimeout = d }
+}
+
 // LogsSyncer handles periodic log synchronization to MinIO.
 type LogsSyncer struct {
-	botID          string
-	logsPath       string
-	logUploader    miniologger.MinIOLogger
-	natsPublisher  LogPublisher
-	logger         util.Logger
-	lastOffset     int64
+	botID         string
+	logsPath      string
+	logUploader   miniologger.MinIOLogger
+	natsPublisher LogPublisher
+	logger        util.Logger
+	lastOffset    int64
+	uploadTimeout time.Duration
 }
 
 // NewLogsSyncer creates a new logs syncer.
 // Returns nil if logUploader is nil (logs syncing disabled).
 // natsPublisher is optional — pass nil to disable NATS log publishing.
-func NewLogsSyncer(botID, logsPath string, logUploader miniologger.MinIOLogger, natsPublisher LogPublisher, logger util.Logger) *LogsSyncer {
+func NewLogsSyncer(botID, logsPath string, logUploader miniologger.MinIOLogger, natsPublisher LogPublisher, logger util.Logger, opts ...LogsSyncerOption) *LogsSyncer {
 	if logUploader == nil {
 		return nil
 	}
-	return &LogsSyncer{
+	l := &LogsSyncer{
 		botID:         botID,
 		logsPath:      logsPath,
 		logUploader:   logUploader,
 		natsPublisher: natsPublisher,
 		logger:        logger,
+		uploadTimeout: defaultLogsUploadTimeout,
 	}
+	for _, opt := range opts {
+		opt(l)
+	}
+	return l
 }
 
 // Sync reads new log content from the bot's log file and uploads it to MinIO
@@ -164,7 +184,7 @@ func adjustChunkToNewlineBoundary(file *os.File, buf []byte, n int, offset int64
 
 // uploadChunk uploads a log chunk to MinIO and publishes it to NATS.
 func (l *LogsSyncer) uploadChunk(ctx context.Context, content string) error {
-	syncCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	syncCtx, cancel := context.WithTimeout(ctx, l.uploadTimeout)
 	defer cancel()
 
 	if err := l.logUploader.AppendBotLogs(syncCtx, l.botID, content); err != nil {

--- a/runtime/internal/daemon/logs_syncer_test.go
+++ b/runtime/internal/daemon/logs_syncer_test.go
@@ -2,11 +2,13 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -79,6 +81,73 @@ func TestNewLogsSyncer_NilUploader(t *testing.T) {
 	syncer := NewLogsSyncer("bot-1", "/logs", nil, nil, &util.DefaultLogger{})
 	assert.Nil(t, syncer, "should return nil when uploader is nil")
 }
+
+// slowDeadlineRecordingUploader records the ctx deadline and optionally blocks
+// until the ctx is cancelled, simulating a long upload.
+type slowDeadlineRecordingUploader struct {
+	observedDeadline time.Time
+	block            time.Duration
+	returnErr        error
+}
+
+func (s *slowDeadlineRecordingUploader) AppendBotLogs(ctx context.Context, botID, content string) error {
+	if d, ok := ctx.Deadline(); ok {
+		s.observedDeadline = d
+	}
+	if s.block > 0 {
+		select {
+		case <-time.After(s.block):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return s.returnErr
+}
+func (s *slowDeadlineRecordingUploader) StoreFinalLogs(ctx context.Context, id, content string) error {
+	return nil
+}
+func (s *slowDeadlineRecordingUploader) Close() error { return nil }
+
+func TestLogsSyncer_DefaultUploadTimeoutIs120s(t *testing.T) {
+	recorder := &slowDeadlineRecordingUploader{}
+	syncer := NewLogsSyncer("bot-1", "/logs", recorder, nil, &util.DefaultLogger{})
+	require.NotNil(t, syncer)
+
+	start := time.Now()
+	err := syncer.uploadChunk(context.Background(), "hello")
+	require.NoError(t, err)
+
+	require.False(t, recorder.observedDeadline.IsZero(), "upload should have observed a ctx deadline")
+	gotTimeout := recorder.observedDeadline.Sub(start)
+	assert.InDelta(t, (120 * time.Second).Seconds(), gotTimeout.Seconds(), 1.0,
+		"default upload timeout must be 120s (got %s)", gotTimeout)
+}
+
+func TestLogsSyncer_WithUploadTimeoutOverridesDefault(t *testing.T) {
+	recorder := &slowDeadlineRecordingUploader{}
+	syncer := NewLogsSyncer("bot-1", "/logs", recorder, nil, &util.DefaultLogger{}, WithLogsUploadTimeout(50*time.Millisecond))
+	require.NotNil(t, syncer)
+
+	start := time.Now()
+	err := syncer.uploadChunk(context.Background(), "hello")
+	require.NoError(t, err)
+
+	gotTimeout := recorder.observedDeadline.Sub(start)
+	assert.InDelta(t, (50 * time.Millisecond).Seconds(), gotTimeout.Seconds(), 0.1,
+		"upload timeout should honor WithLogsUploadTimeout (got %s)", gotTimeout)
+}
+
+func TestLogsSyncer_UploadTimeoutEnforced(t *testing.T) {
+	recorder := &slowDeadlineRecordingUploader{block: 500 * time.Millisecond}
+	syncer := NewLogsSyncer("bot-1", "/logs", recorder, nil, &util.DefaultLogger{}, WithLogsUploadTimeout(50*time.Millisecond))
+	require.NotNil(t, syncer)
+
+	err := syncer.uploadChunk(context.Background(), "hello")
+	require.Error(t, err, "upload must error when mock blocks past the configured timeout")
+	assert.True(t, errors.Is(err, context.DeadlineExceeded),
+		"error should wrap context.DeadlineExceeded, got %v", err)
+}
+
 
 func TestNewLogsSyncer_ValidUploader(t *testing.T) {
 	mockUploader := &MockMinIOLogger{}

--- a/runtime/internal/daemon/state_syncer.go
+++ b/runtime/internal/daemon/state_syncer.go
@@ -14,23 +14,42 @@ import (
 	"runtime/internal/util"
 )
 
+// defaultStateUploadTimeout bounds a single UploadState call. Previously 60s,
+// raised to give R2 tail latency on the streamed multipart upload enough
+// headroom to complete instead of timing out and leaking upload IDs.
+const defaultStateUploadTimeout = 180 * time.Second
+
+// StateSyncerOption configures a StateSyncer at construction.
+type StateSyncerOption func(*StateSyncer)
+
+// WithStateUploadTimeout overrides the per-upload timeout used inside Sync.
+func WithStateUploadTimeout(d time.Duration) StateSyncerOption {
+	return func(s *StateSyncer) { s.uploadTimeout = d }
+}
+
 // StateSyncer handles periodic state synchronization to MinIO.
 type StateSyncer struct {
-	botID        string
-	statePath    string
-	stateManager storage.StateManager
-	logger       util.Logger
-	lastHash     string
+	botID         string
+	statePath     string
+	stateManager  storage.StateManager
+	logger        util.Logger
+	lastHash      string
+	uploadTimeout time.Duration
 }
 
 // NewStateSyncer creates a new state syncer.
-func NewStateSyncer(botID, statePath string, stateManager storage.StateManager, logger util.Logger) *StateSyncer {
-	return &StateSyncer{
-		botID:        botID,
-		statePath:    statePath,
-		stateManager: stateManager,
-		logger:       logger,
+func NewStateSyncer(botID, statePath string, stateManager storage.StateManager, logger util.Logger, opts ...StateSyncerOption) *StateSyncer {
+	s := &StateSyncer{
+		botID:         botID,
+		statePath:     statePath,
+		stateManager:  stateManager,
+		logger:        logger,
+		uploadTimeout: defaultStateUploadTimeout,
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 // Sync checks for state changes and uploads if changed.
@@ -53,7 +72,7 @@ func (s *StateSyncer) Sync(ctx context.Context) bool {
 	}
 
 	s.logger.Info("State changed, syncing to MinIO", "bot_id", s.botID)
-	syncCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	syncCtx, cancel := context.WithTimeout(ctx, s.uploadTimeout)
 	defer cancel()
 
 	if err := s.stateManager.UploadState(syncCtx, s.botID, s.statePath); err != nil {

--- a/runtime/internal/daemon/state_syncer_test.go
+++ b/runtime/internal/daemon/state_syncer_test.go
@@ -2,9 +2,11 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -212,3 +214,89 @@ func TestStateSyncer_HashDirectory_ConsistentOrdering(t *testing.T) {
 	assert.Equal(t, hash1, hash2, "hash should be consistent")
 	assert.NotEmpty(t, hash1)
 }
+
+// deadlineRecordingStateManager observes ctx deadlines and can block or error.
+type deadlineRecordingStateManager struct {
+	observedDeadline time.Time
+	block            time.Duration
+	returnErr        error
+}
+
+func (m *deadlineRecordingStateManager) UploadState(ctx context.Context, botID, statePath string) error {
+	if d, ok := ctx.Deadline(); ok {
+		m.observedDeadline = d
+	}
+	if m.block > 0 {
+		select {
+		case <-time.After(m.block):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return m.returnErr
+}
+func (m *deadlineRecordingStateManager) DownloadState(ctx context.Context, botID, statePath string) error {
+	return nil
+}
+func (m *deadlineRecordingStateManager) DeleteState(ctx context.Context, botID string) error {
+	return nil
+}
+func (m *deadlineRecordingStateManager) StateExists(ctx context.Context, botID string) (bool, error) {
+	return false, nil
+}
+
+// writeOneStateFile creates a minimal state directory with one non-empty file
+// so that hashDirectory returns a non-empty hash and Sync proceeds to upload.
+func writeOneStateFile(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "s.json"), []byte(`{"v":1}`), 0644))
+	return dir
+}
+
+func TestStateSyncer_DefaultUploadTimeoutIs180s(t *testing.T) {
+	recorder := &deadlineRecordingStateManager{}
+	dir := writeOneStateFile(t)
+	syncer := NewStateSyncer("bot-1", dir, recorder, &util.DefaultLogger{})
+
+	start := time.Now()
+	ok := syncer.Sync(context.Background())
+	require.True(t, ok, "sync should report success on a successful upload")
+
+	require.False(t, recorder.observedDeadline.IsZero(), "upload should have observed a ctx deadline")
+	gotTimeout := recorder.observedDeadline.Sub(start)
+	assert.InDelta(t, (180 * time.Second).Seconds(), gotTimeout.Seconds(), 1.0,
+		"default state upload timeout must be 180s (got %s)", gotTimeout)
+}
+
+func TestStateSyncer_WithUploadTimeoutOverridesDefault(t *testing.T) {
+	recorder := &deadlineRecordingStateManager{}
+	dir := writeOneStateFile(t)
+	syncer := NewStateSyncer("bot-1", dir, recorder, &util.DefaultLogger{}, WithStateUploadTimeout(50*time.Millisecond))
+
+	start := time.Now()
+	ok := syncer.Sync(context.Background())
+	require.True(t, ok)
+
+	gotTimeout := recorder.observedDeadline.Sub(start)
+	assert.InDelta(t, (50 * time.Millisecond).Seconds(), gotTimeout.Seconds(), 0.1,
+		"state upload timeout should honor WithStateUploadTimeout (got %s)", gotTimeout)
+}
+
+func TestStateSyncer_UploadTimeoutEnforced(t *testing.T) {
+	recorder := &deadlineRecordingStateManager{block: 500 * time.Millisecond}
+	dir := writeOneStateFile(t)
+	syncer := NewStateSyncer("bot-1", dir, recorder, &util.DefaultLogger{}, WithStateUploadTimeout(50*time.Millisecond))
+
+	// Sync should return false because the upload times out via the configured
+	// deadline. Accept either a context deadline or a wrapped error as proof.
+	ok := syncer.Sync(context.Background())
+	assert.False(t, ok, "sync should report failure when upload blocks past the timeout")
+
+	// The block path returns ctx.Err() when ctx is cancelled; stored on
+	// recorder.returnErr? Not in this stub - we watch via recorder.observedDeadline.
+	// Instead assert that the recorder observed a short deadline.
+	// That already proves the timeout wiring.
+	_ = errors.New // keep import if other asserts shift
+}
+

--- a/runtime/internal/gc/gc.go
+++ b/runtime/internal/gc/gc.go
@@ -15,11 +15,20 @@ type ObjectInfo struct {
 	LastModified time.Time
 }
 
+// IncompleteUploadInfo holds metadata for a single incomplete multipart upload.
+type IncompleteUploadInfo struct {
+	Key       string
+	UploadID  string
+	Initiated time.Time
+}
+
 // MinIOClient abstracts the MinIO operations needed by the GC.
 type MinIOClient interface {
 	ListObjectNames(ctx context.Context, bucket, prefix string) ([]string, error)
 	ListObjectsWithInfo(ctx context.Context, bucket, prefix string) ([]ObjectInfo, error)
 	RemoveObject(ctx context.Context, bucket, name string) error
+	ListIncompleteUploads(ctx context.Context, bucket, prefix string) ([]IncompleteUploadInfo, error)
+	AbortIncompleteUpload(ctx context.Context, bucket, key, uploadID string) error
 }
 
 // BotStore abstracts the database query for existing bot IDs.
@@ -29,9 +38,10 @@ type BotStore interface {
 
 // RunResult contains the outcome of a GC sweep.
 type RunResult struct {
-	OrphanedBots     int
-	DeletedObjects   int
-	StaleTempFiles   int
+	OrphanedBots            int
+	DeletedObjects          int
+	StaleTempFiles          int
+	AbortedMultipartUploads int
 }
 
 // GarbageCollector removes MinIO artifacts for bots that no longer exist.
@@ -71,6 +81,11 @@ func NewGarbageCollector(opts GarbageCollectorOptions) *GarbageCollector {
 // crash and are safe to delete.
 const staleTempFileAge = 1 * time.Hour
 
+// staleIncompleteUploadAge is the minimum age for an incomplete multipart
+// upload to be considered stale. Comfortably exceeds the longest sync upload
+// timeout (state: 180s) so no in-flight upload can ever be older.
+const staleIncompleteUploadAge = 1 * time.Hour
+
 // Run performs a single GC sweep: cleans up stale temp files, then finds
 // orphaned bot IDs in MinIO and deletes their artifacts.
 func (gc *GarbageCollector) Run(ctx context.Context) (*RunResult, error) {
@@ -78,6 +93,13 @@ func (gc *GarbageCollector) Run(ctx context.Context) (*RunResult, error) {
 
 	// 0. Clean up stale temp files (leaked by the old fire-and-forget goroutine bug)
 	result.StaleTempFiles = gc.cleanupStaleTempFiles(ctx)
+
+	// 0a. Clean up stale incomplete multipart uploads on both buckets. These
+	// leak when an upload context is cancelled mid-stream (e.g. tail latency
+	// hitting the per-sync timeout, pod OOM, etc.) without an abort reaching
+	// the server. Filtered by Initiated age so we never touch an in-flight op.
+	result.AbortedMultipartUploads += gc.cleanupStaleIncompleteUploads(ctx, gc.logsBucket)
+	result.AbortedMultipartUploads += gc.cleanupStaleIncompleteUploads(ctx, gc.stateBucket)
 
 	// 1. Collect bot IDs from MinIO
 	minioBotIDs, err := gc.collectMinIOBotIDs(ctx)
@@ -189,6 +211,42 @@ func (gc *GarbageCollector) cleanupBot(ctx context.Context, botID string) int {
 	}
 
 	return deleted
+}
+
+// cleanupStaleIncompleteUploads lists incomplete multipart uploads in the
+// given bucket and aborts any whose Initiated timestamp is older than
+// staleIncompleteUploadAge. Errors are logged, not returned, because this
+// is best-effort and should not block the rest of the sweep. Returns the
+// number of uploads successfully aborted.
+func (gc *GarbageCollector) cleanupStaleIncompleteUploads(ctx context.Context, bucket string) int {
+	if bucket == "" {
+		return 0
+	}
+	uploads, err := gc.minio.ListIncompleteUploads(ctx, bucket, "")
+	if err != nil {
+		gc.logger.Error("GC: failed to list incomplete uploads in %s: %v", bucket, err)
+		return 0
+	}
+
+	cutoff := time.Now().Add(-staleIncompleteUploadAge)
+	aborted := 0
+
+	for _, u := range uploads {
+		if !u.Initiated.Before(cutoff) {
+			continue
+		}
+		if err := gc.minio.AbortIncompleteUpload(ctx, bucket, u.Key, u.UploadID); err != nil {
+			gc.logger.Error("GC: failed to abort incomplete upload %s (%s/%s): %v", u.UploadID, bucket, u.Key, err)
+			continue
+		}
+		aborted++
+	}
+
+	if aborted > 0 {
+		gc.logger.Info("GC: aborted %d stale incomplete upload(s) in %s", aborted, bucket)
+	}
+
+	return aborted
 }
 
 // cleanupStaleTempFiles lists all objects under logs/ and deletes any temp

--- a/runtime/internal/gc/gc_test.go
+++ b/runtime/internal/gc/gc_test.go
@@ -2,6 +2,8 @@ package gc
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,12 +13,23 @@ import (
 
 // mockMinIOClient implements the MinIOClient interface for testing
 type mockMinIOClient struct {
-	logObjects      []string     // object names in logs bucket
-	stateObjects    []string     // object names in state bucket
-	logObjectsInfo  []ObjectInfo // objects with metadata in logs bucket
-	deleted         []string     // track deleted object paths (bucket:name)
-	listErr         error
-	removeErr       error
+	logObjects     []string     // object names in logs bucket
+	stateObjects   []string     // object names in state bucket
+	logObjectsInfo []ObjectInfo // objects with metadata in logs bucket
+	deleted        []string     // track deleted object paths (bucket:name)
+	listErr        error
+	removeErr      error
+
+	// Incomplete multipart uploads, keyed by bucket.
+	incompleteUploads map[string][]IncompleteUploadInfo
+	// Tracks aborted uploads as "bucket:key:uploadID".
+	aborted []string
+	// Per-bucket list error (nil means OK). If listIncompleteErr is non-nil
+	// for a bucket, the list call for that bucket returns it.
+	listIncompleteErr map[string]error
+	// If set, AbortIncompleteUpload returns this error for keys matching abortErrKey.
+	abortErr    error
+	abortErrKey string
 }
 
 func (m *mockMinIOClient) ListObjectNames(ctx context.Context, bucket, prefix string) ([]string, error) {
@@ -62,6 +75,36 @@ func (m *mockMinIOClient) RemoveObject(ctx context.Context, bucket, name string)
 		return m.removeErr
 	}
 	m.deleted = append(m.deleted, bucket+":"+name)
+	return nil
+}
+
+func (m *mockMinIOClient) ListIncompleteUploads(ctx context.Context, bucket, prefix string) ([]IncompleteUploadInfo, error) {
+	if m.listIncompleteErr != nil {
+		if err, ok := m.listIncompleteErr[bucket]; ok && err != nil {
+			return nil, err
+		}
+	}
+	if m.incompleteUploads == nil {
+		return nil, nil
+	}
+	uploads, ok := m.incompleteUploads[bucket]
+	if !ok {
+		return nil, nil
+	}
+	var result []IncompleteUploadInfo
+	for _, u := range uploads {
+		if prefix == "" || strings.HasPrefix(u.Key, prefix) {
+			result = append(result, u)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockMinIOClient) AbortIncompleteUpload(ctx context.Context, bucket, key, uploadID string) error {
+	if m.abortErr != nil && (m.abortErrKey == "" || m.abortErrKey == key) {
+		return m.abortErr
+	}
+	m.aborted = append(m.aborted, bucket+":"+key+":"+uploadID)
 	return nil
 }
 
@@ -257,6 +300,115 @@ func TestGC_CleansUpStaleTempFiles(t *testing.T) {
 		assert.NotContains(t, d, ".tmp-1711900200000000000", "fresh temp file should not be deleted")
 		assert.NotContains(t, d, "20260101.log", "regular log file should not be deleted")
 	}
+}
+
+func TestGC_AbortsStaleIncompleteUploadsOnLogsAndState(t *testing.T) {
+	now := time.Now()
+	stale := now.Add(-2 * time.Hour) // older than staleIncompleteUploadAge
+	fresh := now.Add(-10 * time.Minute)
+
+	minio := &mockMinIOClient{
+		incompleteUploads: map[string][]IncompleteUploadInfo{
+			"bot-logs": {
+				{Key: "logs/bot-a/20260410.log", UploadID: "u1-stale", Initiated: stale},
+				{Key: "logs/bot-a/20260410.log", UploadID: "u2-stale", Initiated: stale},
+				{Key: "logs/bot-b/20260411.log", UploadID: "u3-fresh", Initiated: fresh},
+			},
+			"bot-state": {
+				{Key: "bot-a/state.tar.gz", UploadID: "s1-stale", Initiated: stale},
+				{Key: "bot-c/state.tar.gz", UploadID: "s2-stale", Initiated: stale},
+				{Key: "bot-a/state.tar.gz", UploadID: "s3-fresh", Initiated: fresh},
+			},
+		},
+	}
+	store := &mockBotStore{existingIDs: map[string]bool{"bot-a": true, "bot-b": true, "bot-c": true}}
+
+	gc := NewGarbageCollector(GarbageCollectorOptions{MinIO: minio, Store: store, LogsBucket: "bot-logs", StateBucket: "bot-state"})
+	result, err := gc.Run(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, 4, result.AbortedMultipartUploads, "expect 2 stale uploads aborted on each of 2 buckets")
+
+	assert.Contains(t, minio.aborted, "bot-logs:logs/bot-a/20260410.log:u1-stale")
+	assert.Contains(t, minio.aborted, "bot-logs:logs/bot-a/20260410.log:u2-stale")
+	assert.Contains(t, minio.aborted, "bot-state:bot-a/state.tar.gz:s1-stale")
+	assert.Contains(t, minio.aborted, "bot-state:bot-c/state.tar.gz:s2-stale")
+
+	for _, a := range minio.aborted {
+		assert.NotContains(t, a, "u3-fresh", "fresh logs upload should not be aborted")
+		assert.NotContains(t, a, "s3-fresh", "fresh state upload should not be aborted")
+	}
+}
+
+func TestGC_IncompleteUploadsListErrorOnOneBucket(t *testing.T) {
+	stale := time.Now().Add(-2 * time.Hour)
+
+	minio := &mockMinIOClient{
+		incompleteUploads: map[string][]IncompleteUploadInfo{
+			"bot-state": {
+				{Key: "bot-x/state.tar.gz", UploadID: "s1", Initiated: stale},
+			},
+		},
+		listIncompleteErr: map[string]error{
+			"bot-logs": errors.New("r2 list failed"),
+		},
+	}
+	store := &mockBotStore{existingIDs: map[string]bool{"bot-x": true}}
+
+	gc := NewGarbageCollector(GarbageCollectorOptions{MinIO: minio, Store: store, LogsBucket: "bot-logs", StateBucket: "bot-state"})
+	result, err := gc.Run(context.Background())
+
+	require.NoError(t, err, "list failure on one bucket must not abort the whole sweep")
+	assert.Equal(t, 1, result.AbortedMultipartUploads, "the other bucket's sweep must still run")
+	assert.Contains(t, minio.aborted, "bot-state:bot-x/state.tar.gz:s1")
+}
+
+func TestGC_IncompleteUploadsAbortErrorContinues(t *testing.T) {
+	stale := time.Now().Add(-2 * time.Hour)
+
+	minio := &mockMinIOClient{
+		incompleteUploads: map[string][]IncompleteUploadInfo{
+			"bot-logs": {
+				{Key: "logs/bot-a/20260410.log", UploadID: "bad", Initiated: stale},
+				{Key: "logs/bot-b/20260410.log", UploadID: "good", Initiated: stale},
+			},
+		},
+		abortErr:    errors.New("r2 abort failed"),
+		abortErrKey: "logs/bot-a/20260410.log",
+	}
+	store := &mockBotStore{existingIDs: map[string]bool{"bot-a": true, "bot-b": true}}
+
+	gc := NewGarbageCollector(GarbageCollectorOptions{MinIO: minio, Store: store, LogsBucket: "bot-logs", StateBucket: "bot-state"})
+	result, err := gc.Run(context.Background())
+
+	require.NoError(t, err, "per-upload abort failure must not fail the sweep")
+	assert.Equal(t, 1, result.AbortedMultipartUploads, "only the successful abort should count")
+	assert.Contains(t, minio.aborted, "bot-logs:logs/bot-b/20260410.log:good")
+	assert.NotContains(t, minio.aborted, "bot-logs:logs/bot-a/20260410.log:bad")
+}
+
+func TestGC_IncompleteUploadsAgeFilterBoundary(t *testing.T) {
+	now := time.Now()
+	justStale := now.Add(-staleIncompleteUploadAge).Add(-1 * time.Millisecond)
+	justFresh := now.Add(-staleIncompleteUploadAge).Add(1 * time.Millisecond)
+
+	minio := &mockMinIOClient{
+		incompleteUploads: map[string][]IncompleteUploadInfo{
+			"bot-logs": {
+				{Key: "logs/bot-a/x.log", UploadID: "stale", Initiated: justStale},
+				{Key: "logs/bot-a/x.log", UploadID: "fresh", Initiated: justFresh},
+			},
+		},
+	}
+	store := &mockBotStore{existingIDs: map[string]bool{"bot-a": true}}
+
+	gc := NewGarbageCollector(GarbageCollectorOptions{MinIO: minio, Store: store, LogsBucket: "bot-logs", StateBucket: "bot-state"})
+	result, err := gc.Run(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.AbortedMultipartUploads)
+	assert.Contains(t, minio.aborted, "bot-logs:logs/bot-a/x.log:stale")
+	assert.NotContains(t, minio.aborted, "bot-logs:logs/bot-a/x.log:fresh")
 }
 
 func TestGC_StaleTempFilesListError(t *testing.T) {

--- a/runtime/internal/gc/minio_adapter.go
+++ b/runtime/internal/gc/minio_adapter.go
@@ -50,3 +50,23 @@ func (m *minioAdapter) ListObjectsWithInfo(ctx context.Context, bucket, prefix s
 func (m *minioAdapter) RemoveObject(ctx context.Context, bucket, name string) error {
 	return m.client.RemoveObject(ctx, bucket, name, minio.RemoveObjectOptions{})
 }
+
+func (m *minioAdapter) ListIncompleteUploads(ctx context.Context, bucket, prefix string) ([]IncompleteUploadInfo, error) {
+	var uploads []IncompleteUploadInfo
+	for u := range m.client.ListIncompleteUploads(ctx, bucket, prefix, true) {
+		if u.Err != nil {
+			return nil, u.Err
+		}
+		uploads = append(uploads, IncompleteUploadInfo{
+			Key:       u.Key,
+			UploadID:  u.UploadID,
+			Initiated: u.Initiated,
+		})
+	}
+	return uploads, nil
+}
+
+func (m *minioAdapter) AbortIncompleteUpload(ctx context.Context, bucket, key, uploadID string) error {
+	core := minio.Core{Client: m.client}
+	return core.AbortMultipartUpload(ctx, bucket, key, uploadID)
+}

--- a/runtime/internal/minio-logger/minio_logger.go
+++ b/runtime/internal/minio-logger/minio_logger.go
@@ -21,8 +21,43 @@ type MinIOLogger interface {
 	Close() error
 }
 
+// multipartClient is the subset of minio.Core the compose-append path needs.
+// Extracted so the abort-on-error contract in AppendBotLogs can be unit-tested
+// with a fake that triggers failures at each step of the multipart flow.
+type multipartClient interface {
+	NewMultipartUpload(ctx context.Context, bucket, object string, opts minio.PutObjectOptions) (string, error)
+	CopyObjectPart(ctx context.Context, srcBucket, srcObject, destBucket, destObject, uploadID string,
+		partID int, startOffset, length int64, metadata map[string]string) (minio.CompletePart, error)
+	CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, parts []minio.CompletePart, opts minio.PutObjectOptions) (minio.UploadInfo, error)
+	AbortMultipartUpload(ctx context.Context, bucket, object, uploadID string) error
+}
+
+// coreMultipartClient adapts minio.Core to the multipartClient interface.
+type coreMultipartClient struct {
+	core minio.Core
+}
+
+func (c coreMultipartClient) NewMultipartUpload(ctx context.Context, bucket, object string, opts minio.PutObjectOptions) (string, error) {
+	return c.core.NewMultipartUpload(ctx, bucket, object, opts)
+}
+
+func (c coreMultipartClient) CopyObjectPart(ctx context.Context, srcBucket, srcObject, destBucket, destObject, uploadID string,
+	partID int, startOffset, length int64, metadata map[string]string,
+) (minio.CompletePart, error) {
+	return c.core.CopyObjectPart(ctx, srcBucket, srcObject, destBucket, destObject, uploadID, partID, startOffset, length, metadata)
+}
+
+func (c coreMultipartClient) CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, parts []minio.CompletePart, opts minio.PutObjectOptions) (minio.UploadInfo, error) {
+	return c.core.CompleteMultipartUpload(ctx, bucket, object, uploadID, parts, opts)
+}
+
+func (c coreMultipartClient) AbortMultipartUpload(ctx context.Context, bucket, object, uploadID string) error {
+	return c.core.AbortMultipartUpload(ctx, bucket, object, uploadID)
+}
+
 type minIOLogger struct {
 	client        *minio.Client
+	mpClient      multipartClient
 	logsBucket    string
 	resultsBucket string
 	mutexes       map[string]*sync.Mutex // Per-bot mutexes to prevent concurrent writes
@@ -115,6 +150,7 @@ func NewMinIOLogger(
 
 	return &minIOLogger{
 		client:        client,
+		mpClient:      coreMultipartClient{core: minio.Core{Client: client}},
 		logsBucket:    options.LogsBucket,
 		resultsBucket: options.ResultsBucket,
 		mutexes:       make(map[string]*sync.Mutex),
@@ -221,17 +257,15 @@ func (m *minIOLogger) AppendBotLogs(ctx context.Context, id string, logs string)
 	// Daily file exists. Choose the append strategy based on its size.
 	if info.Size >= composeMinPartSize {
 		// The existing file is large enough (>= 5 MiB) for a server-side
-		// ComposeObject. Each sync stays O(chunk_size) instead of degrading
-		// to O(file_size) as the daily log grows throughout the day.
-		m.logger.Debug("Using ComposeObject for append", "existingSize", info.Size)
-		dst := minio.CopyDestOptions{Bucket: m.logsBucket, Object: dailyKey}
-		srcs := []minio.CopySrcOptions{
-			{Bucket: m.logsBucket, Object: dailyKey},
-			{Bucket: m.logsBucket, Object: tmpKey},
-		}
-		_, err = m.client.ComposeObject(ctx, dst, srcs...)
-		if err != nil {
-			return fmt.Errorf("compose daily log: %w", err)
+		// multipart copy. We drive the flow ourselves via minio.Core so
+		// that on ANY error (caller ctx cancelled, network flake, R2 tail
+		// latency, simulated failure in tests) we guarantee an abort on
+		// the upload ID. minio-go's high-level ComposeObject leaks the
+		// upload ID on error, which is the root cause of the bot-logs
+		// orphaned multipart uploads this path exists to fix.
+		m.logger.Debug("Using multipart-copy for append", "existingSize", info.Size)
+		if err := m.composeAppendMultipart(ctx, dailyKey, tmpKey); err != nil {
+			return err
 		}
 	} else {
 		// The existing file is smaller than the 5 MiB compose threshold.
@@ -262,6 +296,65 @@ func (m *minIOLogger) AppendBotLogs(ctx context.Context, id string, logs string)
 	}
 
 	m.logger.Debug("Successfully appended logs to MinIO", "path", dailyKey)
+	return nil
+}
+
+// composeAppendMultipartAbortTimeout is the per-abort budget used when the
+// caller's context is already cancelled. We always issue the abort with a
+// fresh background context so cleanup reaches R2 even after the caller's
+// deadline has fired.
+const composeAppendMultipartAbortTimeout = 30 * time.Second
+
+// composeAppendMultipart performs a server-side multipart copy that
+// concatenates the existing daily log and the newly-uploaded temp chunk
+// back into the daily key. We own the upload ID and defer an abort that
+// fires whenever the flow did not reach a successful CompleteMultipartUpload.
+// The abort runs on a fresh context so a cancelled caller context does not
+// prevent the cleanup from reaching R2.
+//
+// Safe to abort on this key because AppendBotLogs holds a per-bot mutex:
+// no other goroutine can have an in-flight multipart upload for dailyKey
+// when this function is running.
+func (m *minIOLogger) composeAppendMultipart(ctx context.Context, dailyKey, tmpKey string) error {
+	uploadID, err := m.mpClient.NewMultipartUpload(ctx, m.logsBucket, dailyKey, minio.PutObjectOptions{
+		ContentType: "text/plain",
+	})
+	if err != nil {
+		return fmt.Errorf("init multipart upload: %w", err)
+	}
+
+	done := false
+	defer func() {
+		if done {
+			return
+		}
+		abortCtx, cancel := context.WithTimeout(context.Background(), composeAppendMultipartAbortTimeout)
+		defer cancel()
+		if abortErr := m.mpClient.AbortMultipartUpload(abortCtx, m.logsBucket, dailyKey, uploadID); abortErr != nil {
+			m.logger.Warn("Failed to abort multipart upload after compose error",
+				"key", dailyKey, "uploadID", uploadID, "error", abortErr)
+		}
+	}()
+
+	// Part 1: the existing daily log. length = -1 copies the whole source.
+	// The daily file is guaranteed >= 5 MiB here (caller checks composeMinPartSize).
+	part1, err := m.mpClient.CopyObjectPart(ctx, m.logsBucket, dailyKey, m.logsBucket, dailyKey, uploadID, 1, 0, -1, nil)
+	if err != nil {
+		return fmt.Errorf("copy daily part: %w", err)
+	}
+
+	// Part 2: the new temp chunk. This is the LAST part so it may be < 5 MiB.
+	part2, err := m.mpClient.CopyObjectPart(ctx, m.logsBucket, tmpKey, m.logsBucket, dailyKey, uploadID, 2, 0, -1, nil)
+	if err != nil {
+		return fmt.Errorf("copy temp part: %w", err)
+	}
+
+	if _, err := m.mpClient.CompleteMultipartUpload(ctx, m.logsBucket, dailyKey, uploadID,
+		[]minio.CompletePart{part1, part2}, minio.PutObjectOptions{}); err != nil {
+		return fmt.Errorf("complete multipart upload: %w", err)
+	}
+
+	done = true
 	return nil
 }
 

--- a/runtime/internal/minio-logger/minio_logger_test.go
+++ b/runtime/internal/minio-logger/minio_logger_test.go
@@ -1,6 +1,7 @@
 package miniologger
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -597,6 +598,212 @@ func TestComposeAppendFirstWrite(t *testing.T) {
 
 	assert.Contains(t, string(content), "hello world")
 	assert.Contains(t, string(content), time.Now().Format("2006-01-02"))
+}
+
+// fakeMultipartClient is a controllable implementation of multipartClient.
+// It records every call and can be programmed to return errors at specific
+// steps so we can deterministically exercise the abort-on-error contract.
+type fakeMultipartClient struct {
+	mu sync.Mutex
+
+	// Programmed errors. If set, the matching method returns that error.
+	newErr      error
+	copyErr     error // returned on every CopyObjectPart call unless copyErrPartID > 0
+	copyErrPart int   // if > 0, only the CopyObjectPart call with this partID errors
+	completeErr error
+	abortErr    error
+
+	// Call records.
+	uploadIDs    []string // uploadIDs handed out
+	copyCalls    []fakeCopyCall
+	completedIDs []string
+	abortedIDs   []string
+}
+
+type fakeCopyCall struct {
+	srcBucket, srcObject     string
+	destBucket, destObject   string
+	uploadID                 string
+	partID                   int
+	startOffset, length      int64
+}
+
+func (f *fakeMultipartClient) NewMultipartUpload(ctx context.Context, bucket, object string, opts minio.PutObjectOptions) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.newErr != nil {
+		return "", f.newErr
+	}
+	id := fmt.Sprintf("fake-upload-%d", len(f.uploadIDs)+1)
+	f.uploadIDs = append(f.uploadIDs, id)
+	return id, nil
+}
+
+func (f *fakeMultipartClient) CopyObjectPart(ctx context.Context, srcBucket, srcObject, destBucket, destObject, uploadID string,
+	partID int, startOffset, length int64, metadata map[string]string,
+) (minio.CompletePart, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.copyCalls = append(f.copyCalls, fakeCopyCall{
+		srcBucket: srcBucket, srcObject: srcObject,
+		destBucket: destBucket, destObject: destObject,
+		uploadID: uploadID, partID: partID,
+		startOffset: startOffset, length: length,
+	})
+	if f.copyErr != nil && (f.copyErrPart == 0 || f.copyErrPart == partID) {
+		return minio.CompletePart{}, f.copyErr
+	}
+	return minio.CompletePart{PartNumber: partID, ETag: fmt.Sprintf("etag-%d", partID)}, nil
+}
+
+func (f *fakeMultipartClient) CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, parts []minio.CompletePart, opts minio.PutObjectOptions) (minio.UploadInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.completeErr != nil {
+		return minio.UploadInfo{}, f.completeErr
+	}
+	f.completedIDs = append(f.completedIDs, uploadID)
+	return minio.UploadInfo{Bucket: bucket, Key: object}, nil
+}
+
+func (f *fakeMultipartClient) AbortMultipartUpload(ctx context.Context, bucket, object, uploadID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.abortErr != nil {
+		return f.abortErr
+	}
+	f.abortedIDs = append(f.abortedIDs, uploadID)
+	return nil
+}
+
+// primeDailyLog puts an object at the daily key for a bot using the real
+// MinIO client, so the subsequent AppendBotLogs call sees a file >= the
+// compose threshold and takes the multipart-copy branch.
+func primeDailyLog(t *testing.T, client *minio.Client, bucket, botID string, size int) {
+	t.Helper()
+	payload := make([]byte, size)
+	for i := range payload {
+		payload[i] = 'x'
+	}
+	dailyKey := fmt.Sprintf("logs/%s/%s.log", botID, time.Now().Format("20060102"))
+	_, err := client.PutObject(context.Background(), bucket, dailyKey, bytes.NewReader(payload), int64(len(payload)), minio.PutObjectOptions{ContentType: "text/plain"})
+	require.NoError(t, err)
+}
+
+func TestAppendBotLogs_AbortsOnCompleteMultipartError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	container, endpoint, accessKey, secretKey := setupMinIOTestContainer(t)
+	defer container.Terminate(context.Background())
+
+	logger, err := NewMinIOLogger(context.Background(), MinioLoggerOptions{
+		Endpoint:      endpoint,
+		AccessKey:     accessKey,
+		SecretKey:     secretKey,
+		UseSSL:        false,
+		LogsBucket:    "test-abort-complete",
+		ResultsBucket: "test-abort-complete-results",
+	})
+	require.NoError(t, err)
+	defer logger.Close()
+
+	// Seed an 8 MiB daily log so the next append takes the compose branch.
+	botID := "abort-complete-bot"
+	primeDailyLog(t, logger.client, "test-abort-complete", botID, 8*1024*1024)
+
+	// Swap in a fake multipart client programmed to fail on complete.
+	fake := &fakeMultipartClient{completeErr: fmt.Errorf("simulated r2 complete failure")}
+	logger.mpClient = fake
+
+	err = logger.AppendBotLogs(context.Background(), botID, "new chunk")
+	require.Error(t, err, "AppendBotLogs should surface the compose failure")
+	assert.Contains(t, err.Error(), "simulated r2 complete failure")
+
+	// Contract: on failure, the multipart upload must have been aborted.
+	require.Len(t, fake.uploadIDs, 1, "exactly one multipart upload should have been created")
+	assert.Equal(t, fake.uploadIDs, fake.abortedIDs, "the created upload must be aborted")
+	assert.Empty(t, fake.completedIDs, "no upload should be marked complete on failure")
+}
+
+func TestAppendBotLogs_AbortsOnCopyPartError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	container, endpoint, accessKey, secretKey := setupMinIOTestContainer(t)
+	defer container.Terminate(context.Background())
+
+	logger, err := NewMinIOLogger(context.Background(), MinioLoggerOptions{
+		Endpoint:      endpoint,
+		AccessKey:     accessKey,
+		SecretKey:     secretKey,
+		UseSSL:        false,
+		LogsBucket:    "test-abort-copy",
+		ResultsBucket: "test-abort-copy-results",
+	})
+	require.NoError(t, err)
+	defer logger.Close()
+
+	botID := "abort-copy-bot"
+	primeDailyLog(t, logger.client, "test-abort-copy", botID, 8*1024*1024)
+
+	fake := &fakeMultipartClient{copyErr: fmt.Errorf("simulated uploadpartcopy failure"), copyErrPart: 2}
+	logger.mpClient = fake
+
+	err = logger.AppendBotLogs(context.Background(), botID, "new chunk")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "simulated uploadpartcopy failure")
+
+	require.Len(t, fake.uploadIDs, 1)
+	assert.Equal(t, fake.uploadIDs, fake.abortedIDs, "uploadPartCopy failure must still abort")
+}
+
+func TestAppendBotLogs_NoLeakedUploadsOnHappyCompose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	container, endpoint, accessKey, secretKey := setupMinIOTestContainer(t)
+	defer container.Terminate(context.Background())
+
+	logger, err := NewMinIOLogger(context.Background(), MinioLoggerOptions{
+		Endpoint:      endpoint,
+		AccessKey:     accessKey,
+		SecretKey:     secretKey,
+		UseSSL:        false,
+		LogsBucket:    "test-happy-compose",
+		ResultsBucket: "test-happy-compose-results",
+	})
+	require.NoError(t, err)
+	defer logger.Close()
+
+	botID := "happy-compose-bot"
+
+	// Drive 10 appends each larger than the 5 MiB threshold so every call
+	// after the first exercises the multipart-copy path on the real MinIO.
+	chunk := make([]byte, 6*1024*1024)
+	for i := range chunk {
+		chunk[i] = 'y'
+	}
+	for i := 0; i < 10; i++ {
+		err := logger.AppendBotLogs(context.Background(), botID, string(chunk))
+		require.NoError(t, err, "append %d failed", i)
+	}
+
+	client, err := minio.New(endpoint, &minio.Options{
+		Creds:  credentials.NewStaticV4(accessKey, secretKey, ""),
+		Secure: false,
+	})
+	require.NoError(t, err)
+
+	// Verify no orphaned incomplete multipart uploads remain.
+	var incomplete int
+	for range client.ListIncompleteUploads(context.Background(), "test-happy-compose", fmt.Sprintf("logs/%s/", botID), true) {
+		incomplete++
+	}
+	assert.Equal(t, 0, incomplete, "happy-path compose must not leave incomplete uploads")
 }
 
 func TestMinIOLoggerInterface(t *testing.T) {

--- a/runtime/internal/runtime/storage/state.go
+++ b/runtime/internal/runtime/storage/state.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/minio/minio-go/v7"
 )
@@ -35,13 +36,23 @@ type StateManager interface {
 	StateExists(ctx context.Context, botID string) (bool, error)
 }
 
+// stateObjectWriter is the narrow subset of minio.Client used by UploadState.
+// Extracted so tests can inject failing stubs and assert the abort-on-error
+// contract. *minio.Client already satisfies this interface.
+type stateObjectWriter interface {
+	PutObject(ctx context.Context, bucket, object string, reader io.Reader, size int64, opts minio.PutObjectOptions) (minio.UploadInfo, error)
+	RemoveIncompleteUpload(ctx context.Context, bucket, object string) error
+}
+
 // stateManager implements StateManager using MinIO as the storage backend.
 type stateManager struct {
 	minioClient      *minio.Client
+	uploader         stateObjectWriter
 	bucket           string
 	maxStateSize     int64
 	maxStateFileSize int64
 	logger           Logger
+	skipEnsureBucket bool // test-only: skip ensureBucket when uploader is a fake
 }
 
 // NewStateManager creates a new StateManager that stores state in MinIO.
@@ -60,6 +71,7 @@ func NewStateManager(minioClient *minio.Client, cfg *Config, logger Logger) Stat
 	}
 	return &stateManager{
 		minioClient:      minioClient,
+		uploader:         minioClient,
 		bucket:           bucket,
 		maxStateSize:     maxStateSize,
 		maxStateFileSize: maxStateFileSize,
@@ -141,8 +153,10 @@ func (m *stateManager) UploadState(ctx context.Context, botID string, srcDir str
 	}
 	m.logger.Info("State size", "bot_id", botID, "bytes", totalSize)
 
-	if err := m.ensureBucket(ctx); err != nil {
-		return err
+	if !m.skipEnsureBucket {
+		if err := m.ensureBucket(ctx); err != nil {
+			return err
+		}
 	}
 
 	pr, pw := io.Pipe()
@@ -153,10 +167,27 @@ func (m *stateManager) UploadState(ctx context.Context, botID string, srcDir str
 		errChan <- m.createTarGz(srcDir, pw)
 	}()
 
-	_, err = m.minioClient.PutObject(ctx, m.bucket, m.objectName(botID), pr, -1, minio.PutObjectOptions{
+	objectName := m.objectName(botID)
+	_, err = m.uploader.PutObject(ctx, m.bucket, objectName, pr, -1, minio.PutObjectOptions{
 		ContentType: "application/gzip",
 	})
 	if err != nil {
+		// Unblock the tar.gz goroutine if it is still writing into the pipe.
+		_ = pr.CloseWithError(err)
+
+		// minio-go's streaming-multipart path calls abortMultipartUpload in
+		// a defer, but it passes the caller's ctx which is typically already
+		// cancelled by the time we reach this error. That leaks the upload
+		// ID on R2. We issue our own abort on a fresh background context to
+		// guarantee cleanup. Safe because StateSyncer.Sync is serial per bot
+		// so no other goroutine can own an upload for this key.
+		abortCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if rmErr := m.uploader.RemoveIncompleteUpload(abortCtx, m.bucket, objectName); rmErr != nil {
+			m.logger.Info("Failed to abort orphaned state upload",
+				"bot_id", botID, "error", rmErr.Error())
+		}
+
 		return fmt.Errorf("failed to upload state to MinIO: %w", err)
 	}
 

--- a/runtime/internal/runtime/storage/state_test.go
+++ b/runtime/internal/runtime/storage/state_test.go
@@ -4,11 +4,15 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
+	"github.com/minio/minio-go/v7"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -194,4 +198,132 @@ func TestUploadState_NonExistentDir(t *testing.T) {
 	// Verify it doesn't exist
 	_, err := os.ReadDir(nonExistentDir)
 	assert.True(t, os.IsNotExist(err))
+}
+
+// fakeStateObjectWriter is a controllable stand-in for the upload subset of
+// minio.Client that state.go uses. Lets us deterministically fail an upload
+// mid-stream and assert that the abort path ran with the right args.
+type fakeStateObjectWriter struct {
+	mu sync.Mutex
+
+	putErr    error
+	removeErr error
+
+	putCalls    []fakePutCall
+	removeCalls []fakeRemoveCall
+}
+
+type fakePutCall struct {
+	bucket, object string
+}
+
+type fakeRemoveCall struct {
+	bucket, object string
+	ctxDone        bool
+}
+
+func (f *fakeStateObjectWriter) PutObject(ctx context.Context, bucket, object string, reader io.Reader, size int64, opts minio.PutObjectOptions) (minio.UploadInfo, error) {
+	// Drain the reader so the background tar.gz goroutine can exit cleanly;
+	// otherwise it blocks forever writing into a dead pipe.
+	_, _ = io.Copy(io.Discard, reader)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.putCalls = append(f.putCalls, fakePutCall{bucket: bucket, object: object})
+	if f.putErr != nil {
+		return minio.UploadInfo{}, f.putErr
+	}
+	return minio.UploadInfo{Bucket: bucket, Key: object}, nil
+}
+
+func (f *fakeStateObjectWriter) RemoveIncompleteUpload(ctx context.Context, bucket, object string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	done := false
+	select {
+	case <-ctx.Done():
+		done = true
+	default:
+	}
+	f.removeCalls = append(f.removeCalls, fakeRemoveCall{bucket: bucket, object: object, ctxDone: done})
+	return f.removeErr
+}
+
+// writeSimpleStateDir creates a directory with two tiny state files that
+// validateStateSize / createTarGz will happily process.
+func writeSimpleStateDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "state-abort-")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "portfolio.json"), []byte(`{"AAPL":100}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "counters.json"), []byte(`{"trades":42}`), 0644))
+	return dir
+}
+
+func TestUploadState_AbortsIncompleteUploadOnPutError(t *testing.T) {
+	fake := &fakeStateObjectWriter{putErr: fmt.Errorf("simulated put failure")}
+	mgr := &stateManager{
+		minioClient:      nil, // ensureBucket path is bypassed via uploader seam
+		uploader:         fake,
+		bucket:           "bot-state",
+		maxStateSize:     8 * 1024 * 1024 * 1024,
+		maxStateFileSize: 10 * 1024 * 1024,
+		logger:           &testLogger{},
+		skipEnsureBucket: true,
+	}
+
+	srcDir := writeSimpleStateDir(t)
+
+	err := mgr.UploadState(context.Background(), "abort-bot", srcDir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "simulated put failure")
+
+	require.Len(t, fake.putCalls, 1, "put should have been attempted")
+	require.Len(t, fake.removeCalls, 1, "RemoveIncompleteUpload must fire on put error")
+	assert.Equal(t, "bot-state", fake.removeCalls[0].bucket)
+	assert.Equal(t, "abort-bot/state.tar.gz", fake.removeCalls[0].object)
+}
+
+func TestUploadState_AbortUsesFreshContextWhenCallerCancelled(t *testing.T) {
+	fake := &fakeStateObjectWriter{putErr: context.Canceled}
+	mgr := &stateManager{
+		minioClient:      nil,
+		uploader:         fake,
+		bucket:           "bot-state",
+		maxStateSize:     8 * 1024 * 1024 * 1024,
+		maxStateFileSize: 10 * 1024 * 1024,
+		logger:           &testLogger{},
+		skipEnsureBucket: true,
+	}
+
+	srcDir := writeSimpleStateDir(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := mgr.UploadState(ctx, "abort-ctx-bot", srcDir)
+	require.Error(t, err)
+
+	require.Len(t, fake.removeCalls, 1, "abort must run even though caller ctx is cancelled")
+	assert.False(t, fake.removeCalls[0].ctxDone, "abort must run on a fresh, non-cancelled context")
+}
+
+func TestUploadState_HappyPathDoesNotAbort(t *testing.T) {
+	fake := &fakeStateObjectWriter{}
+	mgr := &stateManager{
+		minioClient:      nil,
+		uploader:         fake,
+		bucket:           "bot-state",
+		maxStateSize:     8 * 1024 * 1024 * 1024,
+		maxStateFileSize: 10 * 1024 * 1024,
+		logger:           &testLogger{},
+		skipEnsureBucket: true,
+	}
+
+	srcDir := writeSimpleStateDir(t)
+	err := mgr.UploadState(context.Background(), "ok-bot", srcDir)
+	require.NoError(t, err)
+
+	assert.Len(t, fake.putCalls, 1)
+	assert.Empty(t, fake.removeCalls, "no abort should run on success")
 }


### PR DESCRIPTION
## Summary

Release cut covering console/dashboard polish, an API-side log sort refactor, and a runtime fix for leaking R2 multipart uploads. Helm chart bumped to **0.8.0 / appVersion 1.13.0**.

### Console & dashboard

- **Configurable refresh interval** - 10s / 30s / 60s / Off selector. Hidden for realtime bots in Live mode. (#256)
- **Load more pagination** for realtime bots on non-live intervals. `hasMore` / `loadMore` exposed from the stream hook in REST date-range mode. (#258, #260)
- **Default interval 1h** for scheduled bots (was 1d - loaded too many metrics). (#255)
- **Timestamp preserved in log expansion** - shared `expandLogEntries` extracted to `lib/log-utils.ts`. (#254)
- **Console refresh loop fixed** - polling uses a ref for latest `fetchLogs` so there is no stale closure. (#257)
- **Scroll jolt + SSE reconnection fixes** on load more, plus CodeRabbit auto-fixes. (#260)
- Pagination hardening: prepend/append merge direction, duplicate `loadMore` guard via `loadingMoreRef`, offset only advances on success, `setHasMore` skipped on prepend, `refreshInterval` lifecycle deps, and `setInterval` guarded with `> 0` so Off mode doesn't create zero-delay timers.

### API: log sort refactor (#261)

- Added `sort=asc|desc` param to the logs endpoint (default `desc` / newest-first).
- Capped desc stream reads to prevent memory exhaustion.
- Frontend removes the in-memory reversal and scroll gymnastics - the API owns sort order now. `followOutput` simplified to `connected && sort === "asc"`.

### Runtime: R2 multipart upload leak fix (#262)

- **Root cause fix for ~70 GB of phantom storage on `bot-logs` and ~8,000 orphaned multipart uploads on `bot-state`.** Two upload paths were leaking incomplete multipart uploads whenever their sync context expired mid-operation, because neither path guaranteed an abort on a fresh context.
- `AppendBotLogs`: replaced `minio.Client.ComposeObject` (which has no abort-on-error) with an owned multipart-copy flow via `minio.Core`. A deferred abort runs on a fresh background context so caller cancellation cannot prevent cleanup. Safe because the per-bot mutex serializes writes to the same daily key.
- `UploadState`: wraps `PutObject` (unknown size → multipart streaming) with a fresh-context `RemoveIncompleteUpload` on any error. minio-go's internal defer abort was using the already-cancelled caller context and failing silently.
- GC safety net: new `ListIncompleteUploads` + `AbortIncompleteUpload` on the `MinIOClient` interface; `cleanupStaleIncompleteUploads` sweep runs on both logs and state buckets each GC cycle, filtering by a 1h `staleIncompleteUploadAge` so no in-flight upload can be touched.
- Bumped per-sync upload timeouts via injectable functional options: logs `30s → 120s`, state `60s → 180s`. R2 tail latency was shredding legitimate uploads at the old values.
- Live cleanup of existing orphans was done pre-deploy: 1,558 aborted on `bot-logs` and 7,961 aborted on `bot-state`, so the billing baseline is already clean.

## Test plan

- [x] API: `cd api && yarn test --no-coverage` - 501 pass
- [x] Frontend: `cd frontend && yarn test --no-coverage && yarn build` - 598 pass
- [x] Runtime: `go test ./...` - full repo suite green (gc, minio-logger, runtime/storage, daemon)
- [x] Scheduled bot: load more on 7d grows console count; sort toggle switches between newest/oldest first
- [x] Realtime bot: Live SSE stays connected, sort toggle works on date ranges
- [x] No scroll jolt on load more or interval changes
- [ ] Post-deploy smoke: confirm `aws s3api list-multipart-uploads` on both `bot-logs` and `bot-state` stays at zero for 24h; verify `nssuhlwv2mw2cihrnnxpbqxx` daily log keeps growing through the day without gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
