### PR TITLE
Harden container images and pod runtime security

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -64,6 +64,13 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Log in to Docker Hardened Images
+      uses: docker/login-action@v3
+      with:
+        registry: dhi.io
+        username: ${{ secrets.DHI_USERNAME }}
+        password: ${{ secrets.DHI_TOKEN }}
+
     - name: Extract metadata
       id: meta
       uses: docker/metadata-action@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,6 +64,13 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Log in to Docker Hardened Images
+      uses: docker/login-action@v3
+      with:
+        registry: dhi.io
+        username: ${{ secrets.DHI_USERNAME }}
+        password: ${{ secrets.DHI_TOKEN }}
+
     - name: Extract metadata
       id: meta
       uses: docker/metadata-action@v5

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -68,6 +68,13 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Log in to Docker Hardened Images
+      uses: docker/login-action@v3
+      with:
+        registry: dhi.io
+        username: ${{ secrets.DHI_USERNAME }}
+        password: ${{ secrets.DHI_TOKEN }}
+
     - name: Extract metadata
       id: meta
       uses: docker/metadata-action@v5

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -36,6 +36,13 @@ jobs:
       working-directory: ./runtime
       run: go mod download
 
+    - name: Log in to Docker Hardened Images
+      uses: docker/login-action@v3
+      with:
+        registry: dhi.io
+        username: ${{ secrets.DHI_USERNAME }}
+        password: ${{ secrets.DHI_TOKEN }}
+
     - name: Build runtime image for integration tests
       run: docker build -t the0/runtime:latest ./runtime
 
@@ -65,6 +72,13 @@ jobs:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Log in to Docker Hardened Images
+      uses: docker/login-action@v3
+      with:
+        registry: dhi.io
+        username: ${{ secrets.DHI_USERNAME }}
+        password: ${{ secrets.DHI_TOKEN }}
 
     - name: Extract metadata
       id: meta

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -73,6 +73,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Log in to Docker Hardened Images
+        uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DHI_USERNAME }}
+          password: ${{ secrets.DHI_TOKEN }}
+
       - name: Run image scan
         run: bash .github/scripts/security/trivy-image-job.sh "api" "the0-security-api:ci" "./api/Dockerfile" "./api"
 
@@ -95,6 +102,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Log in to Docker Hardened Images
+        uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DHI_USERNAME }}
+          password: ${{ secrets.DHI_TOKEN }}
+
       - name: Run image scan
         run: bash .github/scripts/security/trivy-image-job.sh "frontend" "the0-security-frontend:ci" "./frontend/Dockerfile" "./frontend"
 
@@ -116,6 +130,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Log in to Docker Hardened Images
+        uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DHI_USERNAME }}
+          password: ${{ secrets.DHI_TOKEN }}
 
       - name: Run image scan
         env:
@@ -141,6 +162,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Log in to Docker Hardened Images
+        uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DHI_USERNAME }}
+          password: ${{ secrets.DHI_TOKEN }}
 
       - name: Run image scan
         run: bash .github/scripts/security/trivy-image-job.sh "docs" "the0-security-docs:ci" "./docs/Dockerfile" "./docs"

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
-# Use Node.js 20 as specified in package.json
-FROM node:20-alpine AS base
+# Use Docker Hardened Images for build and runtime stages.
+FROM dhi.io/node:20-alpine3.22-dev AS base
 
 # Set working directory
 WORKDIR /app
@@ -16,34 +16,29 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
 RUN yarn build
+RUN mkdir -p uploads/custom-bots
 
 # Production stage
-FROM base AS runner
-RUN apk add --no-cache dumb-init
-
-# Create non-root user
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nestjs
+FROM dhi.io/node:20-alpine3.22 AS runner
+WORKDIR /app
 
 # Copy built application
-COPY --from=builder --chown=nestjs:nodejs /app/dist ./dist
-COPY --from=builder --chown=nestjs:nodejs /app/src/database/migrations ./dist/src/database/migrations
-COPY --from=builder --chown=nestjs:nodejs /app/src/database/schema ./src/database/schema
-COPY --from=builder --chown=nestjs:nodejs /app/node_modules ./node_modules
-COPY --from=builder --chown=nestjs:nodejs /app/package.json ./package.json
-COPY --from=builder --chown=nestjs:nodejs /app/drizzle.config.ts ./drizzle.config.ts
+COPY --from=builder --chown=1000:1000 /app/dist ./dist
+COPY --from=builder --chown=1000:1000 /app/src/database/migrations ./dist/src/database/migrations
+COPY --from=builder --chown=1000:1000 /app/src/database/schema ./src/database/schema
+COPY --from=builder --chown=1000:1000 /app/node_modules ./node_modules
+COPY --from=builder --chown=1000:1000 /app/package.json ./package.json
+COPY --from=builder --chown=1000:1000 /app/drizzle.config.ts ./drizzle.config.ts
+COPY --from=builder --chown=1000:1000 /app/uploads ./uploads
 
