### PR TITLE
Release v1.13.2

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -21,27 +21,26 @@ Download the latest binary from the [releases page](https://github.com/the0platf
 
 ### API Endpoint Setup
 
-The CLI needs to connect to the0 API server. Set the API URL based on your deployment:
+The CLI connects to an API server via named environments. Each environment stores its own URL and API key, so you can switch between local dev and a remote cluster without juggling env vars or clobbering credentials.
 
 **For Docker Compose deployment:**
 ```bash
-export THE0_API_URL=http://localhost:3000
+the0 env add local --url http://localhost:3000
 ```
 
 **For Kubernetes deployment:**
 ```bash
-export THE0_API_URL=http://api.the0.local:3000
+the0 env add cluster --url http://api.the0.local:3000
 ```
+
+Switch the active environment with `the0 env use <name>`, or override a single command with `--env <name>`. See [Environments](#-environment-commands) below.
 
 ## Quick Start
 
-1. **Set up your API endpoint and authenticate:**
+1. **Add an environment and authenticate:**
    ```bash
-   # Set API endpoint (if using local deployment)
-   export THE0_API_URL=http://localhost:3000
-   
-   # Authenticate
-   the0 auth login
+   the0 env add local --url http://localhost:3000
+   # You will be prompted for the API key and it will be validated before saving.
    ```
 
 2. **Deploy a bot instance:**
@@ -72,9 +71,21 @@ export THE0_API_URL=http://api.the0.local:3000
 Manage your API credentials and authentication status.
 
 ```bash
-the0 auth login          # Set or update API key
-the0 auth status         # Check API key validity  
+the0 auth login          # Set or update API key for the active environment
+the0 auth status         # Check API key validity
 the0 auth logout         # Remove saved API key
+```
+
+### 🌐 Environment Commands
+Manage named API environments (local, prod, ...). Each stores its own URL and API key.
+
+```bash
+the0 env add <name> --url <url> [--api-key <key>]   # key validated before save
+the0 env use <name>                                  # switch active environment
+the0 env list                                        # show all; active marked with *
+the0 env remove <name>                               # delete an environment
+the0 env current                                     # show active env + URL
+the0 <any-command> --env <name>                      # one-off override
 ```
 
 **Examples:**
@@ -430,7 +441,7 @@ the0 self-update --force --yes
 ## Configuration
 
 ### Environment Variables
-- `THE0_API_URL` - Override API base URL (default: `https://api.the0.app`)
+- `THE0_API_URL` - **Deprecated legacy fallback** for API base URL. Use `the0 env` instead. Only honoured when no named environments are defined.
 - `THE0_CLI_UPDATE_CHANNEL` - Set update channel (`production` or `staging`, default: `production`)
 - `THE0_QUIET` - Suppress startup update notifications when set to any value
 

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -19,7 +19,6 @@ func NewAuthCmd() *cobra.Command {
 	cmd.AddCommand(NewLoginCmd())
 	cmd.AddCommand(NewStatusCmd())
 	cmd.AddCommand(NewLogoutCmd())
-	cmd.AddCommand(NewConfigCmd())
 	cmd.AddCommand(NewSecretsCmd())
 	return cmd
 }
@@ -49,24 +48,6 @@ func NewLogoutCmd() *cobra.Command {
 		Long:  "Clear your saved credentials from this device",
 		Run:   authLogout,
 	}
-}
-
-func NewConfigCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "config [api-url]",
-		Short: "Configure API endpoint",
-		Long: `Configure the API endpoint for the0 CLI.
-
-If no URL is provided, shows the current API endpoint.
-The API URL can also be set via THE0_API_URL environment variable.
-
-Examples:
-  the0 auth config                           # Show current API URL
-  the0 auth config http://localhost:3001     # Set API URL to localhost
-  the0 auth config http://the0-api:3001      # Set API URL to Docker service`,
-		Run: authConfig,
-	}
-	return cmd
 }
 
 func authLogin(cmd *cobra.Command, args []string) {
@@ -128,42 +109,6 @@ func authLogout(cmd *cobra.Command, args []string) {
 		logger.Success("Logged out successfully")
 		logger.Verbose("Credentials removed from ~/.the0/auth.json")
 	}
-}
-
-func authConfig(cmd *cobra.Command, args []string) {
-	if len(args) == 0 {
-		// Show current API URL
-		currentURL := internal.GetAPIBaseURL()
-		envURL := os.Getenv("THE0_API_URL")
-
-		logger.Print("Current API Configuration:")
-		logger.Print("  API URL: %s", currentURL)
-
-		if envURL != "" {
-			logger.Print("  Source: THE0_API_URL environment variable")
-		} else {
-			logger.Print("  Source: Default (http://localhost:3000)")
-		}
-
-		logger.Newline()
-		logger.Print("To change the API URL:")
-		logger.Print("  the0 auth config <new-url>")
-		logger.Print("  export THE0_API_URL=<new-url>")
-		return
-	}
-
-	// Set API URL via environment variable hint
-	newURL := args[0]
-	logger.Print("To set API URL to %s, use one of these methods:", newURL)
-	logger.Newline()
-	logger.Print("1. Environment variable (recommended):")
-	logger.Print("   export THE0_API_URL=%s", newURL)
-	logger.Newline()
-	logger.Print("2. For this session only:")
-	logger.Print("   THE0_API_URL=%s the0 <command>", newURL)
-	logger.Newline()
-	logger.Print("3. Add to your shell profile (~/.bashrc, ~/.zshrc, etc.):")
-	logger.Print("   echo 'export THE0_API_URL=%s' >> ~/.bashrc", newURL)
 }
 
 // NewSecretsCmd creates the secrets subcommand for managing build secrets

