### PR TITLE
Add v1.14 root admin migration guide

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -122,6 +122,14 @@ export default withMermaid(defineConfig({
           { text: 'Kubernetes', link: '/deployment/kubernetes' },
           { text: 'Admin Bootstrap', link: '/deployment/admin-bootstrap' },
         ]
+      },
+      {
+        text: 'Migration Guides',
+        collapsed: false,
+        items: [
+          { text: 'Overview', link: '/migration-guides/' },
+          { text: 'v1.14.0 Root Admin', link: '/migration-guides/v1-14-root-admin' },
+        ]
       }
     ],
 

--- a/docs/deployment/admin-bootstrap.md
+++ b/docs/deployment/admin-bootstrap.md
@@ -7,7 +7,7 @@ order: 3
 
 # Root Admin Configuration
 
-the0 does not allow public signup and no longer has a browser setup flow. Every deployment must configure one root admin with:
+the0 does not allow public registration. Every deployment must configure one root admin with:
 
 - `THE0_ADMIN_EMAIL`
 - `THE0_ADMIN_PASSWORD`
@@ -27,19 +27,21 @@ The configured root admin's email and password cannot be changed through the UI 
 
 Additional admins and normal users are managed from `/settings/users` after login.
 
+If you are upgrading an existing deployment, follow the [v1.14.0 Root Admin Migration Guide](/migration-guides/v1-14-root-admin) before rolling out the new API.
+
 ## Behavior Matrix
 
 | State | Configuration | Startup behavior |
 |-------|---------------|------------------|
 | Fresh install, no config | none | API fails startup |
 | Fresh install, email/password config | `THE0_ADMIN_EMAIL` and `THE0_ADMIN_PASSWORD` | Creates the root admin automatically |
-| Upgrade, users exist, no admin | email/password for an existing user | Promotes and activates that user, then sets the password |
-| Upgrade, admin email only | `THE0_ADMIN_EMAIL` only | API fails startup |
-| Already-promoted admin with unknown password | same admin email plus a new password | Updates that admin password and invalidates old sessions |
-| Active admin already working | same email and same password | No mutation |
-| Active admin password rotated in config | same email and changed password | Updates password once and increments `session_version` |
+| Upgrade, users exist, configured email matches a user | email/password for that existing user | Promotes and activates that user, then sets the password |
+| Upgrade, users exist, configured email does not match a user | email/password for a new root admin | Creates a new active root admin |
+| Upgrade or startup with email only | `THE0_ADMIN_EMAIL` only | API fails startup |
+| Configured root admin already matches config | same email and same password | No mutation |
+| Configured root admin password rotated in config | same email and changed password | Updates password once and increments `session_version` |
 
-During upgrades, the API also preserves legacy `metadata.role = "admin"` by promoting those users before syncing the configured root admin.
+v1.14.0 introduces the enforced admin role column. During upgrades, the API also preserves the old seed-script `metadata.role = "admin"` marker by promoting those users before syncing the configured root admin.
 
 ## Docker Compose
 

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -47,7 +47,9 @@ See [Kubernetes Deployment](./kubernetes) for setup instructions.
 
 ### Root Admin
 
-Public signup is disabled and the browser setup flow has been removed. Every deployment must configure `THE0_ADMIN_EMAIL` and `THE0_ADMIN_PASSWORD`; the API creates or syncs that root admin on startup. See [Root Admin Configuration](./admin-bootstrap).
+Public registration is disabled. Every deployment must configure `THE0_ADMIN_EMAIL` and `THE0_ADMIN_PASSWORD`; the API creates or syncs that root admin on startup. See [Root Admin Configuration](./admin-bootstrap).
+
+Upgrading from an older deployment requires an explicit migration step. See the [v1.14.0 Root Admin Migration Guide](/migration-guides/v1-14-root-admin).
 
 ## When to Use Each Mode
 

--- a/docs/migration-guides/index.md
+++ b/docs/migration-guides/index.md
@@ -1,0 +1,14 @@
+---
+title: "Migration Guides"
+description: "Operator migration guides for the0 releases"
+order: 6
+---
+
+# Migration Guides
+
+Use these guides before upgrading deployments that already have data or users.
+They focus on operator actions that are easy to miss from release notes alone.
+
+## Guides
+
+- [v1.14.0 Root Admin Migration](./v1-14-root-admin) - migrate from public-registration deployments to deployment-managed root admin credentials.

--- a/docs/migration-guides/v1-14-root-admin.md
+++ b/docs/migration-guides/v1-14-root-admin.md
@@ -1,0 +1,169 @@
+---
+title: "v1.14.0 Root Admin Migration"
+description: "Move existing deployments to deployment-managed root admin credentials"
+tags: ["migration", "deployment", "auth", "admin"]
+order: 1
+---
+
+# v1.14.0 Root Admin Migration
+
+v1.14.0 removes public registration and introduces an explicit admin role model. The API now requires a deployment-managed root admin on every startup:
+
+- `THE0_ADMIN_EMAIL`
+- `THE0_ADMIN_PASSWORD`
+
+If either value is missing, empty, or invalid, the API fails startup and writes the reason to API logs. The frontend stays on login and does not expose bootstrap errors.
+
+The configured root admin is managed by deployment configuration. Its email and password cannot be changed through the UI. To rotate the password, update deployment configuration and restart or roll out the API.
+
+## Who Must Act
+
+You must update configuration before upgrading if:
+
+- You run an existing the0 deployment.
+- Your deployment relied on public registration.
+- Your local Docker Compose files were generated before v1.14.0.
+- Your Kubernetes values do not set `THE0_ADMIN_EMAIL` and secret-backed `THE0_ADMIN_PASSWORD`.
+
+Fresh deployments also need these values. There is no no-config first-user path in v1.14.0.
+
+## What Changes
+
+| Before v1.14.0 | v1.14.0 and later |
+| --- | --- |
+| Public registration could create ordinary user accounts | Public registration is removed |
+| Users did not have an enforced `admin`/`user` role column | Users have explicit roles and admin-only management routes |
+| Any existing user password was user-managed | The configured root admin password is deployment-managed |
+| Missing root admin config was not a startup concern | Missing root admin config fails API startup |
+
+Existing users are preserved. The email you configure becomes the deployment-managed root admin: if it matches an existing user, that user is promoted and the configured password is applied; if it does not match, a new root admin user is created.
+
+The old seed script stored `metadata.role = "admin"` on its seeded user even though there was no enforced role column. During startup, v1.14.0 preserves that legacy marker by promoting those users before syncing the configured root admin.
+
+## Choose The Root Admin
+
+Pick the email address that should be deployment-managed:
+
+- If that user already exists, the API promotes and activates the user, then applies `THE0_ADMIN_PASSWORD`.
+- If that user does not exist, the API creates a new active admin for that email.
+- If the password already matches, the API does not update the user again.
+
+Use a real operator-controlled email address. Do not use a shared throwaway email for production.
+
+## Docker Compose
+
+Update the CLI first, then refresh the generated Compose files and configure the root admin.
+
+For a source-mode local install:
+
+```bash
+the0 local init --source /path/to/the0 --email admin@example.com --password 'new-password'
+the0 local start
+```
+
+For a prebuilt-image local install:
+
+```bash
+the0 local init --email admin@example.com --password 'new-password'
+the0 local start
+```
+
+Rerunning `the0 local init` is important for older installs because it refreshes `~/.the0/compose/docker-compose.yml`. Older generated Compose files may not pass `THE0_ADMIN_PASSWORD` into `the0-api`.
+
+To rotate the local root admin password later:
+
+```bash
+the0 local reset-admin-password 'new-password'
+```
+
+Then verify the stack:
+
+```bash
+the0 local status
+```
+
+If `the0-api` fails to start, inspect:
+
+```bash
+the0 local logs api
+```
+
+## Kubernetes
+
+Set the root admin email in values and provide the password through a Secret. Do not put the password in plaintext Helm values.
+
+Create or update the Secret:
+
+```bash
+kubectl create secret generic the0-root-admin \
+  --namespace the0 \
+  --from-literal=password='new-password' \
+  --dry-run=client \
+  -o yaml | kubectl apply -f -
+```
+
+Configure values:
+
+```yaml
+the0Api:
+  env:
+    THE0_ADMIN_EMAIL: "admin@example.com"
+  extraEnv:
+    - name: THE0_ADMIN_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: the0-root-admin
+          key: password
+```
+
+Upgrade:
+
+```bash
+helm upgrade the0 ./k8s --namespace the0 --values values.yaml
+kubectl rollout status deploy/the0-api --namespace the0
+```
+
+To rotate the Kubernetes root admin password later, update the Secret and restart or roll out the API:
+
+```bash
+kubectl create secret generic the0-root-admin \
+  --namespace the0 \
+  --from-literal=password='new-password' \
+  --dry-run=client \
+  -o yaml | kubectl apply -f -
+
+kubectl rollout restart deploy/the0-api --namespace the0
+kubectl rollout status deploy/the0-api --namespace the0
+```
+
+## Verify The Migration
+
+Check API readiness:
+
+```bash
+curl -fsS http://localhost:3000/health/ready
+```
+
+Then sign in with:
+
+- Email: `THE0_ADMIN_EMAIL`
+- Password: `THE0_ADMIN_PASSWORD`
+
+The authenticated user should have:
+
+- `role: admin`
+- `isConfiguredRootAdmin: true`
+
+The selected user's previous password should stop working after migration or a configured password rotation.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| API fails with `THE0_ADMIN_EMAIL must be configured` | Email env is missing or empty | Set `THE0_ADMIN_EMAIL` and restart the API |
+| API fails with `THE0_ADMIN_PASSWORD must be configured` | Password env is missing or empty | Set `THE0_ADMIN_PASSWORD` and restart the API |
+| Docker Compose has password in `.env` but API still fails | Generated Compose file is stale | Rerun `the0 local init ...` to refresh Compose files |
+| Kubernetes login still uses old password | Pod has not restarted with updated Secret | Roll out or restart `the0-api` |
+| Login works but root admin cannot change password in UI | Expected behavior | Rotate root admin password through deployment configuration |
+
+See [Root Admin Configuration](/deployment/admin-bootstrap) for the full behavior matrix and last-admin protection rules.


### PR DESCRIPTION
## Summary
- add a Migration Guides section to the docs
- document the v1.14 root admin migration for Docker Compose and Kubernetes
- link the guide from deployment overview and root admin docs

## Verification
- cd docs && yarn build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Migration Guides" section to the documentation with links to migration resources.
  * Added comprehensive v1.14.0 Root Admin Migration guide covering configuration, credential setup, and deployment-specific instructions for Docker Compose and Kubernetes.
  * Updated deployment documentation with explicit migration requirements for upgrades from older versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alexanderwanyoike/the0/pull/291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->