### PR TITLE
fix: use MinIO handoff for Docker query results

### DIFF
--- a/runtime/cmd/app/execute.go
+++ b/runtime/cmd/app/execute.go
@@ -293,12 +293,12 @@ func runEphemeralQuery(cfg *execute.Config, logger *util.DefaultLogger) int {
 	exitCode := executeQueryProcess(ctx, cfg, entrypoint, logger)
 	logger.Info("Query process completed with exit code: %d", exitCode)
 
-	// If QUERY_RESULT_KEY is set (K8s mode), upload result to MinIO
+	// If QUERY_RESULT_KEY is set, upload the result for the query server to retrieve.
 	if cfg.QueryResultKey != "" {
 		logger.Info("Uploading query result to MinIO key: %s", cfg.QueryResultKey)
 		if err := uploadQueryResult(ctx, cfg, logger); err != nil {
 			logger.Info("Failed to upload query result: %v", err)
-			// Don't fail the whole query if upload fails
+			return 1
 		}
 	}
 

--- a/runtime/cmd/app/execute_helpers_test.go
+++ b/runtime/cmd/app/execute_helpers_test.go
@@ -341,7 +341,7 @@ func TestLoadExecuteConfig_Success(t *testing.T) {
 	assert.Equal(t, "python3.11", cfg.Runtime)
 	assert.Equal(t, "main.py", cfg.Entrypoint)
 	assert.Equal(t, `{"key": "value"}`, cfg.BotConfig)
-	assert.Equal(t, constants.TestBotDir, cfg.CodePath)   // Default value
+	assert.Equal(t, constants.TestBotDir, cfg.CodePath)    // Default value
 	assert.Equal(t, constants.TestStateDir, cfg.StatePath) // Default value
 }
 
@@ -402,6 +402,7 @@ func TestLoadExecuteConfig_WithOptionalFields(t *testing.T) {
 	os.Setenv("QUERY_ENTRYPOINT", "query.py")
 	os.Setenv("QUERY_PATH", "/status")
 	os.Setenv("QUERY_PARAMS", `{"limit": 10}`)
+	os.Setenv("QUERY_RESULT_KEY", "test-bot/123/result.json")
 	os.Setenv("IS_SCHEDULED", "true")
 	defer func() {
 		os.Unsetenv("BOT_ID")
@@ -411,6 +412,7 @@ func TestLoadExecuteConfig_WithOptionalFields(t *testing.T) {
 		os.Unsetenv("QUERY_ENTRYPOINT")
 		os.Unsetenv("QUERY_PATH")
 		os.Unsetenv("QUERY_PARAMS")
+		os.Unsetenv("QUERY_RESULT_KEY")
 		os.Unsetenv("IS_SCHEDULED")
 	}()
 
@@ -421,6 +423,7 @@ func TestLoadExecuteConfig_WithOptionalFields(t *testing.T) {
 	assert.Equal(t, "query.py", cfg.QueryEntrypoint)
 	assert.Equal(t, "/status", cfg.QueryPath)
 	assert.Equal(t, `{"limit": 10}`, cfg.QueryParams)
+	assert.Equal(t, "test-bot/123/result.json", cfg.QueryResultKey)
 	assert.True(t, cfg.IsScheduled)
 }
 

--- a/runtime/cmd/app/main.go
+++ b/runtime/cmd/app/main.go
@@ -13,15 +13,15 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	mongoOptions "go.mongodb.org/mongo-driver/mongo/options"
 
+	"runtime/internal/constants"
 	dockerrunner "runtime/internal/docker"
-	"runtime/internal/gc"
-	"runtime/internal/runtime/storage"
 	botnatssubscriber "runtime/internal/docker/bot-runner/subscriber"
 	schedulenatssubscriber "runtime/internal/docker/bot-scheduler/subscriber"
-	"runtime/internal/constants"
+	"runtime/internal/gc"
 	"runtime/internal/k8s/controller"
 	"runtime/internal/k8s/detect"
 	"runtime/internal/k8s/health"
+	"runtime/internal/runtime/storage"
 	"runtime/internal/util"
 )
 
@@ -461,13 +461,26 @@ func runQueryServer() {
 		os.Exit(1)
 	}
 
+	storageCfg, err := storage.LoadConfigFromEnv()
+	if err != nil {
+		util.LogMaster("Failed to load storage config: %v", err)
+		os.Exit(1)
+	}
+	minioClient, err := storage.NewMinioClient(storageCfg)
+	if err != nil {
+		util.LogMaster("Failed to create MinIO client: %v", err)
+		os.Exit(1)
+	}
+	resultManager := storage.NewQueryResultManager(minioClient, storageCfg, &util.DefaultLogger{})
+
 	// Create multi-collection bot resolver
 	resolver := dockerrunner.NewMultiBotResolver(mongoClient, runner)
 
 	// Create query handler
 	handler := dockerrunner.NewQueryHandler(dockerrunner.QueryHandlerConfig{
-		Runner: runner,
-		Logger: &util.DefaultLogger{},
+		Runner:        runner,
+		ResultManager: resultManager,
+		Logger:        &util.DefaultLogger{},
 	})
 
 	// Create and start query server

--- a/runtime/cmd/app/main.go
+++ b/runtime/cmd/app/main.go
@@ -461,17 +461,15 @@ func runQueryServer() {
 		os.Exit(1)
 	}
 
+	var resultManager storage.QueryResultManager
 	storageCfg, err := storage.LoadConfigFromEnv()
 	if err != nil {
-		util.LogMaster("Failed to load storage config: %v", err)
-		os.Exit(1)
+		util.LogMaster("Warning: storage config unavailable; scheduled queries will fail: %v", err)
+	} else if minioClient, err := storage.NewMinioClient(storageCfg); err != nil {
+		util.LogMaster("Warning: MinIO unavailable; scheduled queries will fail: %v", err)
+	} else {
+		resultManager = storage.NewQueryResultManager(minioClient, storageCfg, &util.DefaultLogger{})
 	}
-	minioClient, err := storage.NewMinioClient(storageCfg)
-	if err != nil {
-		util.LogMaster("Failed to create MinIO client: %v", err)
-		os.Exit(1)
-	}
-	resultManager := storage.NewQueryResultManager(minioClient, storageCfg, &util.DefaultLogger{})
 
 	// Create multi-collection bot resolver
 	resolver := dockerrunner.NewMultiBotResolver(mongoClient, runner)

--- a/runtime/internal/docker/config.go
+++ b/runtime/internal/docker/config.go
@@ -25,22 +25,23 @@ func (e *EnvConfigLoader) LoadConfig() (*DockerRunnerConfig, error) {
 // DockerRunnerConfig holds all configuration needed to run containers
 // including MinIO credentials, resource limits, and directory paths.
 type DockerRunnerConfig struct {
-	MinIOEndpoint          string // MinIO server endpoint for runner's client (e.g., "localhost:9000")
-	MinIOContainerEndpoint string // MinIO endpoint for containers (e.g., "host.docker.internal:9000"). If empty, uses MinIOEndpoint.
-	MinIOAccessKeyID       string // MinIO access key
-	MinIOSecretAccessKey   string // MinIO secret key
-	MinIOUseSSL            bool   // Whether to use SSL/TLS for MinIO connections
-	MinIOCodeBucket        string // Bucket containing bot code archives
-	MinioLogsBucket        string // Bucket for storing logs
-	MinioStateBucket       string // Bucket for storing persistent bot state
-	MaxStateSizeBytes      int64  // Maximum total size of bot state folder (default: 8GB)
-	MaxStateFileSizeBytes  int64  // Maximum size of individual state file (default: 10MB)
-	TempDir                string // Temporary directory for extracted bot code
-	MemoryLimitMB          int64  // Memory limit in bytes for containers
-	CPUShares              int64  // CPU shares allocated to containers
-	DevRuntimePath         string // Optional: host path to runtime binary for dev mode
-	DockerNetwork          string // Docker network to connect containers to (e.g., "the0-oss-network")
-	NatsURL                string // NATS URL for log publishing inside containers (optional)
+	MinIOEndpoint           string // MinIO server endpoint for runner's client (e.g., "localhost:9000")
+	MinIOContainerEndpoint  string // MinIO endpoint for containers (e.g., "host.docker.internal:9000"). If empty, uses MinIOEndpoint.
+	MinIOAccessKeyID        string // MinIO access key
+	MinIOSecretAccessKey    string // MinIO secret key
+	MinIOUseSSL             bool   // Whether to use SSL/TLS for MinIO connections
+	MinIOCodeBucket         string // Bucket containing bot code archives
+	MinioLogsBucket         string // Bucket for storing logs
+	MinioStateBucket        string // Bucket for storing persistent bot state
+	MinIOQueryResultsBucket string // Bucket for ephemeral query results
+	MaxStateSizeBytes       int64  // Maximum total size of bot state folder (default: 8GB)
+	MaxStateFileSizeBytes   int64  // Maximum size of individual state file (default: 10MB)
+	TempDir                 string // Temporary directory for extracted bot code
+	MemoryLimitMB           int64  // Memory limit in bytes for containers
+	CPUShares               int64  // CPU shares allocated to containers
+	DevRuntimePath          string // Optional: host path to runtime binary for dev mode
+	DockerNetwork           string // Docker network to connect containers to (e.g., "the0-oss-network")
+	NatsURL                 string // NATS URL for log publishing inside containers (optional)
 }
 
 // GetContainerEndpoint returns the MinIO endpoint for containers.
@@ -54,8 +55,8 @@ func (c *DockerRunnerConfig) GetContainerEndpoint() string {
 
 // LoadConfigFromEnv loads configuration from environment variables.
 // Required env vars: MINIO_ENDPOINT, MINIO_ACCESS_KEY, MINIO_SECRET_KEY
-// Optional env vars: MINIO_SSL, TEMP_DIR, MINIO_CODE_BUCKET,
-// MINIO_STATE_BUCKET, MINIO_LOGS_BUCKET, BOT_MEMORY_LIMIT_MB, BOT_CPU_SHARES,
+// Optional env vars: MINIO_USE_SSL, MINIO_SSL, TEMP_DIR, MINIO_CODE_BUCKET,
+// MINIO_STATE_BUCKET, MINIO_LOGS_BUCKET, MINIO_QUERY_RESULTS_BUCKET, BOT_MEMORY_LIMIT_MB, BOT_CPU_SHARES,
 // MAX_STATE_SIZE_MB (default: 8192 = 8GB), MAX_STATE_FILE_SIZE_MB (default: 10),
 // DEV_RUNTIME_PATH (optional: host path to runtime binary for dev mode),
 // DOCKER_NETWORK (optional: Docker network for bot containers, e.g., "the0-oss-network")
@@ -75,7 +76,7 @@ func LoadConfigFromEnv() (*DockerRunnerConfig, error) {
 		return nil, fmt.Errorf("MINIO_SECRET_KEY environment variable is required")
 	}
 
-	useSSL := os.Getenv("MINIO_SSL") == "true"
+	useSSL := os.Getenv("MINIO_USE_SSL") == "true" || os.Getenv("MINIO_SSL") == "true"
 
 	logsBucket := os.Getenv("MINIO_LOGS_BUCKET")
 	if logsBucket == "" {
@@ -90,6 +91,11 @@ func LoadConfigFromEnv() (*DockerRunnerConfig, error) {
 	stateBucket := os.Getenv("MINIO_STATE_BUCKET")
 	if stateBucket == "" {
 		stateBucket = "bot-state"
+	}
+
+	queryResultsBucket := os.Getenv("MINIO_QUERY_RESULTS_BUCKET")
+	if queryResultsBucket == "" {
+		queryResultsBucket = "query-results"
 	}
 
 	tempDir := os.Getenv("TEMP_DIR")
@@ -110,22 +116,23 @@ func LoadConfigFromEnv() (*DockerRunnerConfig, error) {
 	natsURL := os.Getenv("NATS_URL")
 
 	return &DockerRunnerConfig{
-		MinIOEndpoint:          endpoint,
-		MinIOContainerEndpoint: containerEndpoint,
-		MinIOAccessKeyID:       accessKey,
-		MinIOSecretAccessKey:   secretKey,
-		MinIOUseSSL:            useSSL,
-		MinIOCodeBucket:        codeBucket,
-		MinioLogsBucket:        logsBucket,
-		MinioStateBucket:       stateBucket,
-		MaxStateSizeBytes:      getMaxStateSize(),
-		MaxStateFileSizeBytes:  getMaxStateFileSize(),
-		TempDir:                tempDir,
-		MemoryLimitMB:          getMemoryLimit(),
-		CPUShares:              getCPUShares(),
-		DevRuntimePath:         devRuntimePath,
-		DockerNetwork:          dockerNetwork,
-		NatsURL:                natsURL,
+		MinIOEndpoint:           endpoint,
+		MinIOContainerEndpoint:  containerEndpoint,
+		MinIOAccessKeyID:        accessKey,
+		MinIOSecretAccessKey:    secretKey,
+		MinIOUseSSL:             useSSL,
+		MinIOCodeBucket:         codeBucket,
+		MinioLogsBucket:         logsBucket,
+		MinioStateBucket:        stateBucket,
+		MinIOQueryResultsBucket: queryResultsBucket,
+		MaxStateSizeBytes:       getMaxStateSize(),
+		MaxStateFileSizeBytes:   getMaxStateFileSize(),
+		TempDir:                 tempDir,
+		MemoryLimitMB:           getMemoryLimit(),
+		CPUShares:               getCPUShares(),
+		DevRuntimePath:          devRuntimePath,
+		DockerNetwork:           dockerNetwork,
+		NatsURL:                 natsURL,
 	}, nil
 }
 

--- a/runtime/internal/docker/config.go
+++ b/runtime/internal/docker/config.go
@@ -76,7 +76,7 @@ func LoadConfigFromEnv() (*DockerRunnerConfig, error) {
 		return nil, fmt.Errorf("MINIO_SECRET_KEY environment variable is required")
 	}
 
-	useSSL := os.Getenv("MINIO_USE_SSL") == "true" || os.Getenv("MINIO_SSL") == "true"
+	useSSL := parseBoolEnv("MINIO_USE_SSL") || parseBoolEnv("MINIO_SSL")
 
 	logsBucket := os.Getenv("MINIO_LOGS_BUCKET")
 	if logsBucket == "" {
@@ -134,6 +134,15 @@ func LoadConfigFromEnv() (*DockerRunnerConfig, error) {
 		DockerNetwork:           dockerNetwork,
 		NatsURL:                 natsURL,
 	}, nil
+}
+
+func parseBoolEnv(key string) bool {
+	value := os.Getenv(key)
+	if value == "" {
+		return false
+	}
+	parsed, err := strconv.ParseBool(value)
+	return err == nil && parsed
 }
 
 // getCPUShares returns the CPU shares from environment variable BOT_CPU_SHARES.

--- a/runtime/internal/docker/config_test.go
+++ b/runtime/internal/docker/config_test.go
@@ -82,6 +82,7 @@ func TestLoadConfigFromEnv_WithOptionalFields(t *testing.T) {
 	os.Setenv("MINIO_ACCESS_KEY", "access-key")
 	os.Setenv("MINIO_SECRET_KEY", "secret-key")
 	os.Setenv("MINIO_SSL", "true")
+	os.Unsetenv("MINIO_USE_SSL")
 	os.Setenv("MINIO_CODE_BUCKET", "custom-code-bucket")
 	os.Setenv("MINIO_STATE_BUCKET", "custom-state-bucket")
 	os.Setenv("MINIO_LOGS_BUCKET", "custom-logs-bucket")
@@ -98,6 +99,7 @@ func TestLoadConfigFromEnv_WithOptionalFields(t *testing.T) {
 		os.Unsetenv("MINIO_ACCESS_KEY")
 		os.Unsetenv("MINIO_SECRET_KEY")
 		os.Unsetenv("MINIO_SSL")
+		os.Unsetenv("MINIO_USE_SSL")
 		os.Unsetenv("MINIO_CODE_BUCKET")
 		os.Unsetenv("MINIO_STATE_BUCKET")
 		os.Unsetenv("MINIO_LOGS_BUCKET")
@@ -131,6 +133,25 @@ func TestLoadConfigFromEnv_WithOptionalFields(t *testing.T) {
 	assert.Equal(t, "custom-network", cfg.DockerNetwork)
 }
 
+func TestLoadConfigFromEnv_MinIOUseSSL(t *testing.T) {
+	os.Setenv("MINIO_ENDPOINT", "localhost:9000")
+	os.Setenv("MINIO_ACCESS_KEY", "test-key")
+	os.Setenv("MINIO_SECRET_KEY", "test-secret")
+	os.Setenv("MINIO_USE_SSL", "1")
+	os.Unsetenv("MINIO_SSL")
+	defer func() {
+		os.Unsetenv("MINIO_ENDPOINT")
+		os.Unsetenv("MINIO_ACCESS_KEY")
+		os.Unsetenv("MINIO_SECRET_KEY")
+		os.Unsetenv("MINIO_USE_SSL")
+	}()
+
+	cfg, err := LoadConfigFromEnv()
+
+	require.NoError(t, err)
+	assert.True(t, cfg.MinIOUseSSL)
+}
+
 func TestLoadConfigFromEnv_DefaultValues(t *testing.T) {
 	// Only set required fields
 	os.Setenv("MINIO_ENDPOINT", "localhost:9000")
@@ -138,6 +159,7 @@ func TestLoadConfigFromEnv_DefaultValues(t *testing.T) {
 	os.Setenv("MINIO_SECRET_KEY", "test-secret")
 	// Clear optional fields
 	os.Unsetenv("MINIO_SSL")
+	os.Unsetenv("MINIO_USE_SSL")
 	os.Unsetenv("BOT_MEMORY_LIMIT_MB")
 	os.Unsetenv("BOT_CPU_SHARES")
 	os.Unsetenv("MAX_STATE_SIZE_MB")

--- a/runtime/internal/docker/config_test.go
+++ b/runtime/internal/docker/config_test.go
@@ -85,6 +85,7 @@ func TestLoadConfigFromEnv_WithOptionalFields(t *testing.T) {
 	os.Setenv("MINIO_CODE_BUCKET", "custom-code-bucket")
 	os.Setenv("MINIO_STATE_BUCKET", "custom-state-bucket")
 	os.Setenv("MINIO_LOGS_BUCKET", "custom-logs-bucket")
+	os.Setenv("MINIO_QUERY_RESULTS_BUCKET", "custom-query-results-bucket")
 	os.Setenv("TEMP_DIR", "/custom/temp")
 	os.Setenv("BOT_MEMORY_LIMIT_MB", "2048")
 	os.Setenv("BOT_CPU_SHARES", "512")
@@ -100,6 +101,7 @@ func TestLoadConfigFromEnv_WithOptionalFields(t *testing.T) {
 		os.Unsetenv("MINIO_CODE_BUCKET")
 		os.Unsetenv("MINIO_STATE_BUCKET")
 		os.Unsetenv("MINIO_LOGS_BUCKET")
+		os.Unsetenv("MINIO_QUERY_RESULTS_BUCKET")
 		os.Unsetenv("TEMP_DIR")
 		os.Unsetenv("BOT_MEMORY_LIMIT_MB")
 		os.Unsetenv("BOT_CPU_SHARES")
@@ -119,6 +121,7 @@ func TestLoadConfigFromEnv_WithOptionalFields(t *testing.T) {
 	assert.Equal(t, "custom-code-bucket", cfg.MinIOCodeBucket)
 	assert.Equal(t, "custom-state-bucket", cfg.MinioStateBucket)
 	assert.Equal(t, "custom-logs-bucket", cfg.MinioLogsBucket)
+	assert.Equal(t, "custom-query-results-bucket", cfg.MinIOQueryResultsBucket)
 	assert.Equal(t, "/custom/temp", cfg.TempDir)
 	assert.Equal(t, int64(2048*1024*1024), cfg.MemoryLimitMB)
 	assert.Equal(t, int64(512), cfg.CPUShares)
@@ -139,6 +142,7 @@ func TestLoadConfigFromEnv_DefaultValues(t *testing.T) {
 	os.Unsetenv("BOT_CPU_SHARES")
 	os.Unsetenv("MAX_STATE_SIZE_MB")
 	os.Unsetenv("MAX_STATE_FILE_SIZE_MB")
+	os.Unsetenv("MINIO_QUERY_RESULTS_BUCKET")
 	defer func() {
 		os.Unsetenv("MINIO_ENDPOINT")
 		os.Unsetenv("MINIO_ACCESS_KEY")
@@ -150,9 +154,10 @@ func TestLoadConfigFromEnv_DefaultValues(t *testing.T) {
 	require.NoError(t, err)
 	// Check defaults
 	assert.False(t, cfg.MinIOUseSSL)
-	assert.Equal(t, int64(512*1024*1024), cfg.MemoryLimitMB) // Default 512MB
-	assert.Equal(t, int64(512), cfg.CPUShares)                // Default 512
-	assert.Equal(t, int64(8192*1024*1024), cfg.MaxStateSizeBytes) // Default 8GB
+	assert.Equal(t, "query-results", cfg.MinIOQueryResultsBucket)
+	assert.Equal(t, int64(512*1024*1024), cfg.MemoryLimitMB)        // Default 512MB
+	assert.Equal(t, int64(512), cfg.CPUShares)                      // Default 512
+	assert.Equal(t, int64(8192*1024*1024), cfg.MaxStateSizeBytes)   // Default 8GB
 	assert.Equal(t, int64(10*1024*1024), cfg.MaxStateFileSizeBytes) // Default 10MB
 }
 

--- a/runtime/internal/docker/container_builder.go
+++ b/runtime/internal/docker/container_builder.go
@@ -132,6 +132,14 @@ func (b *ContainerBuilder) WithMinIOConfig(endpoint, accessKey, secretKey string
 	return b
 }
 
+// WithQueryResultBucket sets the MinIO bucket used for ephemeral query results.
+func (b *ContainerBuilder) WithQueryResultBucket(bucket string) *ContainerBuilder {
+	if bucket != "" {
+		b.config.Env = append(b.config.Env, fmt.Sprintf("MINIO_QUERY_RESULTS_BUCKET=%s", bucket))
+	}
+	return b
+}
+
 // DaemonConfig holds configuration for daemon init/sync.
 type DaemonConfig struct {
 	BotID           string
@@ -207,6 +215,14 @@ func (b *ContainerBuilder) WithQueryConfig(queryPath string, queryParams string)
 				fmt.Sprintf("QUERY_PARAMS=%s", queryParams),
 			)
 		}
+	}
+	return b
+}
+
+// WithQueryResultKey sets the MinIO object key where an ephemeral query writes its result.
+func (b *ContainerBuilder) WithQueryResultKey(resultKey string) *ContainerBuilder {
+	if resultKey != "" {
+		b.config.Env = append(b.config.Env, fmt.Sprintf("QUERY_RESULT_KEY=%s", resultKey))
 	}
 	return b
 }

--- a/runtime/internal/docker/container_builder_test.go
+++ b/runtime/internal/docker/container_builder_test.go
@@ -410,6 +410,24 @@ func TestContainerBuilder_WithQueryConfig(t *testing.T) {
 	}
 }
 
+func TestContainerBuilder_WithQueryResultKey(t *testing.T) {
+	builder := NewContainerBuilder("python:3.11").
+		WithQueryResultKey("bot-1/123/result.json")
+
+	cfg, _ := builder.Build()
+
+	assert.Contains(t, cfg.Env, "QUERY_RESULT_KEY=bot-1/123/result.json")
+}
+
+func TestContainerBuilder_WithQueryResultBucket(t *testing.T) {
+	builder := NewContainerBuilder("python:3.11").
+		WithQueryResultBucket("custom-query-results")
+
+	cfg, _ := builder.Build()
+
+	assert.Contains(t, cfg.Env, "MINIO_QUERY_RESULTS_BUCKET=custom-query-results")
+}
+
 func TestContainerBuilder_WithExtraHosts(t *testing.T) {
 	builder := NewContainerBuilder("python:3.11").
 		WithExtraHosts("host.docker.internal:host-gateway").
@@ -433,8 +451,10 @@ func TestContainerBuilder_ChainedCalls(t *testing.T) {
 		WithResources(1024*1024*1024, 2048).
 		WithAutoRemove(true).
 		WithMinIOConfig("minio:9000", "admin", "secret", false).
+		WithQueryResultBucket("query-results").
 		WithDaemonConfig("bot-1", "code.zip", "python3.11", "main.py", "{}", false).
 		WithQueryConfig("/query", `{"param":"value"}`).
+		WithQueryResultKey("bot-1/123/result.json").
 		WithExtraHosts("host.docker.internal:host-gateway")
 
 	cfg, hostCfg := builder.Build()
@@ -446,8 +466,10 @@ func TestContainerBuilder_ChainedCalls(t *testing.T) {
 	assert.Equal(t, "/app/start.sh", cfg.Cmd[1])
 	assert.Contains(t, cfg.Env, "KEY1=value1")
 	assert.Contains(t, cfg.Env, "MINIO_ENDPOINT=minio:9000")
+	assert.Contains(t, cfg.Env, "MINIO_QUERY_RESULTS_BUCKET=query-results")
 	assert.Contains(t, cfg.Env, "BOT_ID=bot-1")
 	assert.Contains(t, cfg.Env, "QUERY_PATH=/query")
+	assert.Contains(t, cfg.Env, "QUERY_RESULT_KEY=bot-1/123/result.json")
 
 	// Verify host config
 	assert.Equal(t, container.NetworkMode("the0-network"), hostCfg.NetworkMode)

--- a/runtime/internal/docker/query_handler.go
+++ b/runtime/internal/docker/query_handler.go
@@ -3,6 +3,8 @@ package docker
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -76,7 +78,11 @@ func (h *QueryHandler) executeScheduledQuery(ctx context.Context, req query.Requ
 	queryExecutable.QueryParams = req.Params
 	queryExecutable.IsLongRunning = false
 	queryExecutable.ResultFilePath = ""
-	queryExecutable.QueryResultKey = fmt.Sprintf("%s/%d/result.json", executable.ID, time.Now().UnixNano())
+	resultKey, err := newQueryResultKey(executable.ID)
+	if err != nil {
+		return query.ErrorResponse(fmt.Sprintf("failed to generate query result key: %v", err), start), err
+	}
+	queryExecutable.QueryResultKey = resultKey
 
 	// Add query entrypoint file if not present
 	if queryExecutable.EntrypointFiles == nil {
@@ -109,11 +115,21 @@ func (h *QueryHandler) executeScheduledQuery(ctx context.Context, req query.Requ
 		return query.ErrorResponse(fmt.Sprintf("failed to download query result: %v", err), start), nil
 	}
 
-	if err := h.resultManager.Delete(ctx, queryExecutable.QueryResultKey); err != nil {
+	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cleanupCancel()
+	if err := h.resultManager.Delete(cleanupCtx, queryExecutable.QueryResultKey); err != nil {
 		h.logger.Info("Warning: failed to delete query result from MinIO: %v", err)
 	}
 
 	return query.ParseQueryOutput(resultData, start), nil
+}
+
+func newQueryResultKey(botID string) (string, error) {
+	var suffix [8]byte
+	if _, err := rand.Read(suffix[:]); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/%d-%s/result.json", botID, time.Now().UnixNano(), hex.EncodeToString(suffix[:])), nil
 }
 
 // executeRealtimeQuery proxies the query to the bot's HTTP server.

--- a/runtime/internal/docker/query_handler.go
+++ b/runtime/internal/docker/query_handler.go
@@ -8,6 +8,7 @@ import (
 
 	"runtime/internal/model"
 	"runtime/internal/query"
+	"runtime/internal/runtime/storage"
 	"runtime/internal/util"
 )
 
@@ -17,13 +18,15 @@ import (
 type QueryHandler struct {
 	runner           DockerRunner
 	realtimeExecutor *query.RealtimeExecutor
+	resultManager    storage.QueryResultManager
 	logger           util.Logger
 }
 
 // QueryHandlerConfig contains configuration for the QueryHandler.
 type QueryHandlerConfig struct {
-	Runner DockerRunner
-	Logger util.Logger
+	Runner        DockerRunner
+	ResultManager storage.QueryResultManager
+	Logger        util.Logger
 }
 
 // NewQueryHandler creates a new QueryHandler instance.
@@ -34,6 +37,7 @@ func NewQueryHandler(config QueryHandlerConfig) *QueryHandler {
 	return &QueryHandler{
 		runner:           config.Runner,
 		realtimeExecutor: query.NewRealtimeExecutor(query.DefaultQueryPort, config.Logger),
+		resultManager:    config.ResultManager,
 		logger:           config.Logger,
 	}
 }
@@ -71,7 +75,8 @@ func (h *QueryHandler) executeScheduledQuery(ctx context.Context, req query.Requ
 	queryExecutable.QueryPath = req.QueryPath
 	queryExecutable.QueryParams = req.Params
 	queryExecutable.IsLongRunning = false
-	queryExecutable.ResultFilePath = "/query/result.json"
+	queryExecutable.ResultFilePath = ""
+	queryExecutable.QueryResultKey = fmt.Sprintf("%s/%d/result.json", executable.ID, time.Now().UnixNano())
 
 	// Add query entrypoint file if not present
 	if queryExecutable.EntrypointFiles == nil {
@@ -85,19 +90,27 @@ func (h *QueryHandler) executeScheduledQuery(ctx context.Context, req query.Requ
 
 	h.logger.Info("Executing scheduled query: bot=%s path=%s", req.BotID, req.QueryPath)
 
+	if h.resultManager == nil {
+		err := fmt.Errorf("query result manager is not configured")
+		return query.ErrorResponse(err.Error(), start), err
+	}
+
 	// Execute the container
 	result, err := h.runner.StartContainer(ctx, queryExecutable)
 	if err != nil {
 		return query.ErrorResponse(fmt.Sprintf("failed to execute query container: %v", err), start), err
 	}
+	if result.ExitCode != 0 {
+		return query.ErrorResponse(fmt.Sprintf("query container exited with code %d: %s", result.ExitCode, result.Output), start), nil
+	}
 
-	// Parse the result from the result file
-	var resultData []byte
-	if len(result.ResultFileContents) > 0 {
-		resultData = result.ResultFileContents
-	} else {
-		// Fallback to stdout if no result file
-		resultData = []byte(result.Output)
+	resultData, err := h.resultManager.Download(ctx, queryExecutable.QueryResultKey)
+	if err != nil {
+		return query.ErrorResponse(fmt.Sprintf("failed to download query result: %v", err), start), nil
+	}
+
+	if err := h.resultManager.Delete(ctx, queryExecutable.QueryResultKey); err != nil {
+		h.logger.Info("Warning: failed to delete query result from MinIO: %v", err)
 	}
 
 	return query.ParseQueryOutput(resultData, start), nil

--- a/runtime/internal/docker/query_handler_test.go
+++ b/runtime/internal/docker/query_handler_test.go
@@ -23,6 +23,33 @@ type mockDockerRunner struct {
 	getContainerLogsFunc func(ctx context.Context, containerID string, tail int) (string, error)
 }
 
+type mockQueryResultManager struct {
+	downloadFunc func(ctx context.Context, key string) ([]byte, error)
+	deleteFunc   func(ctx context.Context, key string) error
+	downloadKey  string
+	deleteKey    string
+}
+
+func (m *mockQueryResultManager) Upload(ctx context.Context, key string, data []byte) error {
+	return nil
+}
+
+func (m *mockQueryResultManager) Download(ctx context.Context, key string) ([]byte, error) {
+	m.downloadKey = key
+	if m.downloadFunc != nil {
+		return m.downloadFunc(ctx, key)
+	}
+	return []byte(`{"status":"ok","data":{}}`), nil
+}
+
+func (m *mockQueryResultManager) Delete(ctx context.Context, key string) error {
+	m.deleteKey = key
+	if m.deleteFunc != nil {
+		return m.deleteFunc(ctx, key)
+	}
+	return nil
+}
+
 func (m *mockDockerRunner) StartContainer(ctx context.Context, exec model.Executable) (*ExecutionResult, error) {
 	if m.startContainerFunc != nil {
 		return m.startContainerFunc(ctx, exec)
@@ -134,6 +161,13 @@ func TestQueryHandler_ExecuteScheduledQuery(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			resultManager := &mockQueryResultManager{
+				downloadFunc: func(ctx context.Context, key string) ([]byte, error) {
+					assert.Contains(t, key, tt.executable.ID+"/")
+					assert.Contains(t, key, "/result.json")
+					return []byte(tt.mockOutput), nil
+				},
+			}
 			runner := &mockDockerRunner{
 				startContainerFunc: func(ctx context.Context, exec model.Executable) (*ExecutionResult, error) {
 					// Verify query mode is set correctly
@@ -141,17 +175,22 @@ func TestQueryHandler_ExecuteScheduledQuery(t *testing.T) {
 					assert.Equal(t, tt.request.QueryPath, exec.QueryPath)
 					assert.Equal(t, tt.request.Params, exec.QueryParams)
 					assert.False(t, exec.IsLongRunning)
+					assert.Empty(t, exec.ResultFilePath)
+					assert.Contains(t, exec.QueryResultKey, tt.executable.ID+"/")
+					assert.Contains(t, exec.QueryResultKey, "/result.json")
 
 					return &ExecutionResult{
-						Status: "success",
-						Output: tt.mockOutput,
+						Status:   "success",
+						Output:   `{"status":"error","error":"stdout should not be parsed"}`,
+						ExitCode: 0,
 					}, nil
 				},
 			}
 
 			handler := NewQueryHandler(QueryHandlerConfig{
-				Runner: runner,
-				Logger: &util.DefaultLogger{},
+				Runner:        runner,
+				ResultManager: resultManager,
+				Logger:        &util.DefaultLogger{},
 			})
 
 			ctx := context.Background()
@@ -163,6 +202,7 @@ func TestQueryHandler_ExecuteScheduledQuery(t *testing.T) {
 			if tt.expectedError != "" {
 				assert.Equal(t, tt.expectedError, response.Error)
 			}
+			assert.Equal(t, resultManager.downloadKey, resultManager.deleteKey)
 			assert.True(t, response.Duration > 0)
 			assert.False(t, response.Timestamp.IsZero())
 		})
@@ -199,8 +239,9 @@ func TestQueryHandler_ExecuteRealtimeQuery(t *testing.T) {
 	}
 
 	handler := NewQueryHandler(QueryHandlerConfig{
-		Runner: runner,
-		Logger: &util.DefaultLogger{},
+		Runner:        runner,
+		ResultManager: &mockQueryResultManager{},
+		Logger:        &util.DefaultLogger{},
 	})
 
 	// Note: This test won't work directly because the handler appends :9476
@@ -244,8 +285,9 @@ func TestQueryHandler_Timeout(t *testing.T) {
 	}
 
 	handler := NewQueryHandler(QueryHandlerConfig{
-		Runner: runner,
-		Logger: &util.DefaultLogger{},
+		Runner:        runner,
+		ResultManager: &mockQueryResultManager{},
+		Logger:        &util.DefaultLogger{},
 	})
 
 	request := query.Request{
@@ -275,14 +317,20 @@ func TestQueryHandler_InvalidJSONResponse(t *testing.T) {
 	runner := &mockDockerRunner{
 		startContainerFunc: func(ctx context.Context, exec model.Executable) (*ExecutionResult, error) {
 			return &ExecutionResult{
-				Status: "success",
-				Output: "not valid json",
+				Status:   "success",
+				Output:   `{"status":"ok","data":"stdout ignored"}`,
+				ExitCode: 0,
 			}, nil
 		},
 	}
 
 	handler := NewQueryHandler(QueryHandlerConfig{
 		Runner: runner,
+		ResultManager: &mockQueryResultManager{
+			downloadFunc: func(ctx context.Context, key string) ([]byte, error) {
+				return []byte("not valid json"), nil
+			},
+		},
 		Logger: &util.DefaultLogger{},
 	})
 
@@ -315,15 +363,17 @@ func TestQueryHandler_EntrypointFilesCopied(t *testing.T) {
 		startContainerFunc: func(ctx context.Context, exec model.Executable) (*ExecutionResult, error) {
 			capturedExec = exec
 			return &ExecutionResult{
-				Status: "success",
-				Output: `{"status":"ok","data":{}}`,
+				Status:   "success",
+				Output:   "logs only",
+				ExitCode: 0,
 			}, nil
 		},
 	}
 
 	handler := NewQueryHandler(QueryHandlerConfig{
-		Runner: runner,
-		Logger: &util.DefaultLogger{},
+		Runner:        runner,
+		ResultManager: &mockQueryResultManager{},
+		Logger:        &util.DefaultLogger{},
 	})
 
 	request := query.Request{
@@ -347,4 +397,5 @@ func TestQueryHandler_EntrypointFilesCopied(t *testing.T) {
 	assert.Equal(t, "query", capturedExec.Entrypoint)
 	assert.Equal(t, "main.py", capturedExec.EntrypointFiles["query"])
 	assert.Equal(t, "main.py", capturedExec.EntrypointFiles["bot"])
+	assert.NotEmpty(t, capturedExec.QueryResultKey)
 }

--- a/runtime/internal/docker/query_handler_test.go
+++ b/runtime/internal/docker/query_handler_test.go
@@ -202,6 +202,7 @@ func TestQueryHandler_ExecuteScheduledQuery(t *testing.T) {
 			if tt.expectedError != "" {
 				assert.Equal(t, tt.expectedError, response.Error)
 			}
+			assert.NotEmpty(t, resultManager.downloadKey)
 			assert.Equal(t, resultManager.downloadKey, resultManager.deleteKey)
 			assert.True(t, response.Duration > 0)
 			assert.False(t, response.Timestamp.IsZero())

--- a/runtime/internal/docker/query_server_test.go
+++ b/runtime/internal/docker/query_server_test.go
@@ -80,9 +80,15 @@ func TestQueryServer_HandleQuery_Success(t *testing.T) {
 		Runner: &mockDockerRunner{
 			startContainerFunc: func(ctx context.Context, exec model.Executable) (*ExecutionResult, error) {
 				return &ExecutionResult{
-					Status: "success",
-					Output: `{"status":"ok","data":{"positions":[{"symbol":"BTC","amount":1.5}]}}`,
+					Status:   "success",
+					Output:   "container logs are not the result path",
+					ExitCode: 0,
 				}, nil
+			},
+		},
+		ResultManager: &mockQueryResultManager{
+			downloadFunc: func(ctx context.Context, key string) ([]byte, error) {
+				return []byte(`{"status":"ok","data":{"positions":[{"symbol":"BTC","amount":1.5}]}}`), nil
 			},
 		},
 		Logger: &util.DefaultLogger{},

--- a/runtime/internal/docker/runner.go
+++ b/runtime/internal/docker/runner.go
@@ -103,8 +103,8 @@ type dockerRunner struct {
 
 // DockerRunnerOptions contains configuration options for creating a DockerRunner.
 type DockerRunnerOptions struct {
-	Logger       util.Logger   // Optional logger, defaults to util.DefaultLogger if nil
-	ConfigLoader ConfigLoader  // Optional config loader, defaults to EnvConfigLoader if nil
+	Logger       util.Logger         // Optional logger, defaults to util.DefaultLogger if nil
+	ConfigLoader ConfigLoader        // Optional config loader, defaults to EnvConfigLoader if nil
 	Config       *DockerRunnerConfig // Optional pre-loaded config, takes precedence over ConfigLoader
 }
 
@@ -228,6 +228,7 @@ func (r *dockerRunner) buildContainerConfig(
 			r.config.MinIOSecretAccessKey,
 			r.config.MinIOUseSSL,
 		).
+		WithQueryResultBucket(r.config.MinIOQueryResultsBucket).
 		WithDaemonConfigFull(DaemonConfig{
 			BotID:           executable.ID,
 			CodeFile:        executable.FilePath, // Path to code.zip in MinIO
@@ -250,6 +251,9 @@ func (r *dockerRunner) buildContainerConfig(
 		}
 		r.logger.Info("Adding query config to container", "query_path", executable.QueryPath, "params", queryParamsJSON)
 		builder = builder.WithQueryConfig(executable.QueryPath, queryParamsJSON)
+		if executable.QueryResultKey != "" {
+			builder = builder.WithQueryResultKey(executable.QueryResultKey)
+		}
 	}
 
 	// Pass NATS URL so the daemon can publish logs to NATS for real-time streaming

--- a/runtime/internal/execute/helpers.go
+++ b/runtime/internal/execute/helpers.go
@@ -131,6 +131,14 @@ func BuildBotEnv(cfg *Config) []string {
 		"ENTRYPOINT_TYPE=bot",         // Used by Node.js wrapper
 	)
 
+	if cfg.Runtime == "python3.11" {
+		pythonPath := strings.Join([]string{filepath.Join(cfg.CodePath, "vendor"), cfg.CodePath}, string(os.PathListSeparator))
+		if existing := os.Getenv("PYTHONPATH"); existing != "" {
+			pythonPath = pythonPath + string(os.PathListSeparator) + existing
+		}
+		env = append(env, "PYTHONPATH="+pythonPath)
+	}
+
 	// Add query-specific env vars if applicable
 	if cfg.QueryPath != "" {
 		env = append(env, "QUERY_PATH="+cfg.QueryPath)

--- a/runtime/internal/execute/helpers_test.go
+++ b/runtime/internal/execute/helpers_test.go
@@ -234,7 +234,15 @@ func TestBuildBotEnv_QueryParams(t *testing.T) {
 }
 
 func TestBuildBotEnv_PythonPathIncludesVendor(t *testing.T) {
+	old, hadOld := os.LookupEnv("PYTHONPATH")
 	os.Unsetenv("PYTHONPATH")
+	defer func() {
+		if hadOld {
+			_ = os.Setenv("PYTHONPATH", old)
+		} else {
+			os.Unsetenv("PYTHONPATH")
+		}
+	}()
 
 	cfg := &Config{
 		BotID:    "test-bot",
@@ -244,12 +252,20 @@ func TestBuildBotEnv_PythonPathIncludesVendor(t *testing.T) {
 
 	env := BuildBotEnv(cfg)
 
-	assert.Contains(t, env, "PYTHONPATH=/bot/vendor:/bot")
+	sep := string(os.PathListSeparator)
+	assert.Contains(t, env, "PYTHONPATH=/bot/vendor"+sep+"/bot")
 }
 
 func TestBuildBotEnv_PythonPathPreservesExisting(t *testing.T) {
-	os.Setenv("PYTHONPATH", "/existing")
-	defer os.Unsetenv("PYTHONPATH")
+	old, hadOld := os.LookupEnv("PYTHONPATH")
+	_ = os.Setenv("PYTHONPATH", "/existing")
+	defer func() {
+		if hadOld {
+			_ = os.Setenv("PYTHONPATH", old)
+		} else {
+			os.Unsetenv("PYTHONPATH")
+		}
+	}()
 
 	cfg := &Config{
 		BotID:    "test-bot",
@@ -259,7 +275,8 @@ func TestBuildBotEnv_PythonPathPreservesExisting(t *testing.T) {
 
 	env := BuildBotEnv(cfg)
 
-	assert.Contains(t, env, "PYTHONPATH=/bot/vendor:/bot:/existing")
+	sep := string(os.PathListSeparator)
+	assert.Contains(t, env, "PYTHONPATH=/bot/vendor"+sep+"/bot"+sep+"/existing")
 }
 
 func TestBuildBotEnv_BotType(t *testing.T) {

--- a/runtime/internal/execute/helpers_test.go
+++ b/runtime/internal/execute/helpers_test.go
@@ -233,6 +233,35 @@ func TestBuildBotEnv_QueryParams(t *testing.T) {
 	assert.Contains(t, env, "QUERY_PARAM_offset=20")
 }
 
+func TestBuildBotEnv_PythonPathIncludesVendor(t *testing.T) {
+	os.Unsetenv("PYTHONPATH")
+
+	cfg := &Config{
+		BotID:    "test-bot",
+		Runtime:  "python3.11",
+		CodePath: "/bot",
+	}
+
+	env := BuildBotEnv(cfg)
+
+	assert.Contains(t, env, "PYTHONPATH=/bot/vendor:/bot")
+}
+
+func TestBuildBotEnv_PythonPathPreservesExisting(t *testing.T) {
+	os.Setenv("PYTHONPATH", "/existing")
+	defer os.Unsetenv("PYTHONPATH")
+
+	cfg := &Config{
+		BotID:    "test-bot",
+		Runtime:  "python3.11",
+		CodePath: "/bot",
+	}
+
+	env := BuildBotEnv(cfg)
+
+	assert.Contains(t, env, "PYTHONPATH=/bot/vendor:/bot:/existing")
+}
+
 func TestBuildBotEnv_BotType(t *testing.T) {
 	cfg := &Config{
 		BotID:   "test-bot",

--- a/runtime/internal/model/executable.go
+++ b/runtime/internal/model/executable.go
@@ -13,5 +13,6 @@ type Executable struct {
 	// Query execution fields (used when Entrypoint == "query")
 	QueryPath      string                 // The query path to execute (e.g., "/portfolio")
 	QueryParams    map[string]interface{} // Query parameters as key-value pairs
+	QueryResultKey string                 // MinIO key for ephemeral query result handoff
 	ResultFilePath string                 // Custom result file path (default: /bot/result.json)
 }


### PR DESCRIPTION
## Summary
- make Docker scheduled queries use the same MinIO query-result handoff as Kubernetes
- pass QUERY_RESULT_KEY through the Docker executable/container path and remove Docker result-file copy dependence for scheduled queries
- keep Python direct query entrypoints aware of vendored dependencies
- fail keyed ephemeral queries if result upload fails

## Tests
- go test ./internal/docker -run 'TestQueryHandler|TestQueryServer_HandleQuery_Success|TestContainerBuilder|TestLoadConfigFromEnv'\n- go test ./cmd/app ./internal/execute ./internal/k8s/...\n\n## Notes\n- Full `go test ./cmd/app ./internal/execute ./internal/docker ./internal/k8s/...` was attempted, but the existing Docker integration test `TestIntegration_RealDocker_StartStopContainer_BotEntrypoint` saw extra `runtime.managed=true` containers already present on the local Docker daemon. I did not tear down the local stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query execution now properly validates and handles result management through cloud storage
  * Python runtime now includes vendored dependencies in the execution environment

* **Bug Fixes**
  * Query execution now fails appropriately when result management operations fail, instead of silently continuing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alexanderwanyoike/the0/pull/283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->