### PR TITLE
Validate bot IDs on REST log reads

### DIFF
--- a/api/src/logs/__tests__/logs.controller.spec.ts
+++ b/api/src/logs/__tests__/logs.controller.spec.ts
@@ -91,6 +91,18 @@ describe("LogsController", () => {
       ).rejects.toThrow("Invalid date format");
     });
 
+    it("should reject invalid bot IDs before querying logs", async () => {
+      await expect(
+        controller.getLogs(
+          "../../etc/passwd",
+          { limit: 100, offset: 0 } as any,
+          mockUser,
+        ),
+      ).rejects.toThrow("Invalid bot ID");
+
+      expect(mockLogsService.getLogs).not.toHaveBeenCalled();
+    });
+
     it("should pass type parameter to service", async () => {
       const mockLogs = [
         { date: "20260210", content: '{"_metric":true,"value":42}' },

--- a/api/src/logs/logs.controller.ts
+++ b/api/src/logs/logs.controller.ts
@@ -69,6 +69,10 @@ export class LogsController {
     @Query() query: GetLogsQueryDto,
     @CurrentUser() user: AuthenticatedUser,
   ) {
+    if (!VALID_BOT_ID.test(botId)) {
+      throw new BadRequestException("Invalid bot ID");
+    }
+
     const result = await this.logsService.getLogs(botId, {
       date: query.date,
       dateRange: query.dateRange,


### PR DESCRIPTION
## Summary
- reject invalid REST log bot IDs before they reach storage path construction
- add regression coverage for unsafe bot IDs on getLogs

Fixes #202

## Test
- yarn test logs.controller.spec.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject requests with invalid bot IDs before processing.

* **Tests**
  * Added test coverage for bot ID validation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alexanderwanyoike/the0/pull/295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->