### PR TITLE
Prepare Helm chart for Artifact Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![C#](https://img.shields.io/badge/C%23-.NET%208-512BD4?logo=dotnet)](https://dotnet.microsoft.com/)
 [![Scala](https://img.shields.io/badge/Scala-3-DC322F?logo=scala)](https://www.scala-lang.org/)
 [![Haskell](https://img.shields.io/badge/Haskell-GHC%209.6-5D4F85?logo=haskell)](https://www.haskell.org/)
-[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/the0)](https://artifacthub.io/packages/helm/the0/the0)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/the0)](https://artifacthub.io/packages/search?repo=the0)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ the0Api:
 # Install from the Helm repository
 helm repo add the0 https://alexanderwanyoike.github.io/the0
 helm repo update
-kubectl create namespace the0
+kubectl create namespace the0 --dry-run=client -o yaml | kubectl apply -f -
 read -rsp "Root admin password: " THE0_ADMIN_PASSWORD; echo
 printf '%s' "$THE0_ADMIN_PASSWORD" \
   | kubectl -n the0 create secret generic the0-root-admin --from-file=password=/dev/stdin --dry-run=client -o yaml \

--- a/README.md
+++ b/README.md
@@ -68,11 +68,32 @@ open http://localhost:9001  # MinIO Console (admin/the0password)
 
 ### Option 2: Kubernetes (Helm)
 
+Create `values.yaml` with the deployment-managed root admin email and a
+Secret-backed password reference:
+
+```yaml
+the0Api:
+  env:
+    THE0_ADMIN_EMAIL: "admin@example.com"
+  extraEnv:
+    - name: THE0_ADMIN_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: the0-root-admin
+          key: password
+```
+
 ```bash
 # Install from the Helm repository
 helm repo add the0 https://alexanderwanyoike.github.io/the0
 helm repo update
-helm install the0 the0/the0 --namespace the0 --create-namespace
+kubectl create namespace the0
+read -rsp "Root admin password: " THE0_ADMIN_PASSWORD; echo
+printf '%s' "$THE0_ADMIN_PASSWORD" \
+  | kubectl -n the0 create secret generic the0-root-admin --from-file=password=/dev/stdin --dry-run=client -o yaml \
+  | kubectl apply -f -
+unset THE0_ADMIN_PASSWORD
+helm install the0 the0/the0 --namespace the0 -f values.yaml
 ```
 
 **Local development with Minikube:**

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,4 +1,6 @@
-repositoryID: # Auto-populated after ArtifactHub registration
+# Add this after the repository is registered in Artifact Hub to enable the
+# Verified publisher badge. Artifact Hub exposes the ID on the repository card.
+# repositoryID: 00000000-0000-0000-0000-000000000000
 owners:
   - name: Alexander Wanyoike
     email: team@the0.com

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,6 +1,4 @@
-# Add this after the repository is registered in Artifact Hub to enable the
-# Verified publisher badge. Artifact Hub exposes the ID on the repository card.
-# repositoryID: 00000000-0000-0000-0000-000000000000
+repositoryID: 97e7af7c-6950-4e8c-98ee-0c1f00fc2d45
 owners:
   - name: Alexander Wanyoike
     email: team@the0.com

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -45,7 +45,7 @@ The simplest way to deploy on any Kubernetes cluster:
 ```bash
 helm repo add the0 https://alexanderwanyoike.github.io/the0
 helm repo update
-kubectl create namespace the0
+kubectl create namespace the0 --dry-run=client -o yaml | kubectl apply -f -
 read -rsp "Root admin password: " THE0_ADMIN_PASSWORD; echo
 printf '%s' "$THE0_ADMIN_PASSWORD" \
   | kubectl -n the0 create secret generic the0-root-admin --from-file=password=/dev/stdin --dry-run=client -o yaml \
@@ -101,7 +101,7 @@ cd k8s
 
 # Configure the root admin password secret once
 minikube start --memory=4096 --cpus=4 --disk-size=20g --driver=docker
-kubectl create namespace the0
+kubectl create namespace the0 --dry-run=client -o yaml | kubectl apply -f -
 read -rsp "Root admin password: " THE0_ADMIN_PASSWORD; echo
 printf '%s' "$THE0_ADMIN_PASSWORD" \
   | kubectl -n the0 create secret generic the0-root-admin --from-file=password=/dev/stdin --dry-run=client -o yaml \

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: the0
 description: An open-source algorithmic trading platform for creating, deploying, and managing trading bots
 type: application
-version: 0.9.0
+version: 0.9.1
 appVersion: "1.14.0"
 kubeVersion: ">=1.21.0-0"
 keywords:
@@ -30,6 +30,8 @@ annotations:
     - name: Discord
       url: https://discord.gg/g5mp57nK
   artifacthub.io/changes: |
+    - kind: changed
+      description: Clarify Helm install documentation for deployment-managed root admin credentials
     - kind: changed
       description: Replace public landing, signup, and setup flows with login-first app routing
     - kind: added

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -29,7 +29,7 @@ Then install the chart:
 ```bash
 helm repo add the0 https://alexanderwanyoike.github.io/the0
 helm repo update
-kubectl create namespace the0
+kubectl create namespace the0 --dry-run=client -o yaml | kubectl apply -f -
 read -rsp "Root admin password: " THE0_ADMIN_PASSWORD; echo
 printf '%s' "$THE0_ADMIN_PASSWORD" \
   | kubectl -n the0 create secret generic the0-root-admin --from-file=password=/dev/stdin --dry-run=client -o yaml \
@@ -169,7 +169,7 @@ Or if `make minikube-up` handles image building automatically, just run:
 
 ```bash
 minikube start --memory=4096 --cpus=4 --disk-size=20g --driver=docker
-kubectl create namespace the0
+kubectl create namespace the0 --dry-run=client -o yaml | kubectl apply -f -
 read -rsp "Root admin password: " THE0_ADMIN_PASSWORD; echo
 printf '%s' "$THE0_ADMIN_PASSWORD" \
   | kubectl -n the0 create secret generic the0-root-admin --from-file=password=/dev/stdin --dry-run=client -o yaml \

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -8,11 +8,39 @@ This directory contains Helm charts and configuration for deploying the0 platfor
 
 ### Install from Helm Repository
 
+Create a values file with the deployment-managed root admin email and a
+Secret-backed password reference:
+
+```yaml
+# values.yaml
+the0Api:
+  env:
+    THE0_ADMIN_EMAIL: "admin@example.com"
+  extraEnv:
+    - name: THE0_ADMIN_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: the0-root-admin
+          key: password
+```
+
+Then install the chart:
+
 ```bash
 helm repo add the0 https://alexanderwanyoike.github.io/the0
 helm repo update
-helm install the0 the0/the0 --namespace the0 --create-namespace
+kubectl create namespace the0
+read -rsp "Root admin password: " THE0_ADMIN_PASSWORD; echo
+printf '%s' "$THE0_ADMIN_PASSWORD" \
+  | kubectl -n the0 create secret generic the0-root-admin --from-file=password=/dev/stdin --dry-run=client -o yaml \
+  | kubectl apply -f -
+unset THE0_ADMIN_PASSWORD
+helm install the0 the0/the0 --namespace the0 -f values.yaml
 ```
+
+The API fails startup if `THE0_ADMIN_EMAIL` or `THE0_ADMIN_PASSWORD` is
+missing. For production, use your normal secret workflow such as Sealed Secrets,
+External Secrets, or a protected Secret manifest.
 
 ### Minikube (Local Development)
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,4 +1,4 @@
-[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/the0)](https://artifacthub.io/packages/helm/the0/the0)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/the0)](https://artifacthub.io/packages/search?repo=the0)
 
 # the0 Kubernetes Deployment
 


### PR DESCRIPTION
## Summary
- Bump the Helm chart to 0.9.1 so Artifact Hub can index a fresh package with corrected install docs.
- Update README and chart README Helm install snippets to include deployment-managed root admin configuration.
- Clarify artifacthub-repo.yml so repositoryID is added after Artifact Hub registration instead of being an empty field.

## Verification
- helm lint k8s
- helm package k8s --destination /tmp/the0-chart-artifacthub
- helm show chart /tmp/the0-chart-artifacthub/the0-0.9.1.tgz
- helm show readme /tmp/the0-chart-artifacthub/the0-0.9.1.tgz
- helm template the0 k8s --namespace the0 -f <root-admin-values>
- git diff --check

## Follow-up after merge
1. Merge this PR into dev, then release dev to main so chart 0.9.1 is published to https://alexanderwanyoike.github.io/the0.
2. In Artifact Hub, add a Helm repository named the0 with URL https://alexanderwanyoike.github.io/the0.
3. If claiming ownership or enabling Verified publisher, make sure the Artifact Hub account email matches artifacthub-repo.yml owners, then add the repository ID Artifact Hub gives us to artifacthub-repo.yml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes Helm quick-start instructions for improved root-admin credential management
  * Clarified Secret-backed password reference and `values.yaml` configuration requirements

* **Chores**
  * Bumped Helm chart version to 0.9.1
  * Updated Artifact Hub registry metadata

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alexanderwanyoike/the0/pull/292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->