### PR TITLE
fix: avoid pulling source-mode runtime image

### DIFF
--- a/cli/internal/local/compose_files/docker-compose.yml
+++ b/cli/internal/local/compose_files/docker-compose.yml
@@ -155,7 +155,7 @@ services:
       args:
         - BUILDKIT_INLINE_CACHE=1
     image: the0/runtime:latest
-    pull_policy: always
+    pull_policy: never
     environment:
       # Runtime image override (use locally built image for bot containers)
       RUNTIME_IMAGE: the0/runtime:latest
@@ -217,7 +217,7 @@ services:
       args:
         - BUILDKIT_INLINE_CACHE=1
     image: the0/runtime:latest
-    pull_policy: always
+    pull_policy: never
     environment:
       # Runtime image override (use locally built image for bot containers)
       RUNTIME_IMAGE: the0/runtime:latest
@@ -278,7 +278,7 @@ services:
       args:
         - BUILDKIT_INLINE_CACHE=1
     image: the0/runtime:latest
-    pull_policy: always
+    pull_policy: never
     environment:
       MONGO_URI: mongodb://root:the0_mongo_password@mongo:27017
       MINIO_ENDPOINT: minio:9000
@@ -311,7 +311,7 @@ services:
       args:
         - BUILDKIT_INLINE_CACHE=1
     image: the0/runtime:latest
-    pull_policy: always
+    pull_policy: never
     environment:
       # Runtime image override (use locally built image for bot containers)
       RUNTIME_IMAGE: the0/runtime:latest


### PR DESCRIPTION
## Summary
- set source-mode runtime services to `pull_policy: never`
- keeps prebuilt compose pulling GHCR images unchanged
- removes noisy Docker Hub pull attempts for locally built `the0/runtime:latest`

## Tests
- `go test ./...` from `cli`
- repo-built CLI: `local init --source /home/alexander/Code/Apps/the0 && local start`
- `local status` shows all services healthy
- confirmed no `the0/runtime:latest pull access denied` warnings during source-mode start

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose configuration to use locally cached images for several services instead of pulling from remote registries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alexanderwanyoike/the0/pull/284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->