--- a/cli/cmd/env.go
+++ b/cli/cmd/env.go
@@ -1,0 +1,228 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+	"the0/internal"
+	"the0/internal/logger"
+)
+
+func NewEnvCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "env",
+		Short: "Manage named API environments (local, prod, ...)",
+		Long: `Manage named environments for the the0 CLI.
+
+Each environment stores its own API URL and API key. Switch between them
+instantly with 'the0 env use <name>' or override per-command with --env.
+
+Examples:
+  the0 env add local --url http://localhost:3000
+  the0 env add prod  --url https://api.the0.app --api-key the0_xxx
+  the0 env use prod
+  the0 env list
+  the0 bot list --env prod`,
+	}
+
+	cmd.AddCommand(newEnvAddCmd())
+	cmd.AddCommand(newEnvUseCmd())
+	cmd.AddCommand(newEnvListCmd())
+	cmd.AddCommand(newEnvRemoveCmd())
+	cmd.AddCommand(newEnvCurrentCmd())
+	return cmd
+}
+
+func newEnvAddCmd() *cobra.Command {
+	var url, apiKey string
+	cmd := &cobra.Command{
+		Use:   "add <name>",
+		Short: "Add a new environment",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			name := args[0]
+			if url == "" {
+				logger.Error("--url is required")
+				os.Exit(1)
+			}
+			if apiKey == "" {
+				key, err := promptForAPIKey()
+				if err != nil {
+					logger.Error("%v", err)
+					os.Exit(1)
+				}
+				apiKey = key
+			}
+
+			if err := addEnvironment(name, url, apiKey); err != nil {
+				logger.Error("%v", err)
+				os.Exit(1)
+			}
+			logger.Success("Environment %q added", name)
+		},
+	}
+	cmd.Flags().StringVar(&url, "url", "", "API base URL (e.g. http://localhost:3000)")
+	cmd.Flags().StringVar(&apiKey, "api-key", "", "API key (prompted if omitted)")
+	return cmd
+}
+
+func newEnvUseCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "use <name>",
+		Short: "Switch the active environment",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			envs, err := internal.LoadEnvironments()
+			if err != nil {
+				logger.Error("%v", err)
+				os.Exit(1)
+			}
+			if err := envs.Use(args[0]); err != nil {
+				logger.Error("%v", err)
+				os.Exit(1)
+			}
+			if err := internal.SaveEnvironments(envs); err != nil {
+				logger.Error("%v", err)
+				os.Exit(1)
+			}
+			logger.Success("Active environment: %s", args[0])
+		},
+	}
+}
+
+func newEnvListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all environments",
+		Run: func(cmd *cobra.Command, args []string) {
+			envs, err := internal.LoadEnvironments()
+			if err != nil {
+				logger.Error("%v", err)
+				os.Exit(1)
+			}
+			if len(envs.Environments) == 0 {
+				logger.Print("No environments defined. Run `the0 env add <name> --url <url>` to create one.")
+				return
+			}
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w, "ACTIVE\tNAME\tURL")
+			for name, env := range envs.Environments {
+				marker := " "
+				if name == envs.Active {
+					marker = "*"
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\n", marker, name, env.URL)
+			}
+			_ = w.Flush()
+		},
+	}
+}
+
+func newEnvRemoveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "remove <name>",
+		Aliases: []string{"rm"},
+		Short:   "Remove an environment",
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			envs, err := internal.LoadEnvironments()
+			if err != nil {
+				logger.Error("%v", err)
+				os.Exit(1)
+			}
+			wasActive := envs.Active == args[0]
+			if err := envs.Remove(args[0]); err != nil {
+				logger.Error("%v", err)
+				os.Exit(1)
+			}
+			if err := internal.SaveEnvironments(envs); err != nil {
+				logger.Error("%v", err)
+				os.Exit(1)
+			}
+			logger.Success("Environment %q removed", args[0])
+			if wasActive {
+				logger.Info("No active environment; run `the0 env use <name>` to pick one.")
+			}
+		},
+	}
+}
+
+func newEnvCurrentCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "current",
+		Short: "Show the active environment",
+		Run: func(cmd *cobra.Command, args []string) {
+			envs, err := internal.LoadEnvironments()
+			if err != nil {
+				logger.Error("%v", err)
+				os.Exit(1)
+			}
+			if envs.Active == "" {
+				logger.Print("No active environment. Legacy fallback in use (URL: %s).", internal.GetAPIBaseURL())
+				return
+			}
+			env, ok := envs.Environments[envs.Active]
+			if !ok {
+				logger.Error("active environment %q is not defined", envs.Active)
+				os.Exit(1)
+			}
+			logger.Print("Active: %s", envs.Active)
+			logger.Print("URL:    %s", env.URL)
+		},
+	}
+}
+
+// addEnvironment validates the API key against the URL and, on success,
+// persists the environment. If no environments are defined yet, it first
+// migrates any legacy auth.json so the existing login is preserved.
+func addEnvironment(name, url, apiKey string) error {
+	url = strings.TrimRight(url, "/")
+	apiClient := internal.NewAPIClient(url)
+	if err := apiClient.TestAPIKey(&internal.Auth{APIKey: apiKey}); err != nil {
+		return fmt.Errorf("API key validation failed: %w", err)
+	}
+
+	envs, err := internal.LoadEnvironments()
+	if err != nil {
+		return err
+	}
+	// First env ever: migrate legacy auth so users aren't logged out.
+	if len(envs.Environments) == 0 {
+		migrated, err := internal.MigrateLegacyAuth()
+		if err != nil {
+			return err
+		}
+		envs = migrated
+	}
+
+	if err := envs.Add(name, internal.Environment{
+		URL:       url,
+		APIKey:    apiKey,
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		return err
+	}
+	if envs.Active == "" {
+		envs.Active = name
+	}
+	return internal.SaveEnvironments(envs)
+}
+
+func promptForAPIKey() (string, error) {
+	reader := bufio.NewReader(os.Stdin)
+	logger.Printf("Enter API key: ")
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	key := strings.TrimSpace(line)
+	if key == "" {
+		return "", fmt.Errorf("API key cannot be empty")
+	}
+	return key, nil
+}

--- a/cli/cmd/env.go
+++ b/cli/cmd/env.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 	"the0/internal"
 	"the0/internal/logger"
 )
@@ -68,6 +69,7 @@ func newEnvAddCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&url, "url", "", "API base URL (e.g. http://localhost:3000)")
 	cmd.Flags().StringVar(&apiKey, "api-key", "", "API key (prompted if omitted)")
+	_ = cmd.MarkFlagRequired("url")
 	return cmd
 }
 
@@ -187,12 +189,16 @@ func addEnvironment(name, url, apiKey string) error {
 		return fmt.Errorf("API key validation failed: %w", err)
 	}
 
+	// Detect first-ever opt-in to named environments by the absence of the
+	// persisted file (NOT by an empty map: removing the last env still leaves
+	// the user opted in, and we must not re-import legacy auth in that case).
+	firstRun := !internal.EnvironmentsFileExists()
+
 	envs, err := internal.LoadEnvironments()
 	if err != nil {
 		return err
 	}
