### PR TITLE
Release v1.13.4

### DIFF
--- a/api/src/config/configuration.ts
+++ b/api/src/config/configuration.ts
@@ -29,4 +29,9 @@ export default () => ({
   // JWT configuration
   JWT_SECRET: process.env.JWT_SECRET,
   JWT_EXPIRES_IN: process.env.JWT_EXPIRES_IN || "24h",
+
+  // Readiness probe checks. Off by default to stay friendly to Postgres
+  // providers that bill compute time on idle connections. Enable when
+  // you want Kubernetes to gate pod traffic on deep dependency health.
+  HEALTH_CHECK_DATABASE: process.env.HEALTH_CHECK_DATABASE === "true",
 });

--- a/api/src/health/health.service.ts
+++ b/api/src/health/health.service.ts
@@ -11,7 +11,7 @@ import * as Minio from "minio";
 export interface HealthStatus {
   status: "ok" | "degraded" | "unhealthy";
   checks: {
-    postgres: ComponentHealth;
+    postgres?: ComponentHealth;
     nats: ComponentHealth;
     minio: ComponentHealth;
   };
@@ -26,6 +26,7 @@ interface ComponentHealth {
 @Injectable()
 export class HealthService {
   private readonly minioBucket: string;
+  private readonly checkDatabase: boolean;
 
   constructor(
     private readonly natsService: NatsService,
@@ -35,6 +36,8 @@ export class HealthService {
   ) {
     this.minioBucket =
       this.configService.get<string>("CUSTOM_BOTS_BUCKET") || "custom-bots";
+    this.checkDatabase =
+      this.configService.get<boolean>("HEALTH_CHECK_DATABASE") === true;
   }
 
   async getLiveness(): Promise<{ status: "ok" }> {
@@ -43,14 +46,19 @@ export class HealthService {
 
   async getReadiness(): Promise<HealthStatus> {
     const [postgres, nats, minio] = await Promise.all([
-      this.checkPostgres(),
+      this.checkDatabase ? this.checkPostgres() : Promise.resolve(undefined),
       this.checkNats(),
       this.checkMinio(),
     ]);
 
-    const checks = { postgres, nats, minio };
-    const allUp = Object.values(checks).every((c) => c.status === "up");
-    const allDown = Object.values(checks).every((c) => c.status === "down");
+    const checks: HealthStatus["checks"] = { nats, minio };
+    if (postgres) {
+      checks.postgres = postgres;
+    }
+
+    const values = Object.values(checks) as ComponentHealth[];
+    const allUp = values.every((c) => c.status === "up");
+    const allDown = values.every((c) => c.status === "down");
 
     return {
       status: allUp ? "ok" : allDown ? "unhealthy" : "degraded",

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: the0
 description: An open-source algorithmic trading platform for creating, deploying, and managing trading bots
 type: application
-version: 0.8.2
-appVersion: "1.13.3"
+version: 0.8.3
+appVersion: "1.13.4"
 kubeVersion: ">=1.21.0-0"
 keywords:
   - trading
@@ -31,7 +31,7 @@ annotations:
       url: https://discord.gg/g5mp57nK
   artifacthub.io/changes: |
     - kind: added
-      description: Environments page in the docs site CLI sidebar
+      description: HEALTH_CHECK_DATABASE env var to opt in to database readiness probe (off by default)
   artifacthub.io/images: |
     - name: api
       image: ghcr.io/alexanderwanyoike/the0/api


### PR DESCRIPTION
## Summary

Patch release that makes the database readiness check opt-in (#269).

- `/health/ready` no longer runs `SELECT 1` on every probe by default. That 10s-interval probe was keeping connections hot around the clock, which burns through free-tier compute on Postgres providers that bill idle time.
- New env var `HEALTH_CHECK_DATABASE=true` restores the previous behavior for setups that want Kubernetes to gate pod traffic on deep dependency health.
- Readiness now reports only `nats` and `minio` unless the DB check is opted in.

Chart bumped to **0.8.3 / appVersion 1.13.4**.

## Test plan

- [x] `yarn build` on api clean
- [x] Post-deploy: `/health/ready` returns 200 with only `nats` and `minio` in `checks`; no more `Postgres health check failed` lines in the API logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)