### PR TITLE
Verify API build in CI

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -41,6 +41,10 @@ jobs:
       working-directory: ./api
       run: yarn test
 
+    - name: Verify build
+      working-directory: ./api
+      run: yarn build
+
   build-and-push:
     needs: test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- run yarn build after API tests in CI
- keeps PR and tagged release flows from reaching Docker publishing with TypeScript build failures

Fixes #196

## Test
- Not run locally; workflow-only change.