-	// First env ever: migrate legacy auth so users aren't logged out.
-	if len(envs.Environments) == 0 {
+	if firstRun {
 		migrated, err := internal.MigrateLegacyAuth()
 		if err != nil {
 			return err
@@ -214,13 +220,26 @@ func addEnvironment(name, url, apiKey string) error {
 }
 
 func promptForAPIKey() (string, error) {
-	reader := bufio.NewReader(os.Stdin)
 	logger.Printf("Enter API key: ")
-	line, err := reader.ReadString('\n')
-	if err != nil {
-		return "", err
+	fd := int(os.Stdin.Fd())
+	var key string
+	if term.IsTerminal(fd) {
+		raw, err := term.ReadPassword(fd)
+		// ReadPassword does not emit the trailing newline the user typed; add
+		// one so the next line of CLI output isn't glued to the prompt.
+		fmt.Fprintln(os.Stderr)
+		if err != nil {
+			return "", err
+		}
+		key = strings.TrimSpace(string(raw))
+	} else {
+		// Non-TTY (piped input, tests). Fall back to line read.
+		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		if err != nil {
+			return "", err
+		}
+		key = strings.TrimSpace(line)
 	}
-	key := strings.TrimSpace(line)
 	if key == "" {
 		return "", fmt.Errorf("API key cannot be empty")
 	}

--- a/cli/cmd/env_test.go
+++ b/cli/cmd/env_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -120,6 +122,54 @@ func TestAddEnvironment_SecondEnv_KeepsFirst(t *testing.T) {
 	}
 	if envs.Active != "local" {
 		t.Errorf("Active should remain 'local' after second add, got %q", envs.Active)
+	}
+}
+
+func TestAddEnvironment_RemoveLastThenAdd_DoesNotReimportLegacy(t *testing.T) {
+	dir := t.TempDir()
+	internal.SetConfigDir(dir)
+	t.Cleanup(func() { internal.SetConfigDir("") })
+
+	// Plant a legacy auth.json that would, under the old buggy logic, be
+	// re-imported every time the environments map is empty.
+	if err := os.WriteFile(filepath.Join(dir, "auth.json"),
+		[]byte(`{"api_key":"legacy_key","created_at":"2025-01-01T00:00:00Z"}`), 0600); err != nil {
+		t.Fatalf("seed legacy auth.json: %v", err)
+	}
+
+	srv := newMockAPI(t, "good_key")
+	defer srv.Close()
+
+	// First add: legitimate migration of the legacy key into "default".
+	if err := addEnvironment("local", srv.URL, "good_key"); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+
+	// Remove every environment.
+	envs, err := internal.LoadEnvironments()
+	if err != nil {
+		t.Fatalf("LoadEnvironments: %v", err)
+	}
+	for name := range envs.Environments {
+		if err := envs.Remove(name); err != nil {
+			t.Fatalf("remove %q: %v", name, err)
+		}
+	}
+	if err := internal.SaveEnvironments(envs); err != nil {
+		t.Fatalf("SaveEnvironments: %v", err)
+	}
+
+	// Now add again. The legacy auth.json must NOT be re-imported because
+	// the user has already opted into named environments.
+	if err := addEnvironment("staging", srv.URL, "good_key"); err != nil {
+		t.Fatalf("second add: %v", err)
+	}
+	envs, _ = internal.LoadEnvironments()
+	if _, ok := envs.Environments["default"]; ok {
+		t.Errorf("legacy auth was re-imported after removing all envs; got default=%+v", envs.Environments["default"])
+	}
+	if len(envs.Environments) != 1 {
+		t.Errorf("expected exactly 1 env (staging), got %d: %v", len(envs.Environments), envs.Environments)
 	}
 }
 

--- a/cli/cmd/env_test.go
+++ b/cli/cmd/env_test.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"the0/internal"
+)
+
+func newMockAPI(t *testing.T, validKey string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/auth/validate-api-key" {
+			http.NotFound(w, r)
+			return
+		}
+		auth := r.Header.Get("Authorization")
+		if auth != "ApiKey "+validKey {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"data":    map[string]any{"valid": true, "userId": "u1", "keyId": "k1"},
+		})
+	}))
+}
+
+func TestAddEnvironment_ValidKey(t *testing.T) {
+	internal.SetConfigDir(t.TempDir())
+	t.Cleanup(func() { internal.SetConfigDir("") })
+
+	srv := newMockAPI(t, "good_key")
+	defer srv.Close()
+
+	if err := addEnvironment("local", srv.URL, "good_key"); err != nil {
+		t.Fatalf("addEnvironment() error = %v", err)
+	}
+
+	envs, err := internal.LoadEnvironments()
+	if err != nil {
+		t.Fatalf("LoadEnvironments: %v", err)
+	}
+	if envs.Active != "local" {
+		t.Errorf("Active = %q, want local", envs.Active)
+	}
+	got, ok := envs.Environments["local"]
+	if !ok {
+		t.Fatal("local env not persisted")
+	}
+	if got.APIKey != "good_key" {
+		t.Errorf("APIKey = %q", got.APIKey)
+	}
+	if got.URL != strings.TrimRight(srv.URL, "/") {
+		t.Errorf("URL = %q, want %q", got.URL, srv.URL)
+	}
+}
+
+func TestAddEnvironment_InvalidKey_NothingSaved(t *testing.T) {
+	internal.SetConfigDir(t.TempDir())
+	t.Cleanup(func() { internal.SetConfigDir("") })
+
+	srv := newMockAPI(t, "good_key")
+	defer srv.Close()
+
+	err := addEnvironment("local", srv.URL, "wrong_key")
+	if err == nil {
+		t.Fatal("expected validation error for bad key")
+	}
+
+	envs, loadErr := internal.LoadEnvironments()
+	if loadErr != nil {
+		t.Fatalf("LoadEnvironments: %v", loadErr)
+	}
+	if len(envs.Environments) != 0 {
+		t.Errorf("expected no environments persisted, got %v", envs.Environments)
+	}
+	if envs.Active != "" {
+		t.Errorf("expected empty Active, got %q", envs.Active)
+	}
+}
+
+func TestAddEnvironment_NetworkError_NothingSaved(t *testing.T) {
+	internal.SetConfigDir(t.TempDir())
+	t.Cleanup(func() { internal.SetConfigDir("") })
+
+	// Point at a URL nothing is listening on.
+	err := addEnvironment("local", "http://127.0.0.1:1", "anything")
+	if err == nil {
+		t.Fatal("expected network error")
+	}
+
+	envs, _ := internal.LoadEnvironments()
+	if len(envs.Environments) != 0 {
+		t.Errorf("expected no environments persisted")
+	}
+}
+
+func TestAddEnvironment_SecondEnv_KeepsFirst(t *testing.T) {
+	internal.SetConfigDir(t.TempDir())
+	t.Cleanup(func() { internal.SetConfigDir("") })
+
+	srv := newMockAPI(t, "good_key")
+	defer srv.Close()
+
+	if err := addEnvironment("local", srv.URL, "good_key"); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+	if err := addEnvironment("prod", srv.URL, "good_key"); err != nil {
+		t.Fatalf("second add: %v", err)
+	}
+
+	envs, _ := internal.LoadEnvironments()
+	if len(envs.Environments) != 2 {
+		t.Fatalf("expected 2 envs, got %d", len(envs.Environments))
+	}
+	if envs.Active != "local" {
+		t.Errorf("Active should remain 'local' after second add, got %q", envs.Active)
+	}
+}
+
+func TestAddEnvironment_Duplicate(t *testing.T) {
+	internal.SetConfigDir(t.TempDir())
+	t.Cleanup(func() { internal.SetConfigDir("") })
+
+	srv := newMockAPI(t, "good_key")
+	defer srv.Close()
+
+	if err := addEnvironment("local", srv.URL, "good_key"); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+	err := addEnvironment("local", srv.URL, "good_key")
+	if err == nil {
+		t.Fatal("expected duplicate error")
+	}
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -4,16 +4,17 @@ go 1.24.1
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
+	github.com/briandowns/spinner v1.23.0
 	github.com/docker/docker v28.2.2+incompatible
 	github.com/fatih/color v1.18.0
 	github.com/olekukonko/tablewriter v1.0.7
 	github.com/spf13/cobra v1.8.0
+	golang.org/x/term v0.1.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
-	github.com/briandowns/spinner v1.23.0 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
@@ -46,7 +47,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.36.0 // indirect
 	go.opentelemetry.io/otel/trace v1.36.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
-	golang.org/x/term v0.1.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
 	gotest.tools/v3 v3.5.2 // indirect
 )

--- a/cli/internal/api.go
+++ b/cli/internal/api.go
@@ -129,12 +129,15 @@ func NewAPIClient(baseURL string) *APIClient {
 	}
 }
 
