### PR TITLE
Pin npm to v10 in runtime image

### DIFF
--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -50,10 +50,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && ln -sf /usr/bin/python3.11 /usr/bin/python
 
 # Node.js 20 LTS
+# npm is pinned to the v10 line: npm@latest (v12+) requires Node >= 22 and
+# breaks the install on Node 20.
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/* \
-    && npm install -g npm@latest
+    && npm install -g npm@10
 
 # .NET 8 Runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary

`runtime/Dockerfile` installs Node.js 20 and then ran `npm install -g npm@latest`. npm 12 (the current `latest`) declares `engines.node >= 22`, so the install now fails with `EBADENGINE` on the image's Node 20 and breaks **every** source build of the runtime image (`the0 local init --source` → `the0 local start`). Nothing in the repo changed; npm's release moved out from under the unpinned `@latest`.

Pin to the npm 10 line, which is what Node 20 ships with (10.8.2). Prebuilt GHCR images are unaffected, which is why this went unnoticed.

## Testing
Full `the0 local start` source build succeeds with this change (previously failed at the Node layer); runtime containers healthy, realtime and scheduled example bots deployed and executing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the runtime environment to use npm version 10 for improved consistency and compatibility.
  * Added explanatory documentation for the npm version selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->