### PR TITLE
Fix local runtime Docker socket permissions

### DIFF
--- a/cli/internal/local/compose_files/docker-compose.prebuilt.yml
+++ b/cli/internal/local/compose_files/docker-compose.prebuilt.yml
@@ -176,6 +176,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - bot_runner_data:/app/data
       - /tmp/bot-runner:/tmp/bot-runner
+    group_add:
+      - "${DOCKER_GID:-0}"
     depends_on:
       mongo:
         condition: service_healthy
@@ -227,6 +229,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - bot_scheduler_data:/app/data
       - /tmp/bot-scheduler:/tmp/bot-scheduler
+    group_add:
+      - "${DOCKER_GID:-0}"
     depends_on:
       mongo:
         condition: service_healthy
@@ -301,6 +305,8 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp/query-server:/tmp/query-server
+    group_add:
+      - "${DOCKER_GID:-0}"
     depends_on:
       mongo:
         condition: service_healthy

--- a/cli/internal/local/compose_files/docker-compose.yml
+++ b/cli/internal/local/compose_files/docker-compose.yml
@@ -189,6 +189,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - bot_runner_data:/app/data
       - /tmp/bot-runner:/tmp/bot-runner
+    group_add:
+      - "${DOCKER_GID:-0}"
     depends_on:
       mongo:
         condition: service_healthy
@@ -248,6 +250,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - bot_scheduler_data:/app/data
       - /tmp/bot-scheduler:/tmp/bot-scheduler
+    group_add:
+      - "${DOCKER_GID:-0}"
     depends_on:
       mongo:
         condition: service_healthy
@@ -335,6 +339,8 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp/query-server:/tmp/query-server
+    group_add:
+      - "${DOCKER_GID:-0}"
     depends_on:
       mongo:
         condition: service_healthy

