### PR TITLE
Raise shared password policy minimum

### DIFF
--- a/api/src/common/password-policy.spec.ts
+++ b/api/src/common/password-policy.spec.ts
@@ -1,0 +1,13 @@
+import { MIN_PASSWORD_LENGTH, validatePasswordPolicy } from "./password-policy";
+
+describe("password policy", () => {
+  it("rejects passwords shorter than the minimum length", () => {
+    expect(validatePasswordPolicy("1234567")).toBe(
+      `Password must be at least ${MIN_PASSWORD_LENGTH} characters long`,
+    );
+  });
+
+  it("allows passwords at the minimum length", () => {
+    expect(validatePasswordPolicy("12345678")).toBeNull();
+  });
+});

--- a/api/src/common/password-policy.ts
+++ b/api/src/common/password-policy.ts
@@ -1,4 +1,4 @@
-export const MIN_PASSWORD_LENGTH = 6;
+export const MIN_PASSWORD_LENGTH = 8;
 
 export function validatePasswordPolicy(password: string): string | null {
   if (password.length < MIN_PASSWORD_LENGTH) {


### PR DESCRIPTION
## Summary
- raise the shared password minimum from 6 to 8 characters
- add focused coverage for the password policy helper

## Test
- yarn test password-policy.spec.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated minimum password length requirement from 6 to 8 characters.

* **Tests**
  * Added test suite validating password policy requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alexanderwanyoike/the0/pull/294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->