### PR TITLE
feat(api): make database readiness check opt-in via HEALTH_CHECK_DATABASE

### DIFF
--- a/api/src/config/configuration.ts
+++ b/api/src/config/configuration.ts
@@ -29,4 +29,9 @@ export default () => ({
   // JWT configuration
   JWT_SECRET: process.env.JWT_SECRET,
   JWT_EXPIRES_IN: process.env.JWT_EXPIRES_IN || "24h",
+
+  // Readiness probe checks. Off by default to stay friendly to Postgres
+  // providers that bill compute time on idle connections. Enable when
+  // you want Kubernetes to gate pod traffic on deep dependency health.
+  HEALTH_CHECK_DATABASE: process.env.HEALTH_CHECK_DATABASE === "true",
 });

--- a/api/src/health/health.service.ts
+++ b/api/src/health/health.service.ts
@@ -11,7 +11,7 @@ import * as Minio from "minio";
 export interface HealthStatus {
   status: "ok" | "degraded" | "unhealthy";
   checks: {
-    postgres: ComponentHealth;
+    postgres?: ComponentHealth;
     nats: ComponentHealth;
     minio: ComponentHealth;
   };
@@ -26,6 +26,7 @@ interface ComponentHealth {
 @Injectable()
 export class HealthService {
   private readonly minioBucket: string;
+  private readonly checkDatabase: boolean;
 
   constructor(
     private readonly natsService: NatsService,
@@ -35,6 +36,8 @@ export class HealthService {
   ) {
     this.minioBucket =
       this.configService.get<string>("CUSTOM_BOTS_BUCKET") || "custom-bots";
+    this.checkDatabase =
+      this.configService.get<boolean>("HEALTH_CHECK_DATABASE") === true;
   }
 
   async getLiveness(): Promise<{ status: "ok" }> {
@@ -43,14 +46,19 @@ export class HealthService {
 
   async getReadiness(): Promise<HealthStatus> {
     const [postgres, nats, minio] = await Promise.all([
-      this.checkPostgres(),
+      this.checkDatabase ? this.checkPostgres() : Promise.resolve(undefined),
       this.checkNats(),
       this.checkMinio(),
     ]);
 
-    const checks = { postgres, nats, minio };
-    const allUp = Object.values(checks).every((c) => c.status === "up");
-    const allDown = Object.values(checks).every((c) => c.status === "down");
+    const checks: HealthStatus["checks"] = { nats, minio };
+    if (postgres) {
+      checks.postgres = postgres;
+    }
+
+    const values = Object.values(checks) as ComponentHealth[];
+    const allUp = values.every((c) => c.status === "up");
+    const allDown = values.every((c) => c.status === "down");
 
     return {
       status: allUp ? "ok" : allDown ? "unhealthy" : "degraded",


### PR DESCRIPTION
## Summary

- Readiness probes fire every 10s by default under Kubernetes. Running \`SELECT 1\` on every probe keeps the Postgres connection hot, which is unfriendly to Postgres providers that bill compute on idle connections and can burn through a free tier with no real traffic.
- Database check is now **off by default**. Set \`HEALTH_CHECK_DATABASE=true\` to restore the previous behavior for setups that want pod traffic gated on deep dependency health.

## Test plan

- [x] \`yarn build\` clean
- [ ] Post-deploy: \`/health/ready\` returns 200 with only \`nats\` and \`minio\` in checks; no more \`Postgres health check failed\` lines in the API logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Added environment variable configuration to toggle database health checks
* Database health checks are now optional components in system readiness probes, enabling flexible deployment configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->