-// GetAPIBaseURL returns the API base URL from environment or default
+// GetAPIBaseURL returns the API base URL for the active environment. It
+// consults ResolveActive so the --env flag, active named environment, legacy
+// THE0_API_URL env var, and default URL all compose through a single path.
 func GetAPIBaseURL() string {
-	if url := os.Getenv("THE0_API_URL"); url != "" {
-		return url
+	env, err := ResolveActive("")
+	if err != nil || env == nil || env.URL == "" {
+		return DEFAULT_API_URL
 	}
-	return DEFAULT_API_URL
+	return env.URL
 }
 
 // APIKeyValidationResponse represents the response from the API key validation endpoint

--- a/cli/internal/auth.go
+++ b/cli/internal/auth.go
@@ -13,65 +13,96 @@ import (
 	"the0/internal/logger"
 )
 
-const AUTH_FILE = ".the0/auth.json"
-
 // Auth represents the authentication structure
 type Auth struct {
 	APIKey    string    `json:"api_key"`
 	CreatedAt time.Time `json:"created_at"`
 }
 
-// LoadAuth loads authentication from file
-func LoadAuth() (*Auth, error) {
-	homeDir, err := os.UserHomeDir()
+func authFilePath() (string, error) {
+	dir, err := ConfigDir()
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-
-	authPath := filepath.Join(homeDir, AUTH_FILE)
-	data, err := os.ReadFile(authPath)
-	if err != nil {
-		return nil, err
-	}
-
-	var auth Auth
-	if err := json.Unmarshal(data, &auth); err != nil {
-		return nil, err
-	}
-
-	return &auth, nil
+	return filepath.Join(dir, "auth.json"), nil
 }
 
-// SaveAuth saves authentication to file
+// LoadAuth returns the API key for the active environment (named environment
+// if one is active, otherwise the legacy auth.json). Returns an error if no
+// API key can be resolved.
+func LoadAuth() (*Auth, error) {
+	env, err := ResolveActive("")
+	if err != nil {
+		return nil, err
+	}
+	if env == nil || env.APIKey == "" {
+		return nil, fmt.Errorf("no API key configured (run `the0 auth login` or `the0 env add`)")
+	}
+	return &Auth{APIKey: env.APIKey, CreatedAt: env.CreatedAt}, nil
+}
+
+// SaveAuth persists the API key. If a named environment is active, the key is
+// stored on that environment. Otherwise it is written to the legacy
+// ~/.the0/auth.json so brand-new users don't need to set up environments
+// before their first login.
 func SaveAuth(auth *Auth) error {
-	homeDir, err := os.UserHomeDir()
+	envs, err := LoadEnvironments()
 	if err != nil {
 		return err
 	}
-
-	authDir := filepath.Join(homeDir, ".the0")
-	if err := os.MkdirAll(authDir, 0700); err != nil {
-		return err
+	if envs.Active != "" {
+		if active, ok := envs.Environments[envs.Active]; ok {
+			active.APIKey = auth.APIKey
+			if auth.CreatedAt.IsZero() {
+				active.CreatedAt = time.Now().UTC()
+			} else {
+				active.CreatedAt = auth.CreatedAt
+			}
+			envs.Environments[envs.Active] = active
+			return SaveEnvironments(envs)
+		}
 	}
 
-	authPath := filepath.Join(homeDir, AUTH_FILE)
+	// Legacy fallback.
+	dir, err := ConfigDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	path, err := authFilePath()
+	if err != nil {
+		return err
+	}
 	data, err := json.MarshalIndent(auth, "", "  ")
 	if err != nil {
 		return err
 	}
-
-	return os.WriteFile(authPath, data, 0600)
+	return os.WriteFile(path, data, 0600)
 }
 
-// RemoveAuth removes the saved authentication
+// RemoveAuth clears the API key. If a named environment is active, the key on
+// that environment is cleared (the environment itself is retained). Otherwise
+// the legacy auth.json file is removed.
 func RemoveAuth() error {
-	homeDir, err := os.UserHomeDir()
+	envs, err := LoadEnvironments()
 	if err != nil {
 		return err
 	}
+	if envs.Active != "" {
+		if active, ok := envs.Environments[envs.Active]; ok && active.APIKey != "" {
+			active.APIKey = ""
+			envs.Environments[envs.Active] = active
+			return SaveEnvironments(envs)
+		}
+	}
 
-	authPath := filepath.Join(homeDir, AUTH_FILE)
-	return os.Remove(authPath)
+	path, err := authFilePath()
+	if err != nil {
+		return err
+	}
+	return os.Remove(path)
 }
 
 // PromptForNewAPIKey prompts the user for a new API key

--- a/cli/internal/environments.go
+++ b/cli/internal/environments.go
@@ -1,0 +1,244 @@
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	envFileName         = "environments.json"
+	legacyAuthFileName  = "auth.json"
+	defaultEnvName      = "default"
+)
+
+type Environment struct {
+	URL       string    `json:"url"`
+	APIKey    string    `json:"api_key"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type Environments struct {
+	Active       string                 `json:"active"`
+	Environments map[string]Environment `json:"environments"`
+}
+
+var (
+	configDirOverride   string
+	activeEnvOverride   string
+)
+
+// SetConfigDir overrides the config directory (default: ~/.the0). Used by tests
+// and can also be used for isolated CLI runs. Pass "" to restore default.
+func SetConfigDir(dir string) { configDirOverride = dir }
+
+// SetActiveEnvOverride sets the name of the environment that wins over the
+// persisted active selection for the lifetime of this process. Set by the root
+// command's --env flag. Empty string clears it.
+func SetActiveEnvOverride(name string) { activeEnvOverride = name }
+
+// ConfigDir returns the resolved config directory (override if set, else ~/.the0).
+func ConfigDir() (string, error) {
+	if configDirOverride != "" {
+		return configDirOverride, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".the0"), nil
+}
+
+func environmentsPath() (string, error) {
+	dir, err := ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, envFileName), nil
+}
+
+func legacyAuthPath() (string, error) {
+	dir, err := ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, legacyAuthFileName), nil
+}
+
+// LoadEnvironments reads the environments file. Returns an empty, non-nil
+// Environments struct if the file does not exist.
+func LoadEnvironments() (*Environments, error) {
+	path, err := environmentsPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Environments{Environments: map[string]Environment{}}, nil
+		}
+		return nil, err
+	}
+	var envs Environments
+	if err := json.Unmarshal(data, &envs); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if envs.Environments == nil {
+		envs.Environments = map[string]Environment{}
+	}
+	return &envs, nil
+}
+
+// SaveEnvironments writes the environments file atomically with 0600 perms.
+func SaveEnvironments(envs *Environments) error {
+	dir, err := ConfigDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, envFileName)
+	data, err := json.MarshalIndent(envs, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+// Add registers a new environment. Errors if name already exists.
+func (e *Environments) Add(name string, env Environment) error {
+	if e.Environments == nil {
+		e.Environments = map[string]Environment{}
+	}
+	if _, exists := e.Environments[name]; exists {
+		return fmt.Errorf("environment %q already exists", name)
+	}
+	if env.CreatedAt.IsZero() {
+		env.CreatedAt = time.Now().UTC()
+	}
+	e.Environments[name] = env
+	return nil
+}
+
+// Use marks the named environment as active. Errors if unknown.
+func (e *Environments) Use(name string) error {
+	if _, ok := e.Environments[name]; !ok {
+		return fmt.Errorf("environment %q does not exist", name)
+	}
+	e.Active = name
+	return nil
+}
+
+// Remove deletes the named environment. If it was active, clears Active.
+// Errors if the env does not exist.
+func (e *Environments) Remove(name string) error {
+	if _, ok := e.Environments[name]; !ok {
+		return fmt.Errorf("environment %q does not exist", name)
+	}
+	delete(e.Environments, name)
+	if e.Active == name {
+		e.Active = ""
+	}
+	return nil
+}
+
+// Get returns the named environment, if present.
+func (e *Environments) Get(name string) (*Environment, bool) {
+	env, ok := e.Environments[name]
+	if !ok {
+		return nil, false
+	}
+	return &env, true
+}
+
+// ResolveActive returns the environment (URL + API key) to use for API calls,
+// applying precedence: explicit override arg > process-level override (--env
+// flag) > persisted active env > legacy auth.json + THE0_API_URL > default.
+func ResolveActive(override string) (*Environment, error) {
+	envs, err := LoadEnvironments()
+	if err != nil {
+		return nil, err
+	}
+
+	name := override
+	if name == "" {
+		name = activeEnvOverride
+	}
+	if name != "" {
+		env, ok := envs.Get(name)
+		if !ok {
+			return nil, fmt.Errorf("environment %q is not defined (use `the0 env add %s`)", name, name)
+		}
+		return env, nil
+	}
+
+	if envs.Active != "" {
+		if env, ok := envs.Get(envs.Active); ok {
+			return env, nil
+		}
+	}
+
+	// Legacy fallback: auth.json + THE0_API_URL.
+	legacy := &Environment{URL: legacyURL()}
+	if auth, err := readLegacyAuth(); err == nil && auth != nil {
+		legacy.APIKey = auth.APIKey
+		legacy.CreatedAt = auth.CreatedAt
+	}
+	return legacy, nil
+}
+
+func legacyURL() string {
+	if url := os.Getenv("THE0_API_URL"); url != "" {
+		return url
+	}
+	return DEFAULT_API_URL
+}
+
+func readLegacyAuth() (*Auth, error) {
+	path, err := legacyAuthPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var auth Auth
+	if err := json.Unmarshal(data, &auth); err != nil {
+		return nil, err
+	}
+	return &auth, nil
+}
+
+// MigrateLegacyAuth creates an environments.json seeded from the legacy
+// auth.json + THE0_API_URL/default URL, stored under the name "default" and
+// marked active. If no legacy state exists, returns an empty but valid
+// Environments (still persisted so the CLI starts treating this user as
+// opted-in to named environments).
+func MigrateLegacyAuth() (*Environments, error) {
+	envs := &Environments{Environments: map[string]Environment{}}
+
+	auth, _ := readLegacyAuth()
+	url := legacyURL()
+
+	if auth != nil || os.Getenv("THE0_API_URL") != "" {
+		createdAt := time.Now().UTC()
+		if auth != nil && !auth.CreatedAt.IsZero() {
+			createdAt = auth.CreatedAt.UTC()
+		}
+		env := Environment{URL: url, CreatedAt: createdAt}
+		if auth != nil {
+			env.APIKey = auth.APIKey
+		}
+		envs.Environments[defaultEnvName] = env
+		envs.Active = defaultEnvName
+	}
+
+	if err := SaveEnvironments(envs); err != nil {
+		return nil, err
+	}
+	return envs, nil
+}

--- a/cli/internal/environments.go
+++ b/cli/internal/environments.go
@@ -92,6 +92,8 @@ func LoadEnvironments() (*Environments, error) {
 }
 
 // SaveEnvironments writes the environments file atomically with 0600 perms.
+// The write goes to a same-directory temp file that is fsynced and then
+// renamed over the target so a crash mid-write cannot leave a partial file.
 func SaveEnvironments(envs *Environments) error {
 	dir, err := ConfigDir()
 	if err != nil {
@@ -105,7 +107,50 @@ func SaveEnvironments(envs *Environments) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0600)
+
+	tmp, err := os.CreateTemp(dir, envFileName+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+	if err := tmp.Chmod(0600); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return err
+	}
+	return nil
+}
+
+// EnvironmentsFileExists reports whether the persisted environments file is
+// present on disk. Used to distinguish "user has never opted in to named
+// environments" (legacy migration applies) from "user has opted in but
+// currently has zero environments" (legacy auth must NOT be re-imported).
+func EnvironmentsFileExists() bool {
+	path, err := environmentsPath()
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(path)
+	return err == nil
 }
 
 // Add registers a new environment. Errors if name already exists.
@@ -176,9 +221,12 @@ func ResolveActive(override string) (*Environment, error) {
 	}
 
 	if envs.Active != "" {
-		if env, ok := envs.Get(envs.Active); ok {
-			return env, nil
+		env, ok := envs.Get(envs.Active)
+		if !ok {
+			return nil, fmt.Errorf("active environment %q is not defined; pick one with `the0 env use <name>` or remove the stale entry from %s",
+				envs.Active, envFileName)
 		}
+		return env, nil
 	}
 
 	// Legacy fallback: auth.json + THE0_API_URL.

--- a/cli/internal/environments_test.go
+++ b/cli/internal/environments_test.go
@@ -1,0 +1,350 @@
+package internal
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func withTempConfigDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	prevCfg := configDirOverride
+	prevOverride := activeEnvOverride
+	prevEnv := os.Getenv("THE0_API_URL")
+	SetConfigDir(dir)
+	SetActiveEnvOverride("")
+	os.Unsetenv("THE0_API_URL")
+	t.Cleanup(func() {
+		SetConfigDir(prevCfg)
+		SetActiveEnvOverride(prevOverride)
+		if prevEnv != "" {
+			os.Setenv("THE0_API_URL", prevEnv)
+		} else {
+			os.Unsetenv("THE0_API_URL")
+		}
+	})
+	return dir
+}
+
+func TestLoadEnvironments_FileMissing(t *testing.T) {
+	withTempConfigDir(t)
+
+	envs, err := LoadEnvironments()
+	if err != nil {
+		t.Fatalf("LoadEnvironments() with missing file returned error: %v", err)
+	}
+	if envs == nil {
+		t.Fatal("LoadEnvironments() returned nil envs")
+	}
+	if envs.Active != "" {
+		t.Errorf("expected empty Active, got %q", envs.Active)
+	}
+	if len(envs.Environments) != 0 {
+		t.Errorf("expected empty Environments map, got %v", envs.Environments)
+	}
+}
+
+func TestSaveAndLoadEnvironments_RoundTrip(t *testing.T) {
+	dir := withTempConfigDir(t)
+
+	original := &Environments{
+		Active: "local",
+		Environments: map[string]Environment{
+			"local": {URL: "http://localhost:3000", APIKey: "the0_local", CreatedAt: time.Now().UTC().Truncate(time.Second)},
+			"prod":  {URL: "https://api.the0.app", APIKey: "the0_prod", CreatedAt: time.Now().UTC().Truncate(time.Second)},
+		},
+	}
+
+	if err := SaveEnvironments(original); err != nil {
+		t.Fatalf("SaveEnvironments() error = %v", err)
+	}
+
+	path := filepath.Join(dir, "environments.json")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat on saved file: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		if mode := info.Mode().Perm(); mode != 0600 {
+			t.Errorf("expected file mode 0600, got %v", mode)
+		}
+	}
+
+	loaded, err := LoadEnvironments()
+	if err != nil {
+		t.Fatalf("LoadEnvironments() error = %v", err)
+	}
+	if loaded.Active != original.Active {
+		t.Errorf("Active = %q, want %q", loaded.Active, original.Active)
+	}
+	if len(loaded.Environments) != 2 {
+		t.Fatalf("expected 2 environments, got %d", len(loaded.Environments))
+	}
+	if loaded.Environments["prod"].URL != "https://api.the0.app" {
+		t.Errorf("prod URL mismatch: got %q", loaded.Environments["prod"].URL)
+	}
+	if loaded.Environments["prod"].APIKey != "the0_prod" {
+		t.Errorf("prod APIKey mismatch: got %q", loaded.Environments["prod"].APIKey)
+	}
+}
+
+func TestEnvironments_Add(t *testing.T) {
+	envs := &Environments{Environments: map[string]Environment{}}
+
+	err := envs.Add("local", Environment{URL: "http://localhost:3000", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+	if _, ok := envs.Environments["local"]; !ok {
+		t.Fatal("expected local env to be present")
+	}
+	if envs.Environments["local"].CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be set by Add()")
+	}
+}
+
+func TestEnvironments_Add_Duplicate(t *testing.T) {
+	envs := &Environments{Environments: map[string]Environment{
+		"local": {URL: "http://localhost:3000"},
+	}}
+
+	err := envs.Add("local", Environment{URL: "http://other"})
+	if err == nil {
+		t.Fatal("expected error on duplicate name, got nil")
+	}
+}
+
+func TestEnvironments_Use(t *testing.T) {
+	envs := &Environments{Environments: map[string]Environment{
+		"local": {URL: "http://localhost:3000"},
+		"prod":  {URL: "https://api.the0.app"},
+	}}
+
+	if err := envs.Use("prod"); err != nil {
+		t.Fatalf("Use() error = %v", err)
+	}
+	if envs.Active != "prod" {
+		t.Errorf("Active = %q, want prod", envs.Active)
+	}
+}
+
+func TestEnvironments_Use_Unknown(t *testing.T) {
+	envs := &Environments{Environments: map[string]Environment{}}
+	if err := envs.Use("ghost"); err == nil {
+		t.Fatal("expected error using unknown env")
+	}
+}
+
+func TestEnvironments_Remove(t *testing.T) {
+	envs := &Environments{
+		Active: "local",
+		Environments: map[string]Environment{
+			"local": {URL: "http://localhost:3000"},
+			"prod":  {URL: "https://api.the0.app"},
+		},
+	}
+
+	if err := envs.Remove("prod"); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	if _, ok := envs.Environments["prod"]; ok {
+		t.Error("expected prod to be gone")
+	}
+	if envs.Active != "local" {
+		t.Errorf("Active = %q, want local (unchanged)", envs.Active)
+	}
+}
+
+func TestEnvironments_Remove_Active_UnsetsActive(t *testing.T) {
+	envs := &Environments{
+		Active: "local",
+		Environments: map[string]Environment{
+			"local": {URL: "http://localhost:3000"},
+		},
+	}
+
+	if err := envs.Remove("local"); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	if envs.Active != "" {
+		t.Errorf("expected Active to be cleared, got %q", envs.Active)
+	}
+}
+
+func TestEnvironments_Remove_Unknown(t *testing.T) {
+	envs := &Environments{Environments: map[string]Environment{}}
+	if err := envs.Remove("ghost"); err == nil {
+		t.Fatal("expected error removing unknown env")
+	}
+}
+
+func TestResolveActive_OverrideFlagWins(t *testing.T) {
+	withTempConfigDir(t)
+
+	envs := &Environments{
+		Active: "local",
+		Environments: map[string]Environment{
+			"local": {URL: "http://localhost:3000", APIKey: "local_key"},
+			"prod":  {URL: "https://api.the0.app", APIKey: "prod_key"},
+		},
+	}
+	if err := SaveEnvironments(envs); err != nil {
+		t.Fatalf("SaveEnvironments: %v", err)
+	}
+
+	got, err := ResolveActive("prod")
+	if err != nil {
+		t.Fatalf("ResolveActive(prod) error = %v", err)
+	}
+	if got.URL != "https://api.the0.app" || got.APIKey != "prod_key" {
+		t.Errorf("ResolveActive(prod) = %+v", got)
+	}
+}
+
+func TestResolveActive_OverrideFlag_Unknown(t *testing.T) {
+	withTempConfigDir(t)
+	envs := &Environments{Environments: map[string]Environment{}}
+	_ = SaveEnvironments(envs)
+
+	if _, err := ResolveActive("ghost"); err == nil {
+		t.Fatal("expected error for unknown override")
+	}
+}
+
+func TestResolveActive_GlobalOverride(t *testing.T) {
+	withTempConfigDir(t)
+	envs := &Environments{
+		Active: "local",
+		Environments: map[string]Environment{
+			"local": {URL: "http://localhost:3000", APIKey: "local_key"},
+			"prod":  {URL: "https://api.the0.app", APIKey: "prod_key"},
+		},
+	}
+	_ = SaveEnvironments(envs)
+
+	SetActiveEnvOverride("prod")
+	got, err := ResolveActive("")
+	if err != nil {
+		t.Fatalf("ResolveActive error = %v", err)
+	}
+	if got.URL != "https://api.the0.app" {
+		t.Errorf("expected prod URL, got %q", got.URL)
+	}
+}
+
+func TestResolveActive_ActiveEnv(t *testing.T) {
+	withTempConfigDir(t)
+	envs := &Environments{
+		Active: "local",
+		Environments: map[string]Environment{
+			"local": {URL: "http://localhost:3000", APIKey: "local_key"},
+		},
+	}
+	_ = SaveEnvironments(envs)
+
+	got, err := ResolveActive("")
+	if err != nil {
+		t.Fatalf("ResolveActive error = %v", err)
+	}
+	if got.URL != "http://localhost:3000" || got.APIKey != "local_key" {
+		t.Errorf("ResolveActive = %+v", got)
+	}
+}
+
+func TestResolveActive_LegacyAuthAndEnvVar(t *testing.T) {
+	dir := withTempConfigDir(t)
+	// No environments.json saved. Write legacy auth.json directly.
+	auth := &Auth{APIKey: "legacy_key", CreatedAt: time.Now()}
+	data, _ := json.MarshalIndent(auth, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, "auth.json"), data, 0600); err != nil {
+		t.Fatalf("write legacy auth.json: %v", err)
+	}
+	os.Setenv("THE0_API_URL", "http://legacy.example.com")
+
+	got, err := ResolveActive("")
+	if err != nil {
+		t.Fatalf("ResolveActive error = %v", err)
+	}
+	if got.URL != "http://legacy.example.com" {
+		t.Errorf("expected legacy URL, got %q", got.URL)
+	}
+	if got.APIKey != "legacy_key" {
+		t.Errorf("expected legacy key, got %q", got.APIKey)
+	}
+}
+
+func TestResolveActive_DefaultWhenEmpty(t *testing.T) {
+	withTempConfigDir(t)
+	got, err := ResolveActive("")
+	if err != nil {
+		t.Fatalf("ResolveActive error = %v", err)
+	}
+	if got.URL != DEFAULT_API_URL {
+		t.Errorf("expected default URL, got %q", got.URL)
+	}
+	if got.APIKey != "" {
+		t.Errorf("expected empty APIKey, got %q", got.APIKey)
+	}
+}
+
+func TestMigrateLegacyAuth(t *testing.T) {
+	dir := withTempConfigDir(t)
+	auth := &Auth{APIKey: "legacy_key", CreatedAt: time.Now()}
+	data, _ := json.MarshalIndent(auth, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, "auth.json"), data, 0600); err != nil {
+		t.Fatalf("write legacy auth.json: %v", err)
+	}
+	os.Setenv("THE0_API_URL", "http://legacy.example.com")
+
+	envs, err := MigrateLegacyAuth()
+	if err != nil {
+		t.Fatalf("MigrateLegacyAuth error = %v", err)
+	}
+	if envs.Active != "default" {
+		t.Errorf("expected Active=default, got %q", envs.Active)
+	}
+	dflt, ok := envs.Environments["default"]
+	if !ok {
+		t.Fatal("expected default env to be present")
+	}
+	if dflt.URL != "http://legacy.example.com" {
+		t.Errorf("default URL = %q", dflt.URL)
+	}
+	if dflt.APIKey != "legacy_key" {
+		t.Errorf("default APIKey = %q", dflt.APIKey)
+	}
+
+	// Verify it was persisted
+	loaded, err := LoadEnvironments()
+	if err != nil {
+		t.Fatalf("LoadEnvironments after migrate: %v", err)
+	}
+	if loaded.Active != "default" {
+		t.Errorf("persisted Active = %q", loaded.Active)
+	}
+}
+
+func TestMigrateLegacyAuth_NoAuthFile(t *testing.T) {
+	withTempConfigDir(t)
+	// No legacy auth. Migration should still produce a valid empty/default env.
+	envs, err := MigrateLegacyAuth()
+	if err != nil {
+		t.Fatalf("MigrateLegacyAuth error = %v", err)
+	}
+	if envs == nil {
+		t.Fatal("expected non-nil envs")
+	}
+	// Either zero environments or a default with empty key is acceptable; we just
+	// require it is save-loadable without error.
+	loaded, err := LoadEnvironments()
+	if err != nil {
+		t.Fatalf("LoadEnvironments: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected non-nil loaded envs")
+	}
+}

--- a/cli/internal/environments_test.go
+++ b/cli/internal/environments_test.go
@@ -277,6 +277,21 @@ func TestResolveActive_LegacyAuthAndEnvVar(t *testing.T) {
 	}
 }
 
+func TestResolveActive_ActiveEnvMissingFromMap_FailsFast(t *testing.T) {
+	withTempConfigDir(t)
+	envs := &Environments{
+		Active:       "ghost",
+		Environments: map[string]Environment{},
+	}
+	if err := SaveEnvironments(envs); err != nil {
+		t.Fatalf("SaveEnvironments: %v", err)
+	}
+	_, err := ResolveActive("")
+	if err == nil {
+		t.Fatal("expected error when active env is set but missing from map")
+	}
+}
+
 func TestResolveActive_DefaultWhenEmpty(t *testing.T) {
 	withTempConfigDir(t)
 	got, err := ResolveActive("")

--- a/cli/main.go
+++ b/cli/main.go
@@ -15,7 +15,8 @@ import (
 var VERSION string
 
 var (
-	verbose bool
+	verbose       bool
+	envOverride   string
 )
 
 func main() {
@@ -35,6 +36,9 @@ the0 CLI - Terminal-based trading bot management`,
 				Verbose:   verbose,
 				NoSpinner: os.Getenv("THE0_NO_SPINNER") != "",
 			}))