--- a/cli/internal/local/env.go
+++ b/cli/internal/local/env.go
@@ -52,7 +52,7 @@ func GenerateEnvFile(composeDir string) error {
 		if err != nil {
 			return fmt.Errorf("failed to read existing env file: %w", err)
 		}
-		if !strings.Contains(string(data), "DOCKER_GID=") {
+		if !hasEnvKey(string(data), "DOCKER_GID") {
 			f, err := os.OpenFile(envPath, os.O_APPEND|os.O_WRONLY, 0600)
 			if err != nil {
 				return fmt.Errorf("failed to update env file: %w", err)
@@ -75,4 +75,14 @@ func GenerateEnvFile(composeDir string) error {
 
 	logger.Verbose("Generated .env file at %s", envPath)
 	return nil
+}
+
+func hasEnvKey(content, key string) bool {
+	prefix := key + "="
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/cli/internal/local/env.go
+++ b/cli/internal/local/env.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"syscall"
 
 	"the0/internal/logger"
 )
@@ -34,24 +36,56 @@ JWT_EXPIRES_IN=24h
 API_PORT=3000
 FRONTEND_PORT=3001
 DOCS_PORT=3002
+
+# Docker socket access for non-root runtime services
+DOCKER_GID={{DOCKER_GID}}
 `
 
 // GenerateEnvFile writes a .env file with default values to the compose directory.
-// It does not overwrite an existing .env file.
+// It preserves existing values and appends newly required defaults.
 func GenerateEnvFile(composeDir string) error {
 	envPath := filepath.Join(composeDir, ".env")
+	dockerGID := detectDockerSocketGID()
+	defaults := strings.ReplaceAll(defaultEnvContent, "{{DOCKER_GID}}", dockerGID)
 
 	if _, err := os.Stat(envPath); err == nil {
+		data, err := os.ReadFile(envPath)
+		if err != nil {
+			return fmt.Errorf("failed to read existing env file: %w", err)
+		}
+		if !strings.Contains(string(data), "DOCKER_GID=") {
+			f, err := os.OpenFile(envPath, os.O_APPEND|os.O_WRONLY, 0600)
+			if err != nil {
+				return fmt.Errorf("failed to update env file: %w", err)
+			}
+			defer f.Close()
+			if _, err := fmt.Fprintf(f, "\n# Docker socket access for non-root runtime services\nDOCKER_GID=%s\n", dockerGID); err != nil {
+				return fmt.Errorf("failed to append Docker GID to env file: %w", err)
+			}
+			logger.Verbose("Updated .env file with DOCKER_GID")
+		}
 		logger.Verbose("Skipping .env generation (already exists)")
 		return nil
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("failed to check env file: %w", err)
 	}
 
-	if err := os.WriteFile(envPath, []byte(defaultEnvContent), 0600); err != nil {
+	if err := os.WriteFile(envPath, []byte(defaults), 0600); err != nil {
 		return err
 	}
 
 	logger.Verbose("Generated .env file at %s", envPath)
 	return nil
+}
+
+func detectDockerSocketGID() string {
+	info, err := os.Stat("/var/run/docker.sock")
+	if err != nil {
+		return "0"
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "0"
+	}
+	return fmt.Sprintf("%d", stat.Gid)
 }

--- a/cli/internal/local/env.go
+++ b/cli/internal/local/env.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"the0/internal/logger"
 )
@@ -76,16 +75,4 @@ func GenerateEnvFile(composeDir string) error {
 
 	logger.Verbose("Generated .env file at %s", envPath)
 	return nil
-}
-
-func detectDockerSocketGID() string {
-	info, err := os.Stat("/var/run/docker.sock")
-	if err != nil {
-		return "0"
-	}
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return "0"
-	}
-	return fmt.Sprintf("%d", stat.Gid)
 }

--- a/cli/internal/local/env_nonunix.go
+++ b/cli/internal/local/env_nonunix.go
@@ -1,0 +1,10 @@
+//go:build !unix
+
+package local
+
+import "the0/internal/logger"
+
+func detectDockerSocketGID() string {
+	logger.Verbose("Docker socket GID detection is not supported on this platform, using default")
+	return "0"
+}

--- a/cli/internal/local/env_unix.go
+++ b/cli/internal/local/env_unix.go
@@ -1,0 +1,21 @@
+//go:build unix
+
+package local
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func detectDockerSocketGID() string {
+	info, err := os.Stat("/var/run/docker.sock")
+	if err != nil {
+		return "0"
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "0"
+	}
+	return fmt.Sprintf("%d", stat.Gid)
+}

--- a/cli/tests/local_test.go
+++ b/cli/tests/local_test.go
@@ -270,6 +270,65 @@ func TestGenerateEnvFile_PreservesExistingAndAddsDockerGID(t *testing.T) {
 	}
 }
 
+func TestGenerateEnvFile_IgnoresSimilarDockerGIDKeys(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "env-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	envPath := filepath.Join(tmpDir, ".env")
+	customContent := "MY_DOCKER_GID=1234\n"
+	if err := os.WriteFile(envPath, []byte(customContent), 0600); err != nil {
+		t.Fatalf("Failed to write custom .env: %v", err)
+	}
+
+	if err := local.GenerateEnvFile(tmpDir); err != nil {
+		t.Fatalf("GenerateEnvFile failed: %v", err)
+	}
+
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("Failed to read .env file: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, customContent) {
+		t.Errorf("Expected original content to be preserved, got: %s", content)
+	}
+	if !strings.Contains(content, "\nDOCKER_GID=") {
+		t.Errorf("Expected exact DOCKER_GID key to be added, got: %s", content)
+	}
+}
+
+func TestGenerateEnvFile_DoesNotDuplicateExistingDockerGID(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "env-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	envPath := filepath.Join(tmpDir, ".env")
+	customContent := "CUSTOM_KEY=custom_value\nDOCKER_GID=1234\n"
+	if err := os.WriteFile(envPath, []byte(customContent), 0600); err != nil {
+		t.Fatalf("Failed to write custom .env: %v", err)
+	}
+
+	if err := local.GenerateEnvFile(tmpDir); err != nil {
+		t.Fatalf("GenerateEnvFile failed: %v", err)
+	}
+
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("Failed to read .env file: %v", err)
+	}
+
+	content := string(data)
+	if content != customContent {
+		t.Errorf("Expected existing DOCKER_GID content to be unchanged, got: %s", content)
+	}
+}
+
 func TestGenerateEnvFile_CorrectPermissions(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "env-test")
 	if err != nil {

--- a/cli/tests/local_test.go
+++ b/cli/tests/local_test.go
@@ -227,6 +227,7 @@ func TestGenerateEnvFile_CreatesFile(t *testing.T) {
 		"API_PORT=",
 		"FRONTEND_PORT=",
 		"DOCS_PORT=",
+		"DOCKER_GID=",
 	}
 
 	for _, key := range expectedKeys {
@@ -236,7 +237,7 @@ func TestGenerateEnvFile_CreatesFile(t *testing.T) {
 	}
 }
 
-func TestGenerateEnvFile_DoesNotOverwriteExisting(t *testing.T) {
+func TestGenerateEnvFile_PreservesExistingAndAddsDockerGID(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "env-test")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
@@ -250,20 +251,22 @@ func TestGenerateEnvFile_DoesNotOverwriteExisting(t *testing.T) {
 		t.Fatalf("Failed to write custom .env: %v", err)
 	}
 
-	// GenerateEnvFile should skip the existing file
 	err = local.GenerateEnvFile(tmpDir)
 	if err != nil {
 		t.Fatalf("GenerateEnvFile failed: %v", err)
 	}
 
-	// Verify original content is preserved
 	data, err := os.ReadFile(envPath)
 	if err != nil {
 		t.Fatalf("Failed to read .env file: %v", err)
 	}
 
-	if string(data) != customContent {
-		t.Errorf("Expected original content to be preserved, got: %s", string(data))
+	content := string(data)
+	if !strings.Contains(content, customContent) {
+		t.Errorf("Expected original content to be preserved, got: %s", content)
+	}
+	if !strings.Contains(content, "DOCKER_GID=") {
+		t.Errorf("Expected existing .env to be updated with DOCKER_GID, got: %s", content)
 	}
 }
 
@@ -841,6 +844,7 @@ func TestExtractComposeFiles_PrebuiltMode(t *testing.T) {
 		t.Error("Prebuilt compose file should contain GHCR image references")
 	}
 	assertHardenedComposeHealthchecks(t, composeContent)
+	assertDockerSocketGroup(t, composeContent)
 
 	// docker-compose.dev.yml should NOT exist
 	devPath := filepath.Join(composeDir, "docker-compose.dev.yml")
@@ -897,6 +901,7 @@ func TestExtractComposeFiles_SourceMode(t *testing.T) {
 		t.Error("Source compose file should contain the resolved repo path")
 	}
 	assertHardenedComposeHealthchecks(t, string(composeData))
+	assertDockerSocketGroup(t, string(composeData))
 
 	// docker-compose.dev.yml should exist
 	devData, err := os.ReadFile(filepath.Join(composeDir, "docker-compose.dev.yml"))
@@ -917,6 +922,17 @@ func TestExtractComposeFiles_SourceMode(t *testing.T) {
 	}
 	if state.RepoPath != repoPath {
 		t.Errorf("State.RepoPath: expected %q, got %q", repoPath, state.RepoPath)
+	}
+}
+
+func assertDockerSocketGroup(t *testing.T, composeContent string) {
+	t.Helper()
+
+	if count := strings.Count(composeContent, `- /var/run/docker.sock:/var/run/docker.sock`); count != 3 {
+		t.Errorf("Compose content should mount Docker socket for runner, scheduler, and query server (want 3, got %d)", count)
+	}
+	if count := strings.Count(composeContent, `- "${DOCKER_GID:-0}"`); count != 3 {
+		t.Errorf("Compose content should add Docker socket group for runner, scheduler, and query server (want 3, got %d)", count)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add the host Docker socket group to local runtime services that mount `/var/run/docker.sock`.
- Generate `DOCKER_GID` from the host Docker socket during `the0 local init`.
- Preserve existing `.env` files while appending `DOCKER_GID` if it is missing.
- Add CLI tests covering the Docker socket group wiring.

## Test plan
- `go test ./...` from `cli/`
- Render source/prebuilt compose with `docker compose config`
- `go run . local init --source=/home/alexander/Code/Apps/the0`
- Recreate `bot-runner`, `bot-scheduler`, and `query-server` from generated compose
- Verified `bot-runner` runs with supplemental group matching `/var/run/docker.sock` and no longer logs Docker socket permission denied errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better Docker socket permission handling: local services now honor the host Docker group ID and the environment file is auto-populated with DOCKER_GID when needed.

* **Tests**
  * Strengthened tests to verify Docker socket group handling and to ensure existing env entries are preserved and DOCKER_GID is added correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alexanderwanyoike/the0/pull/281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->