### PR TITLE
Remove Kaniko references from Kubernetes docs

### DIFF
--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -174,7 +174,7 @@ minikube-controller: check-minikube-deps ## Deploy in K8s-native controller mode
 	@echo "   - No Docker-in-Docker (no privileged pods)"
 	@echo "   - Each bot runs as its own K8s Pod"
 	@echo "   - Scheduled bots use K8s CronJobs"
-	@echo "   - Kaniko builds bot images automatically"
+	@echo "   - Bot Pods use the configured runtime image"
 	@echo ""
 	@echo "🌐 NodePort URLs (no tunnel required):"
 	@echo "   Frontend:  http://the0.local:30001"

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -383,7 +383,7 @@ manages bots directly:
 
 - Each bot runs as its own Kubernetes Pod
 - Scheduled bots use native Kubernetes CronJobs
-- Kaniko builds bot images automatically (no Docker-in-Docker)
+- Uses the configured runtime image for bot execution
 - No privileged containers required
 - Better security and Kubernetes integration
 
@@ -395,7 +395,7 @@ The chart enables controller mode through `botController.enabled`.
 |---------|-----------------------|
 | **Bot Isolation** | K8s Pods |
 | **Scheduled Bots** | K8s CronJobs |
-| **Image Building** | Kaniko Jobs |
+| **Runtime Image** | Configured runtime image |
 | **Resource Limits** | K8s ResourceQuota |
 | **Monitoring** | `kubectl logs` |
 | **Scaling** | Kubernetes handles scheduling |
@@ -417,7 +417,7 @@ minikube addons enable registry
 
 1. **Bot Controller** reads enabled bots from MongoDB
 2. For each bot, it ensures a matching Pod exists
-3. If the bot image doesn't exist, Kaniko builds it automatically
+3. Bot Pods use the configured runtime image
 4. Config changes trigger Pod recreation
 5. Deleted bots have their Pods removed
 

--- a/k8s/templates/bot-controller.yaml
+++ b/k8s/templates/bot-controller.yaml
@@ -36,7 +36,7 @@ rules:
   - apiGroups: ["batch"]
     resources: ["cronjobs"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  # Job management for Kaniko builds and CronJob jobs
+  # Job management for scheduled bot executions
   - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
## Summary
- remove inaccurate Kaniko claims from Kubernetes controller-mode docs
- update controller-mode output to describe configured runtime image usage
- clarify the bot-controller Job RBAC comment for scheduled bot executions

## Test
- helm template the0 ./k8s >/tmp/the0-helm-template.yaml