+			// Wire the --env flag through to the internal resolver so the rest
+			// of the CLI (GetAPIBaseURL, LoadAuth) picks up the override.
+			internal.SetActiveEnvOverride(envOverride)
 		},
 	}
 
@@ -44,11 +48,13 @@ the0 CLI - Terminal-based trading bot management`,
 
 	// Add global verbose flag
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
+	rootCmd.PersistentFlags().StringVar(&envOverride, "env", "", "Named environment to use for this command (overrides active env)")
 
 	// Add command groups
 	rootCmd.AddCommand(cmd.NewCustomBotCmd())
 	rootCmd.AddCommand(cmd.NewBotCmd())
 	rootCmd.AddCommand(cmd.NewAuthCmd())
+	rootCmd.AddCommand(cmd.NewEnvCmd())
 	rootCmd.AddCommand(cmd.NewLocalCmd())
 	if VERSION != "" {
 		rootCmd.AddCommand(cmd.NewUpdateCmd(VERSION))

--- a/cli/tests/auth_test.go
+++ b/cli/tests/auth_test.go
@@ -9,31 +9,25 @@ import (
 )
 
 func TestSaveAndLoadAuth(t *testing.T) {
-	// Create test auth
+	internal.SetConfigDir(t.TempDir())
+	t.Cleanup(func() { internal.SetConfigDir("") })
+
 	testAuth := &internal.Auth{
 		APIKey:    "test-api-key-12345",
 		CreatedAt: time.Now(),
 	}
 
-	// Save auth
-	err := internal.SaveAuth(testAuth)
-	if err != nil {
+	if err := internal.SaveAuth(testAuth); err != nil {
 		t.Fatalf("SaveAuth() error = %v", err)
 	}
 
-	// Load auth
 	loadedAuth, err := internal.LoadAuth()
 	if err != nil {
 		t.Fatalf("LoadAuth() error = %v", err)
 	}
-
-	// Compare
 	if loadedAuth.APIKey != testAuth.APIKey {
 		t.Errorf("LoadAuth() APIKey = %v, want %v", loadedAuth.APIKey, testAuth.APIKey)
 	}
-
-	// Cleanup
-	defer internal.RemoveAuth()
 }
 
 func TestIsAuthError(t *testing.T) {

--- a/docs/the0-cli/authentication.md
+++ b/docs/the0-cli/authentication.md
@@ -47,19 +47,24 @@ Remove saved credentials:
 the0 auth logout
 ```
 
