### PR TITLE
Release v1.13.3

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -61,6 +61,7 @@ export default withMermaid(defineConfig({
           { text: 'Overview', link: '/the0-cli/' },
           { text: 'Installation', link: '/the0-cli/installation' },
           { text: 'Authentication', link: '/the0-cli/authentication' },
+          { text: 'Environments', link: '/the0-cli/environments' },
           { text: 'Bot Commands', link: '/the0-cli/bot-commands' },
           { text: 'Custom Bot Commands', link: '/the0-cli/custom-bot-commands' },
           { text: 'Secrets', link: '/the0-cli/secrets' },

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: the0
 description: An open-source algorithmic trading platform for creating, deploying, and managing trading bots
 type: application
-version: 0.8.1
-appVersion: "1.13.1"
+version: 0.8.2
+appVersion: "1.13.3"
 kubeVersion: ">=1.21.0-0"
 keywords:
   - trading
@@ -30,8 +30,8 @@ annotations:
     - name: Discord
       url: https://discord.gg/g5mp57nK
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Per-syncer final sync timeout to prevent R2 multipart upload leaks on pod shutdown
+    - kind: added
+      description: Environments page in the docs site CLI sidebar
   artifacthub.io/images: |
     - name: api
       image: ghcr.io/alexanderwanyoike/the0/api


### PR DESCRIPTION
## Summary

- Adds the **Environments** page to the CLI sidebar in the docs site (previously missing after the `the0 env` feature shipped in v1.13.2).
- Helm chart bumped to `0.8.2` / appVersion `1.13.3`.

## Test plan

- [ ] After merge + tag, verify `docs.the0.app` shows **Environments** under the CLI section of the sidebar.
- [ ] Chart deploys cleanly with the new docs image tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)