### PR TITLE
Release v1.13.1

### DIFF
--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: the0
 description: An open-source algorithmic trading platform for creating, deploying, and managing trading bots
 type: application
-version: 0.8.0
-appVersion: "1.13.0"
+version: 0.8.1
+appVersion: "1.13.1"
 kubeVersion: ">=1.21.0-0"
 keywords:
   - trading
@@ -30,18 +30,8 @@ annotations:
     - name: Discord
       url: https://discord.gg/g5mp57nK
   artifacthub.io/changes: |
-    - kind: added
-      description: Configurable refresh interval (10s/30s/60s/Off) for console and dashboard
-    - kind: added
-      description: Load more pagination for realtime bots on non-live intervals
     - kind: fixed
-      description: Default interval changed from 1d to 1h for scheduled bots
-    - kind: fixed
-      description: Preserve timestamp field in log expansion (shared expandLogEntries)
-    - kind: fixed
-      description: Prevent console refresh loop on interval change (stale closure fix)
-    - kind: fixed
-      description: Correct prepend/append merge direction for pagination
+      description: Per-syncer final sync timeout to prevent R2 multipart upload leaks on pod shutdown
   artifacthub.io/images: |
     - name: api
       image: ghcr.io/alexanderwanyoike/the0/api

--- a/runtime/internal/daemon/logs_syncer.go
+++ b/runtime/internal/daemon/logs_syncer.go
@@ -59,6 +59,11 @@ func NewLogsSyncer(botID, logsPath string, logUploader miniologger.MinIOLogger, 
 	return l
 }
 
+// FinalSyncTimeout returns the context deadline for the shutdown final sync.
+func (l *LogsSyncer) FinalSyncTimeout() time.Duration {
+	return l.uploadTimeout
+}
+
 // Sync reads new log content from the bot's log file and uploads it to MinIO
 // in bounded chunks. It drains all available content (up to the file size at
 // call time) so large bursts are fully caught up in a single Sync call.

--- a/runtime/internal/daemon/state_syncer.go
+++ b/runtime/internal/daemon/state_syncer.go
@@ -52,6 +52,11 @@ func NewStateSyncer(botID, statePath string, stateManager storage.StateManager, 
 	return s
 }
 
+// FinalSyncTimeout returns the context deadline for the shutdown final sync.
+func (s *StateSyncer) FinalSyncTimeout() time.Duration {
+	return s.uploadTimeout
+}
+
 // Sync checks for state changes and uploads if changed.
 // Returns true if state was synced, false otherwise.
 func (s *StateSyncer) Sync(ctx context.Context) bool {

--- a/runtime/internal/daemon/sync.go
+++ b/runtime/internal/daemon/sync.go
@@ -202,8 +202,12 @@ func (r *SyncRunner) run() {
 			r.DoSync()
 		case <-r.ctx.Done():
 			r.logger.Info("Sync runner stopping, performing final sync")
-			// Use fresh context for final sync since r.ctx is canceled
-			finalCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			// Use fresh context for final sync since r.ctx is canceled.
+			// Must be >= the per-chunk upload timeout (120s for logs, 180s
+			// for state) otherwise the parent deadline overrides the child
+			// and the compose path still times out at 30s, leaking multipart
+			// uploads on R2.
+			finalCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			r.doSyncWithContext(finalCtx)
 			cancel()
 			if r.cleanup != nil {

--- a/runtime/internal/daemon/sync.go
+++ b/runtime/internal/daemon/sync.go
@@ -20,6 +20,11 @@ import (
 // Syncer defines the interface for sync components.
 type Syncer interface {
 	Sync(ctx context.Context) bool
+	// FinalSyncTimeout returns the context deadline to use for the final
+	// sync on shutdown. Each syncer knows its own upload timeout; the
+	// shutdown path creates a fresh per-syncer context so serialized
+	// syncers don't starve each other from a shared parent deadline.
+	FinalSyncTimeout() time.Duration
 }
 
 // SyncOptions configures the sync command.
@@ -202,14 +207,16 @@ func (r *SyncRunner) run() {
 			r.DoSync()
 		case <-r.ctx.Done():
 			r.logger.Info("Sync runner stopping, performing final sync")
-			// Use fresh context for final sync since r.ctx is canceled.
-			// Must be >= the per-chunk upload timeout (120s for logs, 180s
-			// for state) otherwise the parent deadline overrides the child
-			// and the compose path still times out at 30s, leaking multipart
-			// uploads on R2.
-			finalCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
-			r.doSyncWithContext(finalCtx)
-			cancel()
+			// Each syncer gets its own fresh context sized to its upload
+			// timeout. This prevents serialized syncers from starving each
+			// other via a shared parent deadline.
+			r.syncMu.Lock()
+			for _, syncer := range r.syncers {
+				ctx, cancel := context.WithTimeout(context.Background(), syncer.FinalSyncTimeout())
+				syncer.Sync(ctx)
+				cancel()
+			}
+			r.syncMu.Unlock()
 			if r.cleanup != nil {
 				r.cleanup()
 			}

--- a/runtime/internal/daemon/sync_runner_test.go
+++ b/runtime/internal/daemon/sync_runner_test.go
@@ -95,6 +95,10 @@ func (m *mockSyncerImpl) Sync(ctx context.Context) bool {
 	return true
 }
 
+func (m *mockSyncerImpl) FinalSyncTimeout() time.Duration {
+	return 120 * time.Second
+}
+
 func TestSyncRunner_DoSync_CallsSyncers(t *testing.T) {
 	runner := NewSyncRunner(SyncOptions{
 		BotID: "test-bot",
@@ -272,4 +276,8 @@ func (s *contextTrackingSyncer) Sync(ctx context.Context) bool {
 		s.onSync(ctx)
 	}
 	return true
+}
+
+func (s *contextTrackingSyncer) FinalSyncTimeout() time.Duration {
+	return 120 * time.Second
 }


### PR DESCRIPTION
## Summary

Patch release following up on v1.13.0's R2 multipart upload leak fix. During post-deploy monitoring we saw ~1 orphan/day still creeping in on `bot-logs`, traced to the final sync on pod shutdown using a hardcoded 30s context that overrode the per-chunk 120s/180s upload timeouts (Go takes the tighter parent deadline).

Fix (#263):
- Added `FinalSyncTimeout() time.Duration` to the `Syncer` interface.
- `LogsSyncer` returns its `uploadTimeout` (default 120s), `StateSyncer` returns its `uploadTimeout` (default 180s).
- Shutdown path creates a fresh per-syncer context so each syncer gets its full budget regardless of how long the previous one took. No more shared parent deadline starving serialized syncers.

Chart bumped to **0.8.1 / appVersion 1.13.1**.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` full suite green
- [ ] Post-deploy: `aws s3api list-multipart-uploads --bucket bot-logs` stays at zero for 24h with no new orphans from scheduled bot shutdowns

🤖 Generated with [Claude Code](https://claude.com/claude-code)