### PR TITLE
Fix Kubernetes hardening writable paths

### DIFF
--- a/k8s/templates/external-services.yaml
+++ b/k8s/templates/external-services.yaml
@@ -85,7 +85,7 @@ spec:
   type: NodePort
   ports:
     - port: 3002
-      targetPort: 80  # nginx serves on port 80
+      targetPort: http
       nodePort: {{ .Values.externalServices.nodePort.docs }}
       protocol: TCP
       name: http

--- a/runtime/internal/k8s/podgen/pod_builder.go
+++ b/runtime/internal/k8s/podgen/pod_builder.go
@@ -54,12 +54,14 @@ func NewPodBuilder(name, namespace string) *PodBuilder {
 			{Name: "bot-state", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 			{Name: "the0", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 			{Name: "tmp", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			{Name: "query", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		},
 		volumeMounts: []corev1.VolumeMount{
 			{Name: "bot-code", MountPath: "/bot"},
 			{Name: "bot-state", MountPath: "/state"},
 			{Name: "the0", MountPath: "/var/the0"},
 			{Name: "tmp", MountPath: "/tmp"},
+			{Name: "query", MountPath: "/query"},
 		},
 		botResources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
@@ -320,10 +322,7 @@ func (b *PodBuilder) WithQuerySidecar(image string) *PodBuilder {
 		ImagePullPolicy: b.botImagePullPolicy,
 		Command:         []string{"/app/runtime", "execute", "--query-server-only"},
 		Env:             b.botEnv, // Share env with bot container
-		VolumeMounts: []corev1.VolumeMount{
-			{Name: "bot-code", MountPath: "/bot"},
-			{Name: "bot-state", MountPath: "/state"},
-		},
+		VolumeMounts:    b.volumeMounts,
 		Ports: []corev1.ContainerPort{
 			{Name: "query", ContainerPort: 9476, Protocol: corev1.ProtocolTCP},
 		},

--- a/runtime/internal/k8s/podgen/pod_generator_test.go
+++ b/runtime/internal/k8s/podgen/pod_generator_test.go
@@ -96,11 +96,12 @@ func TestPodGenerator_GeneratePod_RealtimeBot(t *testing.T) {
 	assert.Equal(t, DefaultCPULimit, botContainer.Resources.Limits.Cpu().String())
 
 	// Check volumes
-	require.Len(t, pod.Spec.Volumes, 4)
+	require.Len(t, pod.Spec.Volumes, 5)
 	assert.Equal(t, "bot-code", pod.Spec.Volumes[0].Name)
 	assert.Equal(t, "bot-state", pod.Spec.Volumes[1].Name)
 	assert.Equal(t, "the0", pod.Spec.Volumes[2].Name)
 	assert.Equal(t, "tmp", pod.Spec.Volumes[3].Name)
+	assert.Equal(t, "query", pod.Spec.Volumes[4].Name)
 
 	require.NotNil(t, pod.Spec.SecurityContext)
 	assert.Equal(t, int64(1000), *pod.Spec.SecurityContext.FSGroup)
@@ -154,6 +155,7 @@ func TestPodGenerator_GeneratePod_WithQueryEntrypoint(t *testing.T) {
 	// Query server should have correct command
 	queryContainer := pod.Spec.Containers[1]
 	assert.Equal(t, []string{"/app/runtime", "execute", "--query-server-only"}, queryContainer.Command)
+	assert.Contains(t, queryContainer.VolumeMounts, corev1.VolumeMount{Name: "query", MountPath: "/query"})
 }
 
 func TestPodGenerator_GenerateScheduledPodSpec(t *testing.T) {
@@ -255,6 +257,7 @@ func TestPodGenerator_GenerateQueryPod(t *testing.T) {
 
 	// Should use query entrypoint when available
 	assert.Equal(t, "query.py", envMap["ENTRYPOINT"])
+	assert.Contains(t, pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{Name: "query", MountPath: "/query"})
 }
 
 func TestPodGenerator_ValidationErrors(t *testing.T) {


### PR DESCRIPTION
## Summary
- point the external docs NodePort at the docs container's named HTTP port instead of the old privileged nginx port 80
- add a writable /query emptyDir mount to generated runtime pods
- give the query sidecar the same writable mounts as the bot container under read-only root filesystems

## Verification
- helm lint ./k8s
- helm template the0 ./k8s
- go test ./internal/k8s/podgen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes configuration to use named port references for improved consistency.
  * Added query volume to default pod setup, mounted at `/query` for enhanced query handling.
  * Updated query sidecar container to utilize shared volume mount configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alexanderwanyoike/the0/pull/282)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->