### PR TITLE
Fix K8s runtime image wiring

### DIFF
--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -63,6 +63,9 @@ minikube-up: check-minikube-deps ## Build, deploy and show service URLs (simplif
 		--set the0Docs.imagePullPolicy=Never \
 		--set botController.image.tag=latest \
 		--set botController.runtimeImage=runtime:latest \
+		--set gc.image.repository=runtime \
+		--set gc.image.tag=latest \
+		--set gc.image.pullPolicy=Never \
 		--set minikube.enabled=true \
 		--set externalServices.enabled=true
 	@echo ""
@@ -157,6 +160,9 @@ minikube-controller: check-minikube-deps ## Deploy in K8s-native controller mode
 		--set botController.imagePullPolicy=Never \
 		--set botController.runtimeImage=runtime:latest \
 		--set botController.imageBuilder.registry=localhost:5000 \
+		--set gc.image.repository=runtime \
+		--set gc.image.tag=latest \
+		--set gc.image.pullPolicy=Never \
 		--set minikube.enabled=true \
 		--set externalServices.enabled=true
 	@echo ""

--- a/k8s/templates/gc-cronjob.yaml
+++ b/k8s/templates/gc-cronjob.yaml
@@ -38,7 +38,7 @@ spec:
                 - name: MINIO_ENDPOINT
                   value: {{ include "the0.minioEndpointWithPort" . | quote }}
                 - name: MINIO_USE_SSL
-                  value: {{ .Values.minio.external.useSSL | default false | quote }}
+                  value: {{ include "the0.minioUseSSL" . | quote }}
                 - name: MINIO_ACCESS_KEY
                   valueFrom:
                     secretKeyRef:

--- a/runtime/internal/k8s/podgen/pod_generator.go
+++ b/runtime/internal/k8s/podgen/pod_generator.go
@@ -100,10 +100,9 @@ func (g *PodGenerator) GeneratePod(bot model.Bot) (*corev1.Pod, error) {
 		return nil, err
 	}
 
-	// Get the runtime image
-	image, err := runtimepkg.GetDockerImage(botConfig.runtime)
+	image, err := g.runtimeImageFor(botConfig.runtime)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Docker image: %w", err)
+		return nil, err
 	}
 
 	// Build the pod using the fluent builder
@@ -146,10 +145,9 @@ func (g *PodGenerator) GenerateScheduledPodSpec(bot model.Bot) (*corev1.PodSpec,
 		return nil, err
 	}
 
-	// Get the runtime image
-	image, err := runtimepkg.GetDockerImage(botConfig.runtime)
+	image, err := g.runtimeImageFor(botConfig.runtime)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Docker image: %w", err)
+		return nil, err
 	}
 
 	// Build the pod for scheduled execution - NO sidecars
@@ -187,10 +185,9 @@ func (g *PodGenerator) GenerateQueryPod(bot model.Bot, queryPath string, queryPa
 		return nil, err
 	}
 
-	// Get the runtime image
-	image, err := runtimepkg.GetDockerImage(botConfig.runtime)
+	image, err := g.runtimeImageFor(botConfig.runtime)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Docker image: %w", err)
+		return nil, err
 	}
 
 	// Use query entrypoint if available, otherwise fall back to bot entrypoint
@@ -216,6 +213,13 @@ func (g *PodGenerator) GenerateQueryPod(bot model.Bot, queryPath string, queryPa
 		ForQuery(queryPath, queryParams)
 
 	return builder.Build()
+}
+
+func (g *PodGenerator) runtimeImageFor(runtime string) (string, error) {
+	if _, err := runtimepkg.GetDockerImage(runtime); err != nil {
+		return "", fmt.Errorf("failed to validate runtime image: %w", err)
+	}
+	return g.config.RuntimeImage, nil
 }
 
 // botConfig holds extracted and validated bot configuration.

--- a/runtime/internal/k8s/podgen/pod_generator_test.go
+++ b/runtime/internal/k8s/podgen/pod_generator_test.go
@@ -75,7 +75,7 @@ func TestPodGenerator_GeneratePod_RealtimeBot(t *testing.T) {
 	// Bot container
 	botContainer := pod.Spec.Containers[0]
 	assert.Equal(t, "bot", botContainer.Name)
-	assert.Equal(t, "ghcr.io/alexanderwanyoike/the0/runtime:latest", botContainer.Image)
+	assert.Equal(t, "the0/runtime:latest", botContainer.Image)
 	assert.Equal(t, []string{"/app/runtime", "execute", "--skip-sync", "--skip-query-server"}, botContainer.Command)
 	assert.Equal(t, "/bot", botContainer.WorkingDir)
 
@@ -150,7 +150,9 @@ func TestPodGenerator_GeneratePod_WithQueryEntrypoint(t *testing.T) {
 	// Should have 2 containers: bot + query-server
 	require.Len(t, pod.Spec.Containers, 2)
 	assert.Equal(t, "bot", pod.Spec.Containers[0].Name)
+	assert.Equal(t, "the0/runtime:latest", pod.Spec.Containers[0].Image)
 	assert.Equal(t, "query-server", pod.Spec.Containers[1].Name)
+	assert.Equal(t, "the0/runtime:latest", pod.Spec.Containers[1].Image)
 
 	// Query server should have correct command
 	queryContainer := pod.Spec.Containers[1]
@@ -195,6 +197,7 @@ func TestPodGenerator_GenerateScheduledPodSpec(t *testing.T) {
 	// Sync runs inline as part of the execute command
 	require.Len(t, podSpec.Containers, 1)
 	assert.Equal(t, "bot", podSpec.Containers[0].Name)
+	assert.Equal(t, "the0/runtime:latest", podSpec.Containers[0].Image)
 
 	// Bot should use inline sync (no --skip-sync flag)
 	botCommand := podSpec.Containers[0].Command
@@ -246,6 +249,7 @@ func TestPodGenerator_GenerateQueryPod(t *testing.T) {
 	// Should have only 1 container: bot (no sidecars)
 	require.Len(t, pod.Spec.Containers, 1)
 	assert.Equal(t, "bot", pod.Spec.Containers[0].Name)
+	assert.Equal(t, "the0/runtime:latest", pod.Spec.Containers[0].Image)
 
 	// Should have QUERY_PATH and QUERY_PARAMS env vars
 	envMap := make(map[string]string)


### PR DESCRIPTION
## Summary
- use the configured K8s runtime image for realtime, scheduled, and query bot containers instead of falling back to the hard-coded GHCR runtime image
- keep runtime validation in pod generation so unsupported runtime names still fail early
- align the GC CronJob with local/minikube runtime defaults and the shared MinIO SSL helper

## Why
K8s smoke testing from `dev` exposed two local-controller failures:
- bot workloads rendered `ghcr.io/alexanderwanyoike/the0/runtime:latest` with `imagePullPolicy: Never`, even though Helm passed `--runtime-image=runtime:latest`
- the GC CronJob tried to pull `ghcr.io/alexanderwanyoike/the0/runtime:1.13.5`, which does not exist, and rendered `MINIO_USE_SSL=true` against internal MinIO

## Verification
- `go test ./internal/k8s/...`
- `helm lint ./k8s`
- minikube K8s smoke:
  - API, frontend, docs, MinIO, Mongo, NATS, Postgres, bot-controller all running
  - realtime bot pod `3/3 Running` with bot/query/sync containers all using `runtime:latest` and `Never`
  - scheduled bot CronJob uses `runtime:latest` and completed scheduled jobs
  - `the0 bot list` returned the realtime and scheduled smoke bots
  - `the0 bot logs` returned logs for both bots
  - `the0 bot state list` returned persisted state for scheduled and realtime bots
  - realtime query `/current-price` returned current price data
  - scheduled query `/portfolio` returned portfolio history
  - controller logs showed scheduled query result download and cleanup
  - manual GC job completed with `runtime:latest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime container image configuration to use `the0/runtime:latest`
  * Enhanced deployment configuration with Helm helpers for improved SSL settings consistency across garbage collection and pod generation services

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alexanderwanyoike/the0/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->