### PR TITLE
Fix local compose healthchecks

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -37,6 +37,7 @@ COPY --from=prod-deps --chown=1000:1000 /app/node_modules ./node_modules
 COPY --from=builder --chown=1000:1000 /app/package.json ./package.json
 COPY --from=builder --chown=1000:1000 /app/drizzle.config.ts ./drizzle.config.ts
 COPY --from=builder --chown=1000:1000 /app/uploads ./uploads
+COPY --chown=1000:1000 scripts/docker-healthcheck.js ./scripts/docker-healthcheck.js
 
 USER 1000:1000
 
@@ -45,7 +46,7 @@ EXPOSE 3000
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD ["node", "-e", "require('http').get('http://127.0.0.1:3000/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]
+  CMD ["node", "/app/scripts/docker-healthcheck.js"]
 
 # Start the application
 CMD ["node", "dist/src/main.js"]

--- a/api/scripts/docker-healthcheck.js
+++ b/api/scripts/docker-healthcheck.js
@@ -1,0 +1,26 @@
+const http = require("http");
+
+const port = process.env.PORT || "3000";
+const path = process.env.HEALTHCHECK_PATH || "/health";
+
+const request = http.get(
+  {
+    host: "127.0.0.1",
+    port,
+    path,
+    timeout: 2000,
+  },
+  (response) => {
+    response.resume();
+    process.exit(response.statusCode === 200 ? 0 : 1);
+  },
+);
+
+request.on("timeout", () => {
+  request.destroy();
+  process.exit(1);
+});
+
+request.on("error", () => {
+  process.exit(1);
+});

--- a/cli/internal/local/compose_files/docker-compose.prebuilt.yml
+++ b/cli/internal/local/compose_files/docker-compose.prebuilt.yml
@@ -133,7 +133,7 @@ services:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://0.0.0.0:3000/ || exit 1"]
+      test: ["CMD", "node", "/app/scripts/docker-healthcheck.js"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -346,7 +346,7 @@ services:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://0.0.0.0:3000/ || exit 1"]
+      test: ["CMD", "node", "/app/scripts/docker-healthcheck.js"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -360,10 +360,10 @@ services:
     image: ghcr.io/alexanderwanyoike/the0/docs:latest
     pull_policy: always
     ports:
-      - "3002:80"
+      - "3002:8080"
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1/health"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8080/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/cli/internal/local/compose_files/docker-compose.yml
+++ b/cli/internal/local/compose_files/docker-compose.yml
@@ -138,7 +138,7 @@ services:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://0.0.0.0:3000/ || exit 1"]
+      test: ["CMD", "node", "/app/scripts/docker-healthcheck.js"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -385,7 +385,7 @@ services:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://0.0.0.0:3000/ || exit 1"]
+      test: ["CMD", "node", "/app/scripts/docker-healthcheck.js"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -401,10 +401,10 @@ services:
       dockerfile: Dockerfile
     pull_policy: always
     ports:
-      - "3002:80"
+      - "3002:8080"
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1/health"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8080/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/cli/tests/local_test.go
+++ b/cli/tests/local_test.go
@@ -836,9 +836,11 @@ func TestExtractComposeFiles_PrebuiltMode(t *testing.T) {
 	}
 
 	// Should contain GHCR image references
-	if !strings.Contains(string(composeData), "ghcr.io/alexanderwanyoike/the0/") {
+	composeContent := string(composeData)
+	if !strings.Contains(composeContent, "ghcr.io/alexanderwanyoike/the0/") {
 		t.Error("Prebuilt compose file should contain GHCR image references")
 	}
+	assertHardenedComposeHealthchecks(t, composeContent)
 
 	// docker-compose.dev.yml should NOT exist
 	devPath := filepath.Join(composeDir, "docker-compose.dev.yml")
@@ -894,6 +896,7 @@ func TestExtractComposeFiles_SourceMode(t *testing.T) {
 	if !strings.Contains(string(composeData), repoPath) {
 		t.Error("Source compose file should contain the resolved repo path")
 	}
+	assertHardenedComposeHealthchecks(t, string(composeData))
 
 	// docker-compose.dev.yml should exist
 	devData, err := os.ReadFile(filepath.Join(composeDir, "docker-compose.dev.yml"))
@@ -914,5 +917,40 @@ func TestExtractComposeFiles_SourceMode(t *testing.T) {
 	}
 	if state.RepoPath != repoPath {
 		t.Errorf("State.RepoPath: expected %q, got %q", repoPath, state.RepoPath)
+	}
+}
+
+func assertHardenedComposeHealthchecks(t *testing.T, composeContent string) {
+	t.Helper()
+
+	nodeHealthcheck := `test: ["CMD", "node", "/app/scripts/docker-healthcheck.js"]`
+	if count := strings.Count(composeContent, nodeHealthcheck); count != 2 {
+		t.Errorf("Compose content should contain hardened node healthcheck for API and frontend (want 2, got %d)", count)
+	}
+
+	expected := []string{
+		`- "3002:8080"`,
+		`http://127.0.0.1:8080/health`,
+	}
+
+	for _, want := range expected {
+		if !strings.Contains(composeContent, want) {
+			t.Errorf("Compose content should contain %q", want)
+		}
+	}
+
+	unexpected := []string{
+		`node", "-e"`,
+		`require("http").get`,
+		`http://127.0.0.1:3000/health`,
+		`wget --no-verbose --tries=1 --spider http://0.0.0.0:3000/ || exit 1`,
+		`- "3002:80"`,
+		`http://127.0.0.1/health`,
+	}
+
+	for _, notWant := range unexpected {
+		if strings.Contains(composeContent, notWant) {
+			t.Errorf("Compose content should not contain stale config %q", notWant)
+		}
 	}
 }

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -59,6 +59,7 @@ COPY --from=builder --chown=1000:1000 /app/public ./public
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=builder --chown=1000:1000 /app/.next/standalone ./
 COPY --from=builder --chown=1000:1000 /app/.next/static ./.next/static
+COPY --chown=1000:1000 scripts/docker-healthcheck.js ./scripts/docker-healthcheck.js
 
 USER 1000:1000
 
@@ -70,4 +71,7 @@ ENV HOSTNAME="0.0.0.0"
 
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/next-config-js/output
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD ["node", "/app/scripts/docker-healthcheck.js"]
+
 CMD ["node", "server.js"]

--- a/frontend/scripts/docker-healthcheck.js
+++ b/frontend/scripts/docker-healthcheck.js
@@ -1,0 +1,26 @@
+const http = require("http");
+
+const port = process.env.PORT || "3000";
+const path = process.env.HEALTHCHECK_PATH || "/";
+
+const request = http.get(
+  {
+    host: "127.0.0.1",
+    port,
+    path,
+    timeout: 2000,
+  },
+  (response) => {
+    response.resume();
+    process.exit(response.statusCode === 200 ? 0 : 1);
+  },
+);
+
+request.on("timeout", () => {
+  request.destroy();
+  process.exit(1);
+});
+
+request.on("error", () => {
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Replace shell-based local compose healthchecks for API/frontend with image-owned healthcheck scripts.
- Add Dockerfile healthchecks for API/frontend that call the checked-in scripts instead of inline Node snippets.
- Update local docs service mapping and healthcheck to use nginx internal port 8080.
- Add CLI extraction assertions for the hardened compose healthcheck config.

## Test plan
- `go test ./...` from `cli/`
- `node --check api/docker-healthcheck.js && node --check frontend/docker-healthcheck.js`
- Render source and prebuilt compose with `docker compose config`
- `docker compose -f ~/.the0/compose/docker-compose.yml -p the0 up -d --build the0-api the0-docs`
- `the0 local status` shows API and docs healthy
- `docker build -t the0-frontend-healthcheck-test ./frontend`

## Notes
- GC still restarts locally because MinIO `bot-logs`/`bot-state` buckets are missing in an empty stack; that is a separate runtime/local bootstrap issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container health checks for API and frontend services using dedicated Node.js scripts.
  * Updated Docker Compose configurations to use enhanced healthcheck mechanisms.
  * Added comprehensive tests to validate healthcheck configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alexanderwanyoike/the0/pull/279)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->