-# Create uploads directory
-RUN mkdir -p uploads/custom-bots && chown -R nestjs:nodejs uploads
-
-USER nestjs
+USER 1000:1000
 
 # Expose port
 EXPOSE 3000
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD wget -qO- http://localhost:3000/health || exit 1
+  CMD ["node", "-e", "require('http').get('http://127.0.0.1:3000/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]
 
 # Start the application
-CMD ["dumb-init", "node", "dist/src/main.js"]
+CMD ["node", "dist/src/main.js"]

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:22-alpine AS builder
+FROM dhi.io/node:22-alpine3.22-dev AS builder
 
 # Install git (required by VitePress for last updated timestamps)
 RUN apk add --no-cache git
@@ -19,7 +19,7 @@ COPY . .
 RUN yarn build
 
 # Production stage
-FROM nginx:alpine AS production
+FROM dhi.io/nginx:1.30-alpine3.23 AS production
 
 # Copy built files to nginx
 COPY --from=builder /app/.vitepress/dist /usr/share/nginx/html
@@ -27,6 +27,4 @@ COPY --from=builder /app/.vitepress/dist /usr/share/nginx/html
 # Copy nginx configuration
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
-EXPOSE 80
-
-CMD ["nginx", "-g", "daemon off;"]
+EXPOSE 8080

--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for production optimization
-FROM node:20-alpine AS base
+FROM dhi.io/node:20-alpine3.22-dev AS base
 
 # Install dependencies only when needed
 FROM base AS deps
@@ -46,34 +46,27 @@ RUN \
   fi
 
 # Production image, copy all the files and run next
-FROM base AS runner
+FROM dhi.io/node:20-alpine3.22 AS runner
 WORKDIR /app
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 # Uncomment the following line in case you want to disable telemetry during runtime.
 # ENV NEXT_TELEMETRY_DISABLED 1
 
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
-
-COPY --from=builder /app/public ./public
-
-# Set the correct permission for prerender cache
-RUN mkdir .next
-RUN chown nextjs:nodejs .next
+COPY --from=builder --chown=1000:1000 /app/public ./public
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=1000:1000 /app/.next/standalone ./
+COPY --from=builder --chown=1000:1000 /app/.next/static ./.next/static
 
-USER nextjs
+USER 1000:1000
 
 EXPOSE 3000
 
-ENV PORT 3000
+ENV PORT=3000
 # set hostname to localhost
-ENV HOSTNAME "0.0.0.0"
+ENV HOSTNAME="0.0.0.0"
 
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/next-config-js/output

--- a/k8s/templates/bot-controller.yaml
+++ b/k8s/templates/bot-controller.yaml
@@ -96,6 +96,11 @@ spec:
         app.kubernetes.io/component: bot-controller
     spec:
       serviceAccountName: {{ include "the0.fullname" . }}-bot-controller
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: bot-controller
           image: {{ .Values.botController.image.repository }}:{{ .Values.botController.image.tag | default .Chart.AppVersion }}
@@ -163,6 +168,7 @@ spec:
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
+            runAsGroup: 1000
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:

--- a/k8s/templates/the0-api.yaml
+++ b/k8s/templates/the0-api.yaml
@@ -43,6 +43,11 @@ spec:
         {{- include "the0.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: api
     spec:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: api
           image: {{ .Values.the0Api.image.repository }}:{{ .Values.the0Api.image.tag | default .Chart.AppVersion }}
@@ -102,4 +107,23 @@ spec:
             timeoutSeconds: 5
           resources:
             {{- toYaml .Values.the0Api.resources | nindent 12 }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: uploads
+              mountPath: /app/uploads
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: uploads
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
 {{- end }}

--- a/k8s/templates/the0-docs.yaml
+++ b/k8s/templates/the0-docs.yaml
@@ -42,6 +42,11 @@ spec:
         {{- include "the0.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: docs
     spec:
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: docs
           image: {{ .Values.the0Docs.image.repository }}:{{ .Values.the0Docs.image.tag | default .Chart.AppVersion }}
@@ -72,3 +77,26 @@ spec:
             timeoutSeconds: 3
           resources:
             {{- toYaml .Values.the0Docs.resources | nindent 12 }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/k8s/templates/the0-frontend.yaml
+++ b/k8s/templates/the0-frontend.yaml
@@ -42,6 +42,11 @@ spec:
         {{- include "the0.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: frontend
     spec:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: frontend
           image: {{ .Values.the0Frontend.image.repository }}:{{ .Values.the0Frontend.image.tag | default .Chart.AppVersion }}
@@ -82,3 +87,18 @@ spec:
             timeoutSeconds: 3
           resources:
             {{- toYaml .Values.the0Frontend.resources | nindent 12 }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -202,7 +202,7 @@ the0Docs:
   # GHCR image (uncomment for production)
   # image:
   #   repository: ghcr.io/alexanderwanyoike/the0/docs
-  port: 80  # nginx serves on port 80
+  port: 8080  # DHI nginx serves on unprivileged port 8080
   env:
     # Documentation configuration
     NEXT_PUBLIC_APP_NAME: "the0"

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -15,7 +15,7 @@
 #   - ghc96: Pre-compiled Haskell binaries
 
 # Stage 1: Build the runtime binary from Go source
-FROM golang:1.24-alpine AS runtime-builder
+FROM dhi.io/golang:1.24-alpine3.22-dev AS runtime-builder
 RUN apk --no-cache add make git
 WORKDIR /build
 COPY go.mod go.sum ./
@@ -89,10 +89,13 @@ RUN chmod 755 /app/wrappers/*.py /app/wrappers/*.js
 # /state - Bot persistent state (synced to MinIO)
 # /query - Query results (for ephemeral queries)
 # /var/the0/logs - Bot logs (synced to MinIO)
-RUN mkdir -p /bot /state /query /var/the0/logs
+RUN mkdir -p /bot /state /query /var/the0/logs \
+    && chown -R 1000:1000 /app /bot /state /query /var/the0
 
 # Set working directory to bot code location
 WORKDIR /bot
+
+USER 1000:1000
 
 # The execute command handles everything:
 # - Downloads code from MinIO

--- a/runtime/internal/docker/container_builder.go
+++ b/runtime/internal/docker/container_builder.go
@@ -12,6 +12,7 @@ import (
 	"runtime/internal/model"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/strslice"
 )
 
 // ContainerBuilder provides a fluent interface for building Docker container configurations.
@@ -25,6 +26,7 @@ func NewContainerBuilder(imageName string) *ContainerBuilder {
 	return &ContainerBuilder{
 		config: &container.Config{
 			Image:      imageName,
+			User:       "1000:1000",
 			StopSignal: "SIGTERM",
 			WorkingDir: "/tmp",
 			Labels:     make(map[string]string),
@@ -32,7 +34,17 @@ func NewContainerBuilder(imageName string) *ContainerBuilder {
 		},
 		hostConfig: &container.HostConfig{
 			// Default to bridge mode; use WithNetwork to join a specific network
-			NetworkMode: "bridge",
+			NetworkMode:    "bridge",
+			ReadonlyRootfs: true,
+			CapDrop:        strslice.StrSlice{"ALL"},
+			SecurityOpt:    []string{"no-new-privileges:true"},
+			Tmpfs: map[string]string{
+				"/bot":      "rw,exec,nosuid,nodev,uid=1000,gid=1000",
+				"/state":    "rw,nosuid,nodev,uid=1000,gid=1000",
+				"/query":    "rw,nosuid,nodev,uid=1000,gid=1000",
+				"/tmp":      "rw,nosuid,nodev,uid=1000,gid=1000,mode=1777",
+				"/var/the0": "rw,nosuid,nodev,uid=1000,gid=1000",
+			},
 		},
 	}
 }

--- a/runtime/internal/docker/container_builder_test.go
+++ b/runtime/internal/docker/container_builder_test.go
@@ -18,11 +18,18 @@ func TestNewContainerBuilder(t *testing.T) {
 
 	// Verify defaults
 	assert.Equal(t, "python:3.11", cfg.Image)
+	assert.Equal(t, "1000:1000", cfg.User)
 	assert.Equal(t, "SIGTERM", cfg.StopSignal)
 	assert.Equal(t, "/tmp", cfg.WorkingDir)
 	assert.NotNil(t, cfg.Labels)
 	assert.Contains(t, cfg.Env, "PYTHONDONTWRITEBYTECODE=1")
 	assert.Equal(t, container.NetworkMode("bridge"), hostCfg.NetworkMode)
+	assert.True(t, hostCfg.ReadonlyRootfs)
+	assert.Contains(t, hostCfg.CapDrop, "ALL")
+	assert.Contains(t, hostCfg.SecurityOpt, "no-new-privileges:true")
+	assert.Contains(t, hostCfg.Tmpfs, "/bot")
+	assert.Contains(t, hostCfg.Tmpfs, "/state")
+	assert.Contains(t, hostCfg.Tmpfs, "/var/the0")
 }
 
 func TestContainerBuilder_WithNetwork(t *testing.T) {
@@ -134,7 +141,7 @@ func TestContainerBuilder_WithExecutable(t *testing.T) {
 			"bot": "main.py",
 		},
 		Config: map[string]interface{}{
-			"symbol": "BTC/USD",
+			"symbol":    "BTC/USD",
 			"threshold": 100,
 		},
 		Segment: 5,
@@ -316,9 +323,9 @@ func TestContainerBuilder_WithDaemonConfigFull(t *testing.T) {
 
 func TestContainerBuilder_WithDevRuntime(t *testing.T) {
 	tests := []struct {
-		name        string
-		hostPath    string
-		expectBind  bool
+		name         string
+		hostPath     string
+		expectBind   bool
 		expectedBind string
 	}{
 		{
@@ -352,9 +359,9 @@ func TestContainerBuilder_WithDevRuntime(t *testing.T) {
 
 func TestContainerBuilder_WithQueryConfig(t *testing.T) {
 	tests := []struct {
-		name        string
-		queryPath   string
-		queryParams string
+		name         string
+		queryPath    string
+		queryParams  string
 		expectedEnvs []string
 	}{
 		{

--- a/runtime/internal/k8s/podgen/pod_builder.go
+++ b/runtime/internal/k8s/podgen/pod_builder.go
@@ -42,22 +42,24 @@ type PodBuilder struct {
 // NewPodBuilder creates a new PodBuilder with sensible defaults.
 func NewPodBuilder(name, namespace string) *PodBuilder {
 	return &PodBuilder{
-		name:          name,
-		namespace:     namespace,
-		labels:        make(map[string]string),
-		annotations:   make(map[string]string),
-		restartPolicy: corev1.RestartPolicyAlways,
-		botCommand:    []string{"/app/runtime", "execute", "--skip-sync", "--skip-query-server"},
+		name:               name,
+		namespace:          namespace,
+		labels:             make(map[string]string),
+		annotations:        make(map[string]string),
+		restartPolicy:      corev1.RestartPolicyAlways,
+		botCommand:         []string{"/app/runtime", "execute", "--skip-sync", "--skip-query-server"},
 		botImagePullPolicy: corev1.PullIfNotPresent,
 		volumes: []corev1.Volume{
 			{Name: "bot-code", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 			{Name: "bot-state", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 			{Name: "the0", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			{Name: "tmp", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		},
 		volumeMounts: []corev1.VolumeMount{
 			{Name: "bot-code", MountPath: "/bot"},
 			{Name: "bot-state", MountPath: "/state"},
 			{Name: "the0", MountPath: "/var/the0"},
+			{Name: "tmp", MountPath: "/tmp"},
 		},
 		botResources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
@@ -69,7 +71,46 @@ func NewPodBuilder(name, namespace string) *PodBuilder {
 				corev1.ResourceCPU:    resource.MustParse(DefaultCPURequest),
 			},
 		},
+		errors: []error{},
 	}
+}
+
+func hardenedContainerSecurityContext() *corev1.SecurityContext {
+	runAsUser := int64(1000)
+	runAsGroup := int64(1000)
+	readOnlyRootFilesystem := true
+	allowPrivilegeEscalation := false
+
+	return &corev1.SecurityContext{
+		RunAsNonRoot:             boolPtr(true),
+		RunAsUser:                &runAsUser,
+		RunAsGroup:               &runAsGroup,
+		ReadOnlyRootFilesystem:   &readOnlyRootFilesystem,
+		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
+}
+
+func hardenedPodSecurityContext() *corev1.PodSecurityContext {
+	runAsUser := int64(1000)
+	runAsGroup := int64(1000)
+	fsGroup := int64(1000)
+
+	return &corev1.PodSecurityContext{
+		RunAsNonRoot: boolPtr(true),
+		RunAsUser:    &runAsUser,
+		RunAsGroup:   &runAsGroup,
+		FSGroup:      &fsGroup,
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }
 
 // WithImage sets the container image for the bot.
@@ -266,6 +307,7 @@ func (b *PodBuilder) WithSyncSidecar(image string, botID string, watchDone bool)
 				corev1.ResourceCPU:    resource.MustParse("100m"),
 			},
 		},
+		SecurityContext: hardenedContainerSecurityContext(),
 	}
 	return b
 }
@@ -295,6 +337,7 @@ func (b *PodBuilder) WithQuerySidecar(image string) *PodBuilder {
 				corev1.ResourceCPU:    resource.MustParse("200m"),
 			},
 		},
+		SecurityContext: hardenedContainerSecurityContext(),
 	}
 	return b
 }
@@ -356,6 +399,7 @@ func (b *PodBuilder) Build() (*corev1.Pod, error) {
 			Env:             b.botEnv,
 			VolumeMounts:    b.volumeMounts,
 			Resources:       b.botResources,
+			SecurityContext: hardenedContainerSecurityContext(),
 		},
 	}
 
@@ -379,10 +423,11 @@ func (b *PodBuilder) Build() (*corev1.Pod, error) {
 			Annotations: b.annotations,
 		},
 		Spec: corev1.PodSpec{
-			RestartPolicy:  b.restartPolicy,
-			InitContainers: initContainers,
-			Containers:     containers,
-			Volumes:        b.volumes,
+			SecurityContext: hardenedPodSecurityContext(),
+			RestartPolicy:   b.restartPolicy,
+			InitContainers:  initContainers,
+			Containers:      containers,
+			Volumes:         b.volumes,
 		},
 	}, nil
 }

--- a/runtime/internal/k8s/podgen/pod_generator_test.go
+++ b/runtime/internal/k8s/podgen/pod_generator_test.go
@@ -96,10 +96,20 @@ func TestPodGenerator_GeneratePod_RealtimeBot(t *testing.T) {
 	assert.Equal(t, DefaultCPULimit, botContainer.Resources.Limits.Cpu().String())
 
 	// Check volumes
-	require.Len(t, pod.Spec.Volumes, 3)
+	require.Len(t, pod.Spec.Volumes, 4)
 	assert.Equal(t, "bot-code", pod.Spec.Volumes[0].Name)
 	assert.Equal(t, "bot-state", pod.Spec.Volumes[1].Name)
 	assert.Equal(t, "the0", pod.Spec.Volumes[2].Name)
+	assert.Equal(t, "tmp", pod.Spec.Volumes[3].Name)
+
+	require.NotNil(t, pod.Spec.SecurityContext)
+	assert.Equal(t, int64(1000), *pod.Spec.SecurityContext.FSGroup)
+	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, pod.Spec.SecurityContext.SeccompProfile.Type)
+	require.NotNil(t, botContainer.SecurityContext)
+	assert.True(t, *botContainer.SecurityContext.RunAsNonRoot)
+	assert.True(t, *botContainer.SecurityContext.ReadOnlyRootFilesystem)
+	assert.False(t, *botContainer.SecurityContext.AllowPrivilegeEscalation)
+	assert.Contains(t, botContainer.SecurityContext.Capabilities.Drop, corev1.Capability("ALL"))
 }
 
 func TestPodGenerator_GeneratePod_WithQueryEntrypoint(t *testing.T) {


### PR DESCRIPTION
## Summary
- move API/frontend/docs build and runtime images to Docker Hardened Images where compatible
- add dhi.io auth to image build and security scan workflows using DHI_USERNAME and DHI_TOKEN
- harden Helm workloads and generated bot containers with non-root users, dropped capabilities, no privilege escalation, seccomp RuntimeDefault, read-only root filesystems, fsGroup, and explicit writable mounts
- move docs nginx to internal port 8080 for DHI nginx

## Verification
- docker build -t the0-api:dhi ./api
- docker build -t the0-frontend:dhi ./frontend
- docker build -t the0-docs:dhi ./docs
- docker build -t the0-runtime:dhi ./runtime
- go test ./internal/k8s/podgen ./internal/docker
- RUNTIME_IMAGE=the0-runtime:dhi go test ./internal/docker
- helm lint ./k8s
- helm template the0 ./k8s
- docs read-only container smoke test on :8080
- Trivy OS-package scans for API, frontend, docs, and runtime images: 0 HIGH/CRITICAL OS findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Implemented hardened base images across API, frontend, docs, and runtime containers
  * Added strict security contexts to Kubernetes deployments (read-only root filesystems, non-root execution, dropped Linux capabilities, seccomp defaults)
  * Enhanced container security configurations with restrictive privilege settings

* **Chores**
  * Updated CI/CD workflows to authenticate with hardened Docker registry
  * Updated docs service port from 80 to 8080
  * Added temporary filesystem mounts for runtime writable paths

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alexanderwanyoike/the0/pull/273)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->