### PR TITLE
feat(runtime): --skip-init and --debug-port flags for local dev

### DIFF
--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -49,6 +49,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && ln -sf /usr/bin/python3.11 /usr/bin/python3 \
     && ln -sf /usr/bin/python3.11 /usr/bin/python
 
+# debugpy: required for `runtime execute --debug-port` to work with Python
+# bots. Pre-installed here (rather than pip-install-on-first-run) so the
+# dev experience is fast and reproducible. Node's --inspect is built in,
+# so no equivalent needed for nodejs20.
+RUN python3.11 -m ensurepip --upgrade \
+    && python3.11 -m pip install --no-cache-dir --break-system-packages debugpy
+
 # Node.js 20 LTS
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \

--- a/runtime/cmd/app/execute.go
+++ b/runtime/cmd/app/execute.go
@@ -56,6 +56,8 @@ var (
 	executeSkipSync        bool
 	executeSkipQueryServer bool
 	executeSkipInit        bool
+	executeDebugPort       int  // 0 = disabled
+	executeDebugWait       bool // only meaningful when executeDebugPort > 0
 )
 
 // Function variables for the init phase: exposed at package scope so tests
@@ -73,7 +75,21 @@ func init() {
 	executeCmd.Flags().BoolVar(&executeSkipSync, "skip-sync", false, "Skip starting sync subprocess (for K8s where sync is a sidecar)")
 	executeCmd.Flags().BoolVar(&executeSkipQueryServer, "skip-query-server", false, "Skip starting query server subprocess (for K8s where query is a sidecar)")
 	executeCmd.Flags().BoolVar(&executeSkipInit, "skip-init", false, "Skip MinIO code/state download (code already mounted, for local dev)")
+	executeCmd.Flags().IntVar(&executeDebugPort, "debug-port", 0, "Launch entrypoint under a debugger on this port, bypassing the wrapper (0 = disabled)")
+	executeCmd.Flags().BoolVar(&executeDebugWait, "debug-wait", false, "With --debug-port: wait for debugger attach before running (python --wait-for-client / node --inspect-brk)")
 	rootCmd.AddCommand(executeCmd)
+}
+
+// buildBotCommandForMode returns the wrapper-bypass debug command when
+// --debug-port is set, otherwise the production wrapper command. Debug
+// mode loses the wrapper's result.json writing (acceptable for local dev);
+// all other runtime concerns (state, query server, signal forwarding) are
+// unaffected because they live outside the bot command itself.
+func buildBotCommandForMode(cfg *execute.Config, entrypoint string) *exec.Cmd {
+	if executeDebugPort > 0 {
+		return execute.BuildBotDebugCommand(cfg.Runtime, entrypoint, cfg.CodePath, executeDebugPort, executeDebugWait)
+	}
+	return execute.BuildBotCommand(cfg.Runtime, entrypoint, cfg.CodePath)
 }
 
 // runInitPhase performs the download+permissions pre-run steps unless skip