-## Configure API Endpoint
+## Pointing at a Different API
 
-For self-hosted deployments, configure the API URL:
+Use named environments to target multiple API endpoints (local dev, staging, prod) without clobbering credentials. See [Environments](./environments) for the full reference.
 
 ```bash
-the0 auth config https://api.your-domain.com
+the0 env add local --url http://localhost:3000
+the0 env add prod  --url https://api.the0.app
+the0 env use prod
 ```
 
-The default endpoint is `http://localhost:3000` for local development. You can also set the `THE0_API_URL` environment variable.
+`the0 auth login` writes the key to the active environment. Use `--env <name>` on any command to override for a single invocation.
 
 ## Credential Storage
 
-The CLI stores credentials in `~/.the0/auth.json`. This file is created automatically on first login.
+The CLI stores credentials under `~/.the0/`:
+
+- `~/.the0/environments.json` - named environments and their API keys (created on first `the0 env add`).
+- `~/.the0/auth.json` - legacy single-environment credential file. Still honoured when no named environments exist, so existing users are not logged out.
 
 If you encounter permission errors, ensure the directory exists with appropriate permissions:
 
@@ -70,5 +75,6 @@ chmod 700 ~/.the0
 
 ## Next Steps
 
+- [Environments](./environments) - Manage multiple API endpoints
 - [Secrets](./secrets) - Configure private dependency access
 - [Custom Bot Commands](./custom-bot-commands) - Deploy your first bot

--- a/docs/the0-cli/environments.md
+++ b/docs/the0-cli/environments.md
@@ -1,0 +1,91 @@
+---
+title: "Environments"
+description: "Manage named API environments with their own URL and credentials"
+tags: ["cli", "environments", "api"]
+order: 3
+---
+
+# Environments
+
+Named environments let the CLI target multiple the0 API endpoints (for example, a local Docker Compose stack and a production cluster) without rewriting environment variables or overwriting your saved API key.
+
+Each environment stores its own:
+
+- **URL** - e.g. `http://localhost:3000` or `https://api.the0.app`
+- **API key** - validated against the URL before it is saved
+
+Environments live in `~/.the0/environments.json`.
+
+## Add an Environment
+
+```bash
+the0 env add local --url http://localhost:3000
+the0 env add prod  --url https://api.the0.app --api-key the0_xxxxxxxxxxxx
+```
+
+If `--api-key` is omitted, the CLI prompts for it. The key is tested against the URL and only persisted if the API accepts it, so typos fail fast.
+
+The first environment you add becomes the active one automatically. If you previously logged in with `the0 auth login`, that existing credential is migrated into a `default` environment so nothing is lost.
+
+## Switch the Active Environment
+
+```bash
+the0 env use prod
+```
+
+All subsequent commands use the new active environment.
+
+## One-off Override
+
+Every command accepts a global `--env <name>` flag that overrides the active environment for that single invocation:
+
+```bash
+the0 bot list --env prod
+the0 custom-bot deploy --env local
+```
+
+## List Environments
+
+```bash
+the0 env list
+```
+
+```
+ACTIVE  NAME   URL
+*       local  http://localhost:3000
+        prod   https://api.the0.app
+```
+
+API keys are never printed.
+
+## Show the Active Environment
+
+```bash
+the0 env current
+```
+
+## Remove an Environment
+
+```bash
+the0 env remove prod
+```
+
+If you remove the active environment, no environment is active until you run `the0 env use <name>`.
+
+## Resolution Precedence
+
+When the CLI needs a URL and API key, it resolves them in this order (highest wins):
+
+1. `--env <name>` flag passed on the command
+2. Active environment in `environments.json`
+3. Legacy `THE0_API_URL` env var + `~/.the0/auth.json` (back-compat for users who haven't run `the0 env add` yet)
+4. Default URL `http://localhost:3000`
+
+## Migrating From `THE0_API_URL`
+
+The `THE0_API_URL` environment variable and the old `the0 auth config` command have been replaced by named environments. Existing setups keep working until you run your first `the0 env add`, which migrates your legacy credential into a `default` environment.
+
+## Next Steps
+
+- [Authentication](./authentication) - `auth login` writes to the active environment
+- [Installation](./installation) - Install the CLI

--- a/docs/the0-cli/index.md
+++ b/docs/the0-cli/index.md
@@ -12,14 +12,23 @@ The `the0` CLI is the primary interface for deploying custom bots and managing b
 
 The CLI is organized into the following command groups:
 
-**auth** - Manage authentication and configuration
+**auth** - Manage authentication
 
 ```bash
-the0 auth login          # Set API key
-the0 auth logout         # Remove API key
+the0 auth login          # Set API key for the active environment
+the0 auth logout         # Remove saved API key
 the0 auth status         # Check authentication status
-the0 auth config <url>   # Configure API endpoint
 the0 auth secrets        # Manage build secrets
+```
+
+**env** - Manage named API environments
+
+```bash
+the0 env add <name> --url <url>  # Add a new environment (validates key)
+the0 env use <name>              # Switch active environment
+the0 env list                    # List all environments
+the0 env remove <name>           # Delete an environment
+the0 env current                 # Show the active environment
 ```
 
 **custom-bot** - Deploy and manage custom bot definitions
@@ -63,14 +72,16 @@ the0 update                # Update to latest version
 All commands support the following flags:
 
 ```bash
--v, --verbose    Enable verbose output
--h, --help       Show help for any command
+-v, --verbose      Enable verbose output
+    --env <name>   Use the named environment for this command
+-h, --help         Show help for any command
 ```
 
 ## Documentation
 
 - [Installation](./installation) - Install the CLI
 - [Authentication](./authentication) - Configure API credentials
+- [Environments](./environments) - Manage multiple API endpoints (local, prod, ...)
 - [Bot Commands](./bot-commands) - Bot instance management reference
 - [Custom Bot Commands](./custom-bot-commands) - Custom bot deployment reference
 - [Local Development](./local-development) - Local environment management reference

--- a/docs/the0-cli/index.md
+++ b/docs/the0-cli/index.md
@@ -16,7 +16,7 @@ The CLI is organized into the following command groups:
 
 ```bash
 the0 auth login          # Set API key for the active environment
-the0 auth logout         # Remove saved API key
+the0 auth logout         # Remove the API key for the active environment
 the0 auth status         # Check authentication status
 the0 auth secrets        # Manage build secrets
 ```

--- a/docs/the0-cli/installation.md
+++ b/docs/the0-cli/installation.md
@@ -73,11 +73,13 @@ The help command displays all available commands and global flags.
 
 The CLI stores configuration in `~/.the0/`:
 
-- `auth.json` - API authentication credentials
+- `environments.json` - named API environments and their credentials (see [Environments](./environments))
+- `auth.json` - legacy single-environment credential file; still honoured when no named environments exist
 
-No manual configuration is required. The CLI creates this directory automatically when you first authenticate.
+No manual configuration is required. The CLI creates this directory automatically when you first authenticate or run `the0 env add`.
 
 ## Next Steps
 
 - [Authentication](./authentication) - Configure your API credentials
+- [Environments](./environments) - Target multiple API endpoints
 - [Custom Bot Commands](./custom-bot-commands) - Deploy your first bot

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: the0
 description: An open-source algorithmic trading platform for creating, deploying, and managing trading bots
 type: application
-version: 0.8.2
-appVersion: "1.13.2"
+version: 0.8.1
+appVersion: "1.13.1"
 kubeVersion: ">=1.21.0-0"
 keywords:
   - trading
@@ -30,14 +30,8 @@ annotations:
     - name: Discord
       url: https://discord.gg/g5mp57nK
   artifacthub.io/changes: |
-    - kind: added
-      description: CLI `the0 env` command to manage named API environments (local, prod, ...) each with their own URL and API key
-    - kind: added
-      description: Global `--env <name>` flag to override the active environment for a single command
-    - kind: changed
-      description: CLI auth login/logout/status now operate against the active named environment; `auth config` removed
-    - kind: changed
-      description: CLI prompts for API keys without echo when stdin is a TTY
+    - kind: fixed
+      description: Per-syncer final sync timeout to prevent R2 multipart upload leaks on pod shutdown
   artifacthub.io/images: |
     - name: api
       image: ghcr.io/alexanderwanyoike/the0/api

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: the0
 description: An open-source algorithmic trading platform for creating, deploying, and managing trading bots
 type: application
-version: 0.8.1
-appVersion: "1.13.1"
+version: 0.8.2
+appVersion: "1.13.2"
 kubeVersion: ">=1.21.0-0"
 keywords:
   - trading
@@ -30,8 +30,14 @@ annotations:
     - name: Discord
       url: https://discord.gg/g5mp57nK
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Per-syncer final sync timeout to prevent R2 multipart upload leaks on pod shutdown
+    - kind: added
+      description: CLI `the0 env` command to manage named API environments (local, prod, ...) each with their own URL and API key
+    - kind: added
+      description: Global `--env <name>` flag to override the active environment for a single command
+    - kind: changed
+      description: CLI auth login/logout/status now operate against the active named environment; `auth config` removed
+    - kind: changed
+      description: CLI prompts for API keys without echo when stdin is a TTY
   artifacthub.io/images: |
     - name: api
       image: ghcr.io/alexanderwanyoike/the0/api


### PR DESCRIPTION
## Summary

- **CLI: named environments** (#265) — new `the0 env add/use/list/remove/current` subcommands let you manage multiple API endpoints (local, prod, ...) each with their own URL and API key. Includes a global `--env <name>` flag for one-off overrides, validation of API keys before they are saved, no-echo prompts on TTYs, and atomic writes to `~/.the0/environments.json`.
- CLI `auth config` removed (replaced by `the0 env`); `auth login/logout/status` now operate against the active environment.
- Legacy `THE0_API_URL` + `~/.the0/auth.json` continue to work as a deprecated fallback; first `env add` migrates them into a `default` environment so existing users are not logged out.
- Docs site: new `docs/the0-cli/environments.md` reference, updated `authentication.md`, `installation.md`, and CLI index.

CLI-only release — no Helm chart bump. After merge, tag `v1.13.2` on `main` to trigger `release-cli.yml`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` clean (24 tests, including regression coverage for legacy migration + corrupted active env)
- [x] Smoke: env add/use/list/remove/current happy paths
- [x] Smoke: invalid API key rejected before persistence; nothing written
- [x] Smoke: legacy `auth.json` + `THE0_API_URL` keeps working until first `env add`, then migrates into `default` with original `CreatedAt`
- [x] Smoke: removing the last environment does NOT re-import legacy auth on next add

🤖 Generated with [Claude Code](https://claude.com/claude-code)