### PR TITLE
Fix source-mode local start refresh

### DIFF
--- a/cli/cmd/local.go
+++ b/cli/cmd/local.go
@@ -155,6 +155,21 @@ func newLocalStartCmd() *cobra.Command {
 				}
 				logger.StopSpinnerWithSuccess("Images pulled")
 			} else {
+				// Source mode uses embedded compose templates. Refresh them on
+				// every start so local config follows CLI updates after git pulls.
+				logger.StartSpinner("Refreshing compose files")
+				if err := local.ExtractComposeFiles(runner.State.RepoPath, false); err != nil {
+					logger.StopSpinnerWithError("Failed to refresh compose files")
+					return fmt.Errorf("failed to refresh compose files: %w", err)
+				}
+				logger.StopSpinnerWithSuccess("Compose files refreshed")
+
+				var err error
+				runner, err = local.NewComposeRunner()
+				if err != nil {
+					return err
+				}
+
 				// Source mode: build from local Dockerfiles
 				logger.StartSpinner("Building services")
 				if err := runner.Build(); err != nil {

--- a/cli/internal/local/compose_files/docker-compose.yml
+++ b/cli/internal/local/compose_files/docker-compose.yml
@@ -155,7 +155,7 @@ services:
       args:
         - BUILDKIT_INLINE_CACHE=1
     image: the0/runtime:latest
-    pull_policy: always
+    pull_policy: build
     environment:
       # Runtime image override (use locally built image for bot containers)
       RUNTIME_IMAGE: the0/runtime:latest
@@ -215,7 +215,7 @@ services:
       args:
         - BUILDKIT_INLINE_CACHE=1
     image: the0/runtime:latest
-    pull_policy: always
+    pull_policy: build
     environment:
       # Runtime image override (use locally built image for bot containers)
       RUNTIME_IMAGE: the0/runtime:latest
@@ -274,7 +274,7 @@ services:
       args:
         - BUILDKIT_INLINE_CACHE=1
     image: the0/runtime:latest
-    pull_policy: always
+    pull_policy: build
     environment:
       MONGO_URI: mongodb://root:the0_mongo_password@mongo:27017
       MINIO_ENDPOINT: minio:9000
@@ -307,7 +307,7 @@ services:
       args:
         - BUILDKIT_INLINE_CACHE=1
     image: the0/runtime:latest
-    pull_policy: always
+    pull_policy: build
     environment:
       # Runtime image override (use locally built image for bot containers)
       RUNTIME_IMAGE: the0/runtime:latest

--- a/cli/tests/local_test.go
+++ b/cli/tests/local_test.go
@@ -954,3 +954,39 @@ func assertHardenedComposeHealthchecks(t *testing.T, composeContent string) {
 		}
 	}
 }
+
+func TestExtractComposeFiles_SourceModeUsesLocalRuntimeBuilds(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "source-runtime-build-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	repoPath := filepath.Join(tmpDir, "repo")
+	for _, dir := range []string{"api", "frontend", "runtime", "docker"} {
+		if err := os.MkdirAll(filepath.Join(repoPath, dir), 0755); err != nil {
+			t.Fatalf("Failed to create repo dir %q: %v", dir, err)
+		}
+	}
+
+	if err := local.ExtractComposeFiles(repoPath, false); err != nil {
+		t.Fatalf("ExtractComposeFiles failed: %v", err)
+	}
+
+	composeData, err := os.ReadFile(filepath.Join(tmpDir, ".the0", "compose", "docker-compose.yml"))
+	if err != nil {
+		t.Fatalf("Failed to read docker-compose.yml: %v", err)
+	}
+
+	composeContent := string(composeData)
+	if count := strings.Count(composeContent, "image: the0/runtime:latest"); count != 4 {
+		t.Errorf("Source compose should define four local runtime services (want 4, got %d)", count)
+	}
+	if count := strings.Count(composeContent, "pull_policy: build"); count != 4 {
+		t.Errorf("Source compose should build local runtime images instead of pulling Docker Hub image (want 4, got %d)", count)
+	}
+}

--- a/runtime/internal/gc/gc.go
+++ b/runtime/internal/gc/gc.go
@@ -24,6 +24,7 @@ type IncompleteUploadInfo struct {
 
 // MinIOClient abstracts the MinIO operations needed by the GC.
 type MinIOClient interface {
+	EnsureBucket(ctx context.Context, bucket string) error
 	ListObjectNames(ctx context.Context, bucket, prefix string) ([]string, error)
 	ListObjectsWithInfo(ctx context.Context, bucket, prefix string) ([]ObjectInfo, error)
 	RemoveObject(ctx context.Context, bucket, name string) error
@@ -91,6 +92,10 @@ const staleIncompleteUploadAge = 1 * time.Hour
 func (gc *GarbageCollector) Run(ctx context.Context) (*RunResult, error) {
 	result := &RunResult{}
 
+	if err := gc.ensureBuckets(ctx); err != nil {
+		return nil, err
+	}
+
 	// 0. Clean up stale temp files (leaked by the old fire-and-forget goroutine bug)
 	result.StaleTempFiles = gc.cleanupStaleTempFiles(ctx)
 
@@ -145,6 +150,18 @@ func (gc *GarbageCollector) Run(ctx context.Context) (*RunResult, error) {
 	result.OrphanedBots = len(orphanIDs)
 	result.DeletedObjects = totalDeleted
 	return result, nil
+}
+
+func (gc *GarbageCollector) ensureBuckets(ctx context.Context) error {
+	for _, bucket := range []string{gc.logsBucket, gc.stateBucket} {
+		if bucket == "" {
+			continue
+		}
+		if err := gc.minio.EnsureBucket(ctx, bucket); err != nil {
+			return fmt.Errorf("failed to ensure MinIO bucket %s: %w", bucket, err)
+		}
+	}
+	return nil
 }
 
 // collectMinIOBotIDs lists all unique bot IDs that have artifacts in MinIO.

--- a/runtime/internal/gc/gc_test.go
+++ b/runtime/internal/gc/gc_test.go
@@ -19,6 +19,8 @@ type mockMinIOClient struct {
 	deleted        []string     // track deleted object paths (bucket:name)
 	listErr        error
 	removeErr      error
+	ensureErr      error
+	ensured        []string
 
 	// Incomplete multipart uploads, keyed by bucket.
 	incompleteUploads map[string][]IncompleteUploadInfo
@@ -30,6 +32,14 @@ type mockMinIOClient struct {
 	// If set, AbortIncompleteUpload returns this error for keys matching abortErrKey.
 	abortErr    error
 	abortErrKey string
+}
+
+func (m *mockMinIOClient) EnsureBucket(ctx context.Context, bucket string) error {
+	if m.ensureErr != nil {
+		return m.ensureErr
+	}
+	m.ensured = append(m.ensured, bucket)
+	return nil
 }
 
 func (m *mockMinIOClient) ListObjectNames(ctx context.Context, bucket, prefix string) ([]string, error) {
@@ -198,6 +208,18 @@ func TestGC_EmptyMinIO(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, result.OrphanedBots)
 	assert.Equal(t, 0, result.DeletedObjects)
+	assert.Equal(t, []string{"bot-logs", "bot-state"}, minio.ensured)
+}
+
+func TestGC_EnsureBucketError(t *testing.T) {
+	minio := &mockMinIOClient{ensureErr: assert.AnError}
+	store := &mockBotStore{existingIDs: map[string]bool{}}
+
+	gc := NewGarbageCollector(GarbageCollectorOptions{MinIO: minio, Store: store, LogsBucket: "bot-logs", StateBucket: "bot-state"})
+	_, err := gc.Run(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to ensure MinIO bucket bot-logs")
 }
 
 func TestGC_MinIOListError(t *testing.T) {

--- a/runtime/internal/gc/minio_adapter.go
+++ b/runtime/internal/gc/minio_adapter.go
@@ -16,6 +16,17 @@ func NewMinIOAdapter(client *minio.Client) MinIOClient {
 	return &minioAdapter{client: client}
 }
 
+func (m *minioAdapter) EnsureBucket(ctx context.Context, bucket string) error {
+	exists, err := m.client.BucketExists(ctx, bucket)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	return m.client.MakeBucket(ctx, bucket, minio.MakeBucketOptions{})
+}
+
 func (m *minioAdapter) ListObjectNames(ctx context.Context, bucket, prefix string) ([]string, error) {
 	var names []string
 	for obj := range m.client.ListObjects(ctx, bucket, minio.ListObjectsOptions{


### PR DESCRIPTION
## Summary
- Refresh source-mode compose files during `the0 local start` so merged CLI template changes are applied before build/start.
- Use `pull_policy: build` for local runtime services to avoid Docker Hub pull attempts for `the0/runtime:latest`.
- Ensure GC creates its MinIO logs/state buckets before sweeping, so fresh local stacks do not fail waiting on GC health.

## Test plan
- `go test ./...` from `cli/`
- `go test ./internal/gc ./cmd/app` from `runtime/`
- Render source compose with `docker compose config` and verify runtime build policies
- `go run . local start` from `cli/`
- `the0 local status` shows all services healthy

## Notes
- This is a follow-up to #279 after confirming stale generated compose could still be used by `local start`.