### PR TITLE
fix: bump final sync timeout from 30s to 3m

### DIFF
--- a/runtime/internal/daemon/logs_syncer.go
+++ b/runtime/internal/daemon/logs_syncer.go
@@ -59,6 +59,11 @@ func NewLogsSyncer(botID, logsPath string, logUploader miniologger.MinIOLogger, 
 	return l
 }
 
+// FinalSyncTimeout returns the context deadline for the shutdown final sync.
+func (l *LogsSyncer) FinalSyncTimeout() time.Duration {
+	return l.uploadTimeout
+}
+
 // Sync reads new log content from the bot's log file and uploads it to MinIO
 // in bounded chunks. It drains all available content (up to the file size at
 // call time) so large bursts are fully caught up in a single Sync call.

--- a/runtime/internal/daemon/state_syncer.go
+++ b/runtime/internal/daemon/state_syncer.go
@@ -52,6 +52,11 @@ func NewStateSyncer(botID, statePath string, stateManager storage.StateManager, 
 	return s
 }
 
+// FinalSyncTimeout returns the context deadline for the shutdown final sync.
+func (s *StateSyncer) FinalSyncTimeout() time.Duration {
+	return s.uploadTimeout
+}
+
 // Sync checks for state changes and uploads if changed.
 // Returns true if state was synced, false otherwise.
 func (s *StateSyncer) Sync(ctx context.Context) bool {

--- a/runtime/internal/daemon/sync.go
+++ b/runtime/internal/daemon/sync.go
@@ -202,8 +202,12 @@ func (r *SyncRunner) run() {
 			r.DoSync()
 		case <-r.ctx.Done():
 			r.logger.Info("Sync runner stopping, performing final sync")
-			// Use fresh context for final sync since r.ctx is canceled
-			finalCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			// Use fresh context for final sync since r.ctx is canceled.
+			// Must be >= the per-chunk upload timeout (120s for logs, 180s
+			// for state) otherwise the parent deadline overrides the child
+			// and the compose path still times out at 30s, leaking multipart
+			// uploads on R2.
+			finalCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			r.doSyncWithContext(finalCtx)
 			cancel()
 			if r.cleanup != nil {

--- a/runtime/internal/daemon/sync.go
+++ b/runtime/internal/daemon/sync.go
@@ -20,6 +20,11 @@ import (
 // Syncer defines the interface for sync components.
 type Syncer interface {
 	Sync(ctx context.Context) bool
+	// FinalSyncTimeout returns the context deadline to use for the final
+	// sync on shutdown. Each syncer knows its own upload timeout; the
+	// shutdown path creates a fresh per-syncer context so serialized
+	// syncers don't starve each other from a shared parent deadline.
+	FinalSyncTimeout() time.Duration
 }
 
 // SyncOptions configures the sync command.
@@ -202,14 +207,16 @@ func (r *SyncRunner) run() {
 			r.DoSync()
 		case <-r.ctx.Done():
 			r.logger.Info("Sync runner stopping, performing final sync")
-			// Use fresh context for final sync since r.ctx is canceled.
-			// Must be >= the per-chunk upload timeout (120s for logs, 180s
-			// for state) otherwise the parent deadline overrides the child
-			// and the compose path still times out at 30s, leaking multipart
-			// uploads on R2.
-			finalCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
-			r.doSyncWithContext(finalCtx)
-			cancel()
+			// Each syncer gets its own fresh context sized to its upload
+			// timeout. This prevents serialized syncers from starving each
+			// other via a shared parent deadline.
+			r.syncMu.Lock()
+			for _, syncer := range r.syncers {
+				ctx, cancel := context.WithTimeout(context.Background(), syncer.FinalSyncTimeout())
+				syncer.Sync(ctx)
+				cancel()
+			}
+			r.syncMu.Unlock()
 			if r.cleanup != nil {
 				r.cleanup()
 			}

--- a/runtime/internal/daemon/sync_runner_test.go
+++ b/runtime/internal/daemon/sync_runner_test.go
@@ -95,6 +95,10 @@ func (m *mockSyncerImpl) Sync(ctx context.Context) bool {
 	return true
 }
 
+func (m *mockSyncerImpl) FinalSyncTimeout() time.Duration {
+	return 120 * time.Second
+}
+
 func TestSyncRunner_DoSync_CallsSyncers(t *testing.T) {
 	runner := NewSyncRunner(SyncOptions{
 		BotID: "test-bot",
@@ -272,4 +276,8 @@ func (s *contextTrackingSyncer) Sync(ctx context.Context) bool {
 		s.onSync(ctx)
 	}
 	return true
+}
+
+func (s *contextTrackingSyncer) FinalSyncTimeout() time.Duration {
+	return 120 * time.Second
 }


### PR DESCRIPTION
## Summary

- One-line fix: the final sync on pod shutdown was hardcoded to a 30s context at `sync.go:206`, which overrode the 120s/180s per-chunk upload timeouts we added in #262 (Go's `context.WithTimeout` takes the tighter parent deadline).
- This caused the compose-append path for `nssuhlwv2mw2cihrnnxpbqxx`'s large daily logs to still hit context cancellation during the final sync, leaking ~1 multipart upload/day on R2 despite the abort-on-error fix.
- Bumped to 3 minutes (180s), which covers the longest upload timeout (state: 180s) with no slack wasted.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/daemon/...` pass
- [ ] Post-deploy: `aws s3api list-multipart-uploads` on bot-logs stays at zero for 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended timeout duration for final synchronization operations from 30 seconds to 3 minutes, allowing more time for completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->