@@ -468,7 +484,7 @@ func executeProcessWithLogFile(ctx context.Context, cfg *execute.Config, entrypo
 
 // executeProcessWithDeps executes a process with injectable dependencies for testing.
 func executeProcessWithDeps(ctx context.Context, cfg *execute.Config, entrypoint string, logger *util.DefaultLogger, logFile *os.File, deps execute.Dependencies) int {
-	cmd := execute.BuildBotCommand(cfg.Runtime, entrypoint, cfg.CodePath)
+	cmd := buildBotCommandForMode(cfg, entrypoint)
 
 	// Set up output: both stdout and optionally log file
 	if logFile != nil {

--- a/runtime/cmd/app/execute.go
+++ b/runtime/cmd/app/execute.go
@@ -55,6 +55,16 @@ var (
 	executeQueryServerOnly bool
 	executeSkipSync        bool
 	executeSkipQueryServer bool
+	executeSkipInit        bool
+)
+
+// Function variables for the init phase: exposed at package scope so tests
+// can swap them to assert call counts without wiring a full dependency-
+// injection harness. Production callers go through runInitPhase.
+var (
+	downloadCodeFn     = downloadCode
+	downloadStateFn    = downloadState
+	ensureExecutableFn = execute.EnsureExecutable
 )
 
 func init() {
@@ -62,7 +72,30 @@ func init() {
 	executeCmd.Flags().BoolVar(&executeQueryServerOnly, "query-server-only", false, "Run only the query server (for K8s sidecar mode)")
 	executeCmd.Flags().BoolVar(&executeSkipSync, "skip-sync", false, "Skip starting sync subprocess (for K8s where sync is a sidecar)")
 	executeCmd.Flags().BoolVar(&executeSkipQueryServer, "skip-query-server", false, "Skip starting query server subprocess (for K8s where query is a sidecar)")
+	executeCmd.Flags().BoolVar(&executeSkipInit, "skip-init", false, "Skip MinIO code/state download (code already mounted, for local dev)")
 	rootCmd.AddCommand(executeCmd)
+}
+
+// runInitPhase performs the download+permissions pre-run steps unless skip
+// is true. Skip is used by local dev mode (`--skip-init`) where code is
+// already mounted into /bot and state is host-persistent at /state, so
+// reaching MinIO is both unnecessary and noisy.
+func runInitPhase(ctx context.Context, cfg *execute.Config, logger *util.DefaultLogger, skip bool) error {
+	if skip {
+		logger.Info("Skipping init (--skip-init flag set)")
+		return nil
+	}
+	if err := downloadCodeFn(ctx, cfg, logger); err != nil {
+		return err
+	}
+	if err := ensureExecutableFn(cfg); err != nil {
+		logger.Info("Warning: failed to set execute permissions: %v", err)
+	}
+	if err := downloadStateFn(ctx, cfg, logger); err != nil {
+		// State may not exist on first run - log but continue.
+		logger.Info("No existing state or download failed: %v", err)
+	}
+	return nil
 }
 
 // loadExecuteConfig loads configuration from environment variables.
@@ -176,22 +209,11 @@ func runBot(cfg *execute.Config, logger *util.DefaultLogger) int {
 		cancel()
 	}()
 
-	// Step 1: Download code
-	if err := downloadCode(ctx, cfg, logger); err != nil {
-		logger.Info("Failed to download code: %v", err)
+	// Steps 1-2: code download, executable permissions, state download.
+	// Gated as a unit so `--skip-init` (local dev) bypasses all of them.
+	if err := runInitPhase(ctx, cfg, logger, executeSkipInit); err != nil {
+		logger.Info("Init phase failed: %v", err)
 		return 1
-	}
-
-	// Step 1.5: Ensure binaries are executable for compiled runtimes
-	if err := execute.EnsureExecutable(cfg); err != nil {
-		logger.Info("Warning: failed to set execute permissions: %v", err)
-		// Continue anyway - may work if permissions are already set
-	}
-
-	// Step 2: Download state
-	if err := downloadState(ctx, cfg, logger); err != nil {
-		// State may not exist on first run - log but continue
-		logger.Info("No existing state or download failed: %v", err)
 	}
 
 	// Step 2.5: Ensure logs directory exists

--- a/runtime/cmd/app/execute.go
+++ b/runtime/cmd/app/execute.go
@@ -92,6 +92,16 @@ func buildBotCommandForMode(cfg *execute.Config, entrypoint string) *exec.Cmd {
 	return execute.BuildBotCommand(cfg.Runtime, entrypoint, cfg.CodePath)
 }
 
+// shouldStartQueryServer centralises the criteria for spawning the
+// in-container query-server subprocess: realtime bots with a query
+// entrypoint, unless --skip-query-server has been passed (K8s sidecar
+// mode). Debug mode intentionally does not affect this decision — local
+// dev users need queries to continue flowing while they're attached to
+// the bot with a debugger.
+func shouldStartQueryServer(cfg *execute.Config) bool {
+	return cfg.BotType == "realtime" && cfg.QueryEntrypoint != "" && !executeSkipQueryServer
+}
+
 // runInitPhase performs the download+permissions pre-run steps unless skip
 // is true. Skip is used by local dev mode (`--skip-init`) where code is
 // already mounted into /bot and state is host-persistent at /state, so
@@ -263,7 +273,7 @@ func runBot(cfg *execute.Config, logger *util.DefaultLogger) int {
 	}
 
 	// Step 4: Start query server subprocess (for realtime bots, unless skipped)
-	if cfg.BotType == "realtime" && cfg.QueryEntrypoint != "" && !executeSkipQueryServer {
+	if shouldStartQueryServer(cfg) {
 		var err error
 		queryCmd, err = startQueryServerProcess(cfg, logger)
 		if err != nil {

--- a/runtime/cmd/app/execute_test.go
+++ b/runtime/cmd/app/execute_test.go
@@ -141,3 +141,61 @@ func TestExecuteDebugFlagsRegistered(t *testing.T) {
 		assert.Equal(t, "false", wait.DefValue)
 	}
 }
+
+// TestShouldStartQueryServer_RealtimeWithQueryEntrypoint is the baseline:
+// realtime bot + query entrypoint + default flags => query server starts.
+func TestShouldStartQueryServer_RealtimeWithQueryEntrypoint(t *testing.T) {
+	origSkip := executeSkipQueryServer
+	defer func() { executeSkipQueryServer = origSkip }()
+	executeSkipQueryServer = false
+
+	cfg := &execute.Config{BotType: "realtime", QueryEntrypoint: "query.py"}
+	assert.True(t, shouldStartQueryServer(cfg))
+}
+
+// TestShouldStartQueryServer_DebugPortDoesNotInterfere locks in the
+// invariant that debug mode preserves the query server decision. This is
+// important for local dev where the user is debugging the bot/dashboard
+// integration and needs queries to still work end-to-end.
+func TestShouldStartQueryServer_DebugPortDoesNotInterfere(t *testing.T) {
+	origPort := executeDebugPort
+	origSkip := executeSkipQueryServer
+	defer func() {
+		executeDebugPort = origPort
+		executeSkipQueryServer = origSkip
+	}()
+	executeDebugPort = 5678
+	executeSkipQueryServer = false
+
+	cfg := &execute.Config{BotType: "realtime", QueryEntrypoint: "query.py"}
+	assert.True(t, shouldStartQueryServer(cfg), "debug mode must not disable query server")
+}
+
+// TestShouldStartQueryServer_SkipFlagDisables verifies the explicit skip
+// flag still works (K8s sidecar mode).
+func TestShouldStartQueryServer_SkipFlagDisables(t *testing.T) {
+	origSkip := executeSkipQueryServer
+	defer func() { executeSkipQueryServer = origSkip }()
+	executeSkipQueryServer = true
+
+	cfg := &execute.Config{BotType: "realtime", QueryEntrypoint: "query.py"}
+	assert.False(t, shouldStartQueryServer(cfg))
+}
+
+// TestShouldStartQueryServer_ScheduledBotNoServer ensures scheduled bots
+// (which don't expose a live query server) are correctly excluded.
+func TestShouldStartQueryServer_ScheduledBotNoServer(t *testing.T) {
+	cfg := &execute.Config{BotType: "scheduled", QueryEntrypoint: "query.py"}
+	assert.False(t, shouldStartQueryServer(cfg))
+}
+
+// TestShouldStartQueryServer_NoQueryEntrypoint ensures realtime bots
+// without a query entrypoint don't spin up an idle query server.
+func TestShouldStartQueryServer_NoQueryEntrypoint(t *testing.T) {
+	origSkip := executeSkipQueryServer
+	defer func() { executeSkipQueryServer = origSkip }()
+	executeSkipQueryServer = false
+
+	cfg := &execute.Config{BotType: "realtime", QueryEntrypoint: ""}
+	assert.False(t, shouldStartQueryServer(cfg))
+}

--- a/runtime/cmd/app/execute_test.go
+++ b/runtime/cmd/app/execute_test.go
@@ -90,3 +90,54 @@ func TestExecuteSkipInitFlagRegistered(t *testing.T) {
 		assert.Equal(t, "false", f.DefValue)
 	}
 }
+
+// TestBuildBotCommandForMode_DebugPortPositive_UsesDebugCommand asserts that
+// when executeDebugPort is set, the runtime builds the wrapper-bypassing
+// debug command (python -m debugpy ... / node --inspect ...) instead of the
+// wrapper-based production command.
+func TestBuildBotCommandForMode_DebugPortPositive_UsesDebugCommand(t *testing.T) {
+	origPort := executeDebugPort
+	origWait := executeDebugWait
+	defer func() {
+		executeDebugPort = origPort
+		executeDebugWait = origWait
+	}()
+	executeDebugPort = 5678
+	executeDebugWait = false
+
+	cfg := &execute.Config{Runtime: "python3.11", CodePath: "/bot"}
+	cmd := buildBotCommandForMode(cfg, "main.py")
+
+	expected := execute.BuildBotDebugCommand("python3.11", "main.py", "/bot", 5678, false)
+	assert.Equal(t, expected.Args, cmd.Args)
+	assert.Equal(t, expected.Dir, cmd.Dir)
+}
+
+// TestBuildBotCommandForMode_DebugPortZero_UsesWrapperCommand is the
+// regression guard: default (0) port must still route to the production
+// wrapper invocation so real deployments are not silently debug-enabled.
+func TestBuildBotCommandForMode_DebugPortZero_UsesWrapperCommand(t *testing.T) {
+	origPort := executeDebugPort
+	defer func() { executeDebugPort = origPort }()
+	executeDebugPort = 0
+
+	cfg := &execute.Config{Runtime: "python3.11", CodePath: "/bot"}
+	cmd := buildBotCommandForMode(cfg, "main.py")
+
+	expected := execute.BuildBotCommand("python3.11", "main.py", "/bot")
+	assert.Equal(t, expected.Args, cmd.Args)
+	assert.Equal(t, expected.Dir, cmd.Dir)
+}
+
+// TestExecuteDebugFlagsRegistered asserts both --debug-port and --debug-wait
+// are registered with the expected defaults.
+func TestExecuteDebugFlagsRegistered(t *testing.T) {
+	port := executeCmd.Flags().Lookup("debug-port")
+	if assert.NotNil(t, port, "--debug-port must be registered") {
+		assert.Equal(t, "0", port.DefValue)
+	}
+	wait := executeCmd.Flags().Lookup("debug-wait")
+	if assert.NotNil(t, wait, "--debug-wait must be registered") {
+		assert.Equal(t, "false", wait.DefValue)
+	}
+}

--- a/runtime/cmd/app/execute_test.go
+++ b/runtime/cmd/app/execute_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"runtime/internal/execute"
+	"runtime/internal/util"
+)
+
+// TestInitPhase_SkipTrue_DoesNotCallDownloadsOrEnsureExecutable asserts that
+// with skip=true, runInitPhase returns nil immediately and invokes neither
+// downloadCode, downloadState, nor EnsureExecutable. This is the core
+// contract of the --skip-init flag for local dev mode where code is
+// already mounted and state is host-persistent.
+func TestInitPhase_SkipTrue_DoesNotCallDownloadsOrEnsureExecutable(t *testing.T) {
+	var codeCalls, stateCalls, ensureCalls int
+
+	origCode := downloadCodeFn
+	origState := downloadStateFn
+	origEnsure := ensureExecutableFn
+	defer func() {
+		downloadCodeFn = origCode
+		downloadStateFn = origState
+		ensureExecutableFn = origEnsure
+	}()
+
+	downloadCodeFn = func(_ context.Context, _ *execute.Config, _ *util.DefaultLogger) error {
+		codeCalls++
+		return nil
+	}
+	downloadStateFn = func(_ context.Context, _ *execute.Config, _ *util.DefaultLogger) error {
+		stateCalls++
+		return nil
+	}
+	ensureExecutableFn = func(_ *execute.Config) error {
+		ensureCalls++
+		return nil
+	}
+
+	err := runInitPhase(context.Background(), &execute.Config{BotID: "t"}, &util.DefaultLogger{}, true)
+
+	assert.NoError(t, err)
+	assert.Zero(t, codeCalls, "downloadCode must not be called when skip=true")
+	assert.Zero(t, stateCalls, "downloadState must not be called when skip=true")
+	assert.Zero(t, ensureCalls, "ensureExecutable must not be called when skip=true")
+}
+
+// TestInitPhase_SkipFalse_CallsAllPhases asserts the default path still runs
+// downloadCode, EnsureExecutable, and downloadState in order. Regression guard
+// against accidentally gating production code paths behind the flag.
+func TestInitPhase_SkipFalse_CallsAllPhases(t *testing.T) {
+	var order []string
+
+	origCode := downloadCodeFn
+	origState := downloadStateFn
+	origEnsure := ensureExecutableFn
+	defer func() {
+		downloadCodeFn = origCode
+		downloadStateFn = origState
+		ensureExecutableFn = origEnsure
+	}()
+
+	downloadCodeFn = func(_ context.Context, _ *execute.Config, _ *util.DefaultLogger) error {
+		order = append(order, "code")
+		return nil
+	}
+	downloadStateFn = func(_ context.Context, _ *execute.Config, _ *util.DefaultLogger) error {
+		order = append(order, "state")
+		return nil
+	}
+	ensureExecutableFn = func(_ *execute.Config) error {
+		order = append(order, "ensure")
+		return nil
+	}
+
+	err := runInitPhase(context.Background(), &execute.Config{BotID: "t"}, &util.DefaultLogger{}, false)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"code", "ensure", "state"}, order)
+}
+
+// TestExecuteSkipInitFlagRegistered asserts that cobra registers --skip-init
+// with the expected default (false) so users can pass it via CLI.
+func TestExecuteSkipInitFlagRegistered(t *testing.T) {
+	f := executeCmd.Flags().Lookup("skip-init")
+	if assert.NotNil(t, f, "--skip-init flag must be registered on executeCmd") {
+		assert.Equal(t, "false", f.DefValue)
+	}
+}

--- a/runtime/internal/execute/helpers.go
+++ b/runtime/internal/execute/helpers.go
@@ -67,6 +67,33 @@ func BuildBotCommand(runtime, entrypoint, workDir string) *exec.Cmd {
 	return cmd
 }
 
+// BuildBotDebugCommand creates an exec.Cmd that runs the bot entrypoint
+// under a debugger, bypassing the Python/Node wrapper scripts.
+//
+// Used by `runtime execute --debug-port <p>` for local dev mode. The wrapper
+// scripts at /app/wrappers/ own signal handling, config parsing, and result
+// file writing in production — all of which are unnecessary for dev mode
+// where the user is attaching an IDE debugger. This escape hatch keeps the
+// wrappers themselves untouched while still delivering breakpoint debugging.
+//
+// For runtimes without breakpoint-debug support (rust, c++, haskell, .NET,
+// scala in v1), falls back to BuildBotCommand unchanged.
+func BuildBotDebugCommand(runtime, entrypoint, workDir string, port int, wait bool) *exec.Cmd {
+	switch runtime {
+	case "python3.11":
+		scriptPath := filepath.Join(workDir, entrypoint)
+		args := []string{"-m", "debugpy", "--listen", fmt.Sprintf("0.0.0.0:%d", port)}
+		if wait {
+			args = append(args, "--wait-for-client")
+		}
+		args = append(args, scriptPath)
+		cmd := exec.Command("python3", args...)
+		cmd.Dir = workDir
+		return cmd
+	}
+	return BuildBotCommand(runtime, entrypoint, workDir)
+}
+
 // BuildQueryCommand creates an exec.Cmd for query execution.
 // Queries run directly without wrappers - the SDK handles everything.
 func BuildQueryCommand(runtime, entrypoint, workDir string) *exec.Cmd {

--- a/runtime/internal/execute/helpers.go
+++ b/runtime/internal/execute/helpers.go
@@ -90,6 +90,15 @@ func BuildBotDebugCommand(runtime, entrypoint, workDir string, port int, wait bo
 		cmd := exec.Command("python3", args...)
 		cmd.Dir = workDir
 		return cmd
+	case "nodejs20":
+		scriptPath := filepath.Join(workDir, entrypoint)
+		flag := "--inspect"
+		if wait {
+			flag = "--inspect-brk"
+		}
+		cmd := exec.Command("node", fmt.Sprintf("%s=0.0.0.0:%d", flag, port), scriptPath)
+		cmd.Dir = workDir
+		return cmd
 	}
 	return BuildBotCommand(runtime, entrypoint, workDir)
 }

--- a/runtime/internal/execute/helpers_test.go
+++ b/runtime/internal/execute/helpers_test.go
@@ -155,6 +155,24 @@ func TestBuildBotDebugCommand_NodeJS_WithWait(t *testing.T) {
 	assert.Equal(t, constants.TestBotDir, cmd.Dir)
 }
 
+// TestBuildBotDebugCommand_UnsupportedRuntime_FallsBack asserts that runtimes
+// without a breakpoint-debug integration in v1 (Rust, C++, Haskell, .NET,
+// Scala) produce the same command as BuildBotCommand when debug is requested.
+// This preserves the option to request debug for a compiled-language bot
+// without changing the execution shape (phase 2 will extend this).
+func TestBuildBotDebugCommand_UnsupportedRuntime_FallsBack(t *testing.T) {
+	unsupported := []string{"rust-stable", "gcc13", "cpp-gcc13", "ghc96", "dotnet8", "scala3"}
+	for _, rt := range unsupported {
+		t.Run(rt, func(t *testing.T) {
+			debug := BuildBotDebugCommand(rt, "app", constants.TestBotDir, 5678, false)
+			normal := BuildBotCommand(rt, "app", constants.TestBotDir)
+
+			assert.Equal(t, normal.Args, debug.Args, "debug argv should equal BuildBotCommand argv for unsupported runtimes")
+			assert.Equal(t, normal.Dir, debug.Dir)
+		})
+	}
+}
+
 func TestBuildQueryCommand_Python(t *testing.T) {
 	cmd := BuildQueryCommand("python3.11", "query.py", constants.TestBotDir)
 

--- a/runtime/internal/execute/helpers_test.go
+++ b/runtime/internal/execute/helpers_test.go
@@ -141,6 +141,13 @@ func TestBuildBotDebugCommand_Python_WithWait(t *testing.T) {
 	assert.Equal(t, constants.TestBotDir, cmd.Dir)
 }
 
+func TestBuildBotDebugCommand_NodeJS_Basic(t *testing.T) {
+	cmd := BuildBotDebugCommand("nodejs20", "main.js", constants.TestBotDir, 9229, false)
+
+	assert.Equal(t, []string{"node", "--inspect=0.0.0.0:9229", "/bot/main.js"}, cmd.Args)
+	assert.Equal(t, constants.TestBotDir, cmd.Dir)
+}
+
 func TestBuildQueryCommand_Python(t *testing.T) {
 	cmd := BuildQueryCommand("python3.11", "query.py", constants.TestBotDir)
 

--- a/runtime/internal/execute/helpers_test.go
+++ b/runtime/internal/execute/helpers_test.go
@@ -134,6 +134,13 @@ func TestBuildBotDebugCommand_Python_Basic(t *testing.T) {
 	assert.Equal(t, constants.TestBotDir, cmd.Dir)
 }
 
+func TestBuildBotDebugCommand_Python_WithWait(t *testing.T) {
+	cmd := BuildBotDebugCommand("python3.11", "main.py", constants.TestBotDir, 5678, true)
+
+	assert.Equal(t, []string{"python3", "-m", "debugpy", "--listen", "0.0.0.0:5678", "--wait-for-client", "/bot/main.py"}, cmd.Args)
+	assert.Equal(t, constants.TestBotDir, cmd.Dir)
+}
+
 func TestBuildQueryCommand_Python(t *testing.T) {
 	cmd := BuildQueryCommand("python3.11", "query.py", constants.TestBotDir)
 

--- a/runtime/internal/execute/helpers_test.go
+++ b/runtime/internal/execute/helpers_test.go
@@ -148,6 +148,13 @@ func TestBuildBotDebugCommand_NodeJS_Basic(t *testing.T) {
 	assert.Equal(t, constants.TestBotDir, cmd.Dir)
 }
 
+func TestBuildBotDebugCommand_NodeJS_WithWait(t *testing.T) {
+	cmd := BuildBotDebugCommand("nodejs20", "main.js", constants.TestBotDir, 9229, true)
+
+	assert.Equal(t, []string{"node", "--inspect-brk=0.0.0.0:9229", "/bot/main.js"}, cmd.Args)
+	assert.Equal(t, constants.TestBotDir, cmd.Dir)
+}
+
 func TestBuildQueryCommand_Python(t *testing.T) {
 	cmd := BuildQueryCommand("python3.11", "query.py", constants.TestBotDir)
 

--- a/runtime/internal/execute/helpers_test.go
+++ b/runtime/internal/execute/helpers_test.go
@@ -127,6 +127,13 @@ func TestBuildBotCommand_AllRuntimes(t *testing.T) {
 	}
 }
 
+func TestBuildBotDebugCommand_Python_Basic(t *testing.T) {
+	cmd := BuildBotDebugCommand("python3.11", "main.py", constants.TestBotDir, 5678, false)
+
+	assert.Equal(t, []string{"python3", "-m", "debugpy", "--listen", "0.0.0.0:5678", "/bot/main.py"}, cmd.Args)
+	assert.Equal(t, constants.TestBotDir, cmd.Dir)
+}
+
 func TestBuildQueryCommand_Python(t *testing.T) {
 	cmd := BuildQueryCommand("python3.11", "query.py", constants.TestBotDir)
 


### PR DESCRIPTION
## Summary

Adds two opt-in flags to \`runtime execute\` that enable \`the0/runtime:latest\` to be driven by the CLI's new \`the0 dev\` command (PR to follow on \`feature/the0-dev\`). Both flags are no-ops by default; production Docker and K8s paths are unaffected.

- \`--skip-init\`: skip MinIO code/state download (code already mounted via \`-v local:/bot\`, state is host-persistent at \`/state\`).
- \`--debug-port <p>\` + \`--debug-wait\`: launch the entrypoint under \`debugpy\` (Python) or \`--inspect\`/\`--inspect-brk\` (Node), bypassing the Python/Node wrapper scripts which have no debug integration and are off-limits per project convention.

## Why

The upcoming \`the0 dev\` CLI feature delegates bot execution to this image rather than reimplementing 7 per-language Docker dispatchers in the CLI. To make that possible:

- \`runBot\` currently always downloads from MinIO; for local dev we need a clean bypass. The existing \`storage.DownloadCode\` already no-ops on empty \`CODE_FILE\`, but \`--skip-init\` makes the intent explicit and skips state-download noise too.
- Breakpoint debugging is a core dev need. The wrappers at \`runtime/wrappers/*\` own signal handling, \`BOT_CONFIG\` parsing, and \`result.json\` writing in production — and must not be modified. A runtime-binary-level escape hatch (bypass wrapper, launch under debugger) is the right layer to solve this. Debug mode loses \`result.json\` writing (fine for dev); state, query server, and signal handling are all preserved because they live outside the bot command itself.

Key invariant locked in by tests: \`--debug-port\` does NOT disable the query server. Users of \`the0 dev --debug\` are specifically debugging the bot ↔ dashboard ↔ query integration; silently disabling queries in debug mode would defeat the tool's purpose.

## Changes

### \`runtime/internal/execute/helpers.go\`
- New \`BuildBotDebugCommand(runtime, entrypoint, workDir, port, wait)\`:
  - \`python3.11\` → \`python3 -m debugpy --listen 0.0.0.0:<port> [--wait-for-client] <workDir>/<entrypoint>\`
  - \`nodejs20\` → \`node --inspect[-brk]=0.0.0.0:<port> <workDir>/<entrypoint>\`
  - Unsupported runtimes (Rust, C++, Haskell, .NET, Scala): fall back to \`BuildBotCommand\`

### \`runtime/cmd/app/execute.go\`
- Three new flags: \`--skip-init\`, \`--debug-port\`, \`--debug-wait\` (all opt-in, defaults preserve production behavior).
- \`runInitPhase(ctx, cfg, logger, skip)\` helper encapsulates the code-download / permissions / state-download block, gated by \`--skip-init\`.
- \`buildBotCommandForMode(cfg, entrypoint)\` picks between wrapper-based and wrapper-bypass commands based on \`--debug-port\`.
- \`shouldStartQueryServer(cfg)\` centralises the query-subprocess decision (explicitly independent of debug mode).
- Downloads and \`EnsureExecutable\` are now invoked via function variables (\`downloadCodeFn\`, \`downloadStateFn\`, \`ensureExecutableFn\`) to enable unit testing without full DI surgery.

### Tests (TDD, one behaviour per commit)
- \`helpers_test.go\`: Python basic + \`--wait-for-client\`, Node basic + \`--inspect-brk\`, fallback coverage for all compiled runtimes.
- \`cmd/app/execute_test.go\` (new): \`runInitPhase\` skip / no-skip behaviour, both debug-flag registrations, \`buildBotCommandForMode\` branching, five cases for \`shouldStartQueryServer\` (including the \"debug doesn't interfere\" invariant).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` all packages pass
- [x] \`go test -race ./internal/execute ./cmd/app\` clean (pre-existing race in \`internal/k8s/controller\` is unrelated)
- [ ] Rebuild runtime image (\`the0 local build-images\`) and smoke \`docker run the0/runtime:latest execute --skip-init --skip-sync --debug-port 5678 ...\` against a Python bot; verify debugpy listens on 5678 inside the container.

## Follow-up

This PR unlocks the \`the0 dev\` CLI rewrite on \`feature/the0-dev\` (PR #268), which will delete ~1,400 LOC of duplicated per-language Docker dispatchers and delegate to \`runtime execute\` with these flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--skip-init`, `--debug-port`, and `--debug-wait` CLI flags to control initialization and debugging behavior
  * Introduced local breakpoint debugging support for Python 3.11 and Node.js 20 runtimes

* **Tests**
  * Added comprehensive test coverage for initialization phase, CLI flag registration, debug command selection, and query server startup logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->