### PR TITLE
Add deployment runbooks for local and production ops

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -118,9 +118,12 @@ export default withMermaid(defineConfig({
         collapsed: false,
         items: [
           { text: 'Overview', link: '/deployment/' },
+          { text: 'Local Getting Started', link: '/deployment/local-getting-started' },
           { text: 'Docker Compose', link: '/deployment/docker-compose' },
           { text: 'Kubernetes', link: '/deployment/kubernetes' },
           { text: 'Admin Bootstrap', link: '/deployment/admin-bootstrap' },
+          { text: 'Production Checklist', link: '/deployment/production-checklist' },
+          { text: 'Secret Rotation', link: '/deployment/secret-rotation' },
         ]
       },
       {

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -39,6 +39,8 @@ Docker Compose provides the simplest and most tested path to running the0. A sin
 
 See [Docker Compose Deployment](./docker-compose) for setup instructions.
 
+For the CLI-managed local workflow, see [Local Getting Started](./local-getting-started).
+
 ### Kubernetes (Multi-Node & HA)
 
 Kubernetes mode is for deployments that need multi-node scaling or high availability. The runtime controller manages bots as individual Pods, leveraging K8s for scheduling, health checks, and automatic restarts.
@@ -50,6 +52,11 @@ See [Kubernetes Deployment](./kubernetes) for setup instructions.
 Public registration is disabled. Every deployment must configure `THE0_ADMIN_EMAIL` and `THE0_ADMIN_PASSWORD`; the API creates or syncs that root admin on startup. See [Root Admin Configuration](./admin-bootstrap).
 
 Upgrading from an older deployment requires an explicit migration step. See the [v1.14.0 Root Admin Migration Guide](/migration-guides/v1-14-root-admin).
+
+## Operator Runbooks
+
+- [Production Checklist](./production-checklist) covers the preflight checks for credentials, TLS, storage, backups, runtime limits, and upgrades.
+- [Secret Rotation](./secret-rotation) covers local root admin rotation, Kubernetes Secret updates, Sealed Secrets, and external service credentials.
 
 ## When to Use Each Mode
 

--- a/docs/deployment/local-getting-started.md
+++ b/docs/deployment/local-getting-started.md
@@ -1,0 +1,91 @@
+---
+title: "Local Getting Started"
+description: "Start and operate a local the0 stack with the CLI"
+tags: ["deployment", "local", "docker-compose"]
+order: 1
+---
+
+# Local Getting Started
+
+Use `the0 local` when you want a full platform stack on one machine. The CLI writes Docker Compose files to `~/.the0/compose/`, manages the root admin credentials, and starts the API, frontend, docs, runtime workers, and backing services.
+
+## Initialize
+
+Prebuilt images are the fastest path:
+
+```bash
+the0 local init --email you@example.com --password testuse123
+```
+
+If you omit either flag, the CLI prompts interactively. The password prompt does not echo input when stdin is a terminal.
+
+To build the stack from a local clone instead of GHCR images:
+
+```bash
+the0 local init --source /path/to/the0 --email you@example.com --password testuse123
+```
+
+Use `--source` without a path to use the current directory.
+
+## Start And Sign In
+
+```bash
+the0 local start
+```
+
+When startup completes, open:
+
+| Service | URL |
+|---------|-----|
+| Frontend | http://localhost:3001 |
+| API | http://localhost:3000 |
+| Docs | http://localhost:3002 |
+| MinIO Console | http://localhost:9001 |
+
+Sign in at `http://localhost:3001/login` with the root admin email and password configured during `init`.
+
+## Check Status
+
+```bash
+the0 local status
+```
+
+Use this after startup or restart to confirm container state and health. If a service is unhealthy, inspect that service's logs first.
+
+## View Logs
+
+```bash
+the0 local logs          # all services
+the0 local logs api      # API service only
+the0 local logs -f api   # follow API logs
+```
+
+Friendly service names such as `api`, `frontend`, `runner`, and `scheduler` are resolved by the CLI.
+
+## Rotate Root Admin Password
+
+The local root admin is deployment-managed. Rotate it by updating Compose configuration and restarting the API:
+
+```bash
+the0 local reset-admin-password new-password
+```
+
+To change both the email and password:
+
+```bash
+the0 local admin set --email you@example.com
+```
+
+If `--password` is omitted, the CLI prompts for it. The API validates the configured password policy at startup, so check `the0 local logs api` if the API does not become healthy after rotation.
+
+## Development Mode
+
+For frontend and API hot reload, initialize from source and start dev mode:
+
+```bash
+the0 local init --source /path/to/the0 --email you@example.com --password testuse123
+the0 local dev
+```
+
+Dev mode starts infrastructure and runtime services normally, then runs the API and frontend with source mounts for faster iteration.
+

--- a/docs/deployment/production-checklist.md
+++ b/docs/deployment/production-checklist.md
@@ -1,0 +1,53 @@
+---
+title: "Production Checklist"
+description: "Preflight checks before running the0 in production"
+tags: ["deployment", "production", "security"]
+order: 4
+---
+
+# Production Checklist
+
+Use this checklist before exposing a the0 deployment to users or real broker credentials.
+
+## Identity And Access
+
+- Configure `THE0_ADMIN_EMAIL` and `THE0_ADMIN_PASSWORD`; public registration is disabled.
+- Store the root admin password in protected deployment configuration, not plaintext Helm values or committed Compose files.
+- Create named admin and user accounts after first login; avoid routine use of the deployment-managed root admin.
+- Rotate API keys when users leave or automation ownership changes.
+
+## Secrets
+
+- Generate a strong `JWT_SECRET`; the API fails startup when it is missing.
+- Replace default PostgreSQL, MongoDB, MinIO, and Redis credentials.
+- Keep broker and exchange credentials outside bot config until runtime secret storage is available.
+- Use Kubernetes Secrets, Sealed Secrets, External Secrets, or an equivalent secret manager for production clusters.
+
+## Network And TLS
+
+- Terminate HTTPS at the ingress, reverse proxy, or load balancer.
+- Do not expose PostgreSQL, MongoDB, NATS, Redis, or MinIO API ports publicly.
+- Restrict MinIO console access to operators.
+- Set DNS records and ingress hosts before issuing certificates.
+
+## Storage And Backups
+
+- Back up PostgreSQL; it contains users, bot definitions, and platform configuration.
+- Back up MongoDB if runtime state and execution coordination data must survive disaster recovery.
+- Back up object storage buckets containing bot packages, logs, state archives, and artifacts.
+- Test restore steps before relying on the backups.
+
+## Runtime Safety
+
+- Set bot memory and CPU limits for the deployment mode you use.
+- Keep runtime workers on nodes where Docker or Kubernetes permissions are intentional and isolated.
+- Monitor API, runtime, database, NATS, and object storage health.
+- Confirm completed scheduled jobs and pods are cleaned up in Kubernetes deployments.
+
+## Upgrades
+
+- Read migration guides before upgrading across minor versions.
+- For Kubernetes, confirm deployment pod templates include chart-version checksum annotations so Flux and Kubernetes roll pods after chart upgrades.
+- Run upgrades first in a non-production namespace or host when possible.
+- Keep a rollback path for the chart version, image tags, and database backup.
+

--- a/docs/deployment/secret-rotation.md
+++ b/docs/deployment/secret-rotation.md
@@ -1,0 +1,77 @@
+---
+title: "Secret Rotation"
+description: "Rotate root admin and external service secrets safely"
+tags: ["deployment", "secrets", "operations"]
+order: 5
+---
+
+# Secret Rotation
+
+Rotate secrets from the deployment layer, then restart or roll out the services that consume them. Do not change deployment-managed root admin credentials through the UI.
+
+## Local Root Admin
+
+Rotate only the password:
+
+```bash
+the0 local reset-admin-password new-password
+```
+
+Rotate email and password together:
+
+```bash
+the0 local admin set --email admin@example.com
+```
+
+The command updates `~/.the0/compose/.env` and recreates `the0-api`. Existing sessions are invalidated when the configured root admin password changes.
+
+## Kubernetes Root Admin
+
+Root admin password should be supplied from a Secret through `the0Api.extraEnv`:
+
+```yaml
+the0Api:
+  env:
+    THE0_ADMIN_EMAIL: "admin@example.com"
+  extraEnv:
+    - name: THE0_ADMIN_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: the0-root-admin
+          key: password
+```
+
+Update the referenced Secret, then roll the API:
+
+```bash
+kubectl -n the0 rollout restart deployment/the0-api
+kubectl -n the0 rollout status deployment/the0-api
+```
+
+## Sealed Secrets
+
+When using Bitnami Sealed Secrets, rotate by sealing a new Secret value and applying it through GitOps:
+
+```bash
+kubectl -n the0 create secret generic the0-root-admin \
+  --from-literal=password='new-password' \
+  --dry-run=client \
+  -o yaml > /tmp/the0-root-admin.yaml
+
+kubeseal --format yaml < /tmp/the0-root-admin.yaml > clusters/prod/the0-root-admin.sealed.yaml
+```
+
+Commit the sealed manifest and let Flux apply it. After the Secret changes in the cluster, restart the API deployment so startup syncs the configured root admin password.
+
+## External Service Secrets
+
+Rotate database, object storage, NATS, Redis, and JWT secrets one at a time:
+
+1. Create or seal the new secret value.
+2. Apply it to the cluster or host.
+3. Restart the consuming service.
+4. Confirm health checks and login still work.
+5. Remove the old value from the external provider after consumers have moved.
+
+For `JWT_SECRET`, all existing API tokens become invalid after rotation. Plan a user re-login window and rotate API keys separately if required.
+


### PR DESCRIPTION
## Summary
- add a dedicated local getting-started guide for the0 local init/start/status/logs/admin rotation/dev mode
- add a production checklist covering credentials, TLS, storage, backups, runtime safety, and upgrades
- add a secret rotation runbook covering local root admin, Kubernetes Secrets, Sealed Secrets, and external service credentials
- link the new runbooks from deployment docs and sidebar

## Test
- yarn build