### PR TITLE
feat: Latest interval mode for scheduled-bot dashboards

### DIFF
--- a/api/src/logs/__tests__/get-logs-query.dto.spec.ts
+++ b/api/src/logs/__tests__/get-logs-query.dto.spec.ts
@@ -1,0 +1,43 @@
+import { plainToInstance } from "class-transformer";
+import { validate } from "class-validator";
+import { GetLogsQueryDto } from "../dto/get-logs-query.dto";
+
+async function validateQuery(query: Record<string, string>) {
+  const dto = plainToInstance(GetLogsQueryDto, query);
+  const errors = await validate(dto);
+  return { dto, errors };
+}
+
+describe("GetLogsQueryDto", () => {
+  describe("numeric query params", () => {
+    it.each([
+      ["lookbackDays", "30", 30],
+      ["limit", "100", 100],
+      ["offset", "0", 0],
+    ])("accepts %s=%s", async (field, value, expected) => {
+      const { dto, errors } = await validateQuery({ [field]: value });
+
+      expect(errors).toHaveLength(0);
+      expect((dto as any)[field]).toBe(expected);
+    });
+
+    it.each([
+      ["lookbackDays", "30days"],
+      ["lookbackDays", "1.5"],
+      ["limit", "50abc"],
+      ["offset", "2.5"],
+    ])("rejects malformed %s=%s", async (field, value) => {
+      const { errors } = await validateQuery({ [field]: value });
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].property).toBe(field);
+    });
+
+    it("rejects lookbackDays outside 1-90", async () => {
+      expect((await validateQuery({ lookbackDays: "0" })).errors.length)
+        .toBeGreaterThan(0);
+      expect((await validateQuery({ lookbackDays: "91" })).errors.length)
+        .toBeGreaterThan(0);
+    });
+  });
+});

--- a/api/src/logs/__tests__/logs.controller.spec.ts
+++ b/api/src/logs/__tests__/logs.controller.spec.ts
@@ -131,6 +131,24 @@ describe("LogsController", () => {
       );
     });
 
+    it("should pass lookbackDays parameter to service", async () => {
+      (mockLogsService.getLogs as jest.Mock).mockResolvedValue(
+        Ok({ entries: [], hasMore: false }),
+      );
+
+      await controller.getLogs(
+        "bot-123",
+        { limit: 100, offset: 0, lookbackDays: 30, type: "metrics" } as any,
+        mockUser,
+      );
+
+      expect(mockLogsService.getLogs).toHaveBeenCalledWith(
+        "bot-123",
+        expect.objectContaining({ lookbackDays: 30, type: "metrics" }),
+        "user123",
+      );
+    });
+
     it("should return hasMore=true when entries equal limit", async () => {
       const mockLogs = Array.from({ length: 100 }, (_, i) => ({
         date: "20260210",

--- a/api/src/logs/__tests__/logs.service.spec.ts
+++ b/api/src/logs/__tests__/logs.service.spec.ts
@@ -1258,6 +1258,58 @@ describe("LogsService", () => {
       ]);
     });
 
+    it("should fall back to a full read when the tail window holds too few lines", async () => {
+      const today = localDateStr(0);
+      const todayPath = `logs/bot-1/${today}.log`;
+      // File larger than the 512KB tail window whose tail only contains 2
+      // lines (very long lines); the full file has 5
+      const fullLines = Array.from(
+        { length: 5 },
+        (_, i) => `{"message":"line-${i + 1}"}`,
+      );
+      const notFound = () => {
+        const err: any = new Error("NoSuchKey");
+        err.code = "NoSuchKey";
+        return Promise.reject(err);
+      };
+      mockMinioClient.statObject.mockImplementation(
+        (_bucket: string, path: string) =>
+          path === todayPath
+            ? Promise.resolve({ size: 512 * 1024 + 1000 })
+            : notFound(),
+      );
+      mockMinioClient.getPartialObject.mockImplementation(
+        (_bucket: string, path: string) =>
+          path === todayPath
+            ? Promise.resolve(
+                stringStream("partial-junk\n" + fullLines.slice(-2).join("\n")),
+              )
+            : notFound(),
+      );
+      mockMinioClient.getObject.mockImplementation(
+        (_bucket: string, path: string) =>
+          path === todayPath
+            ? Promise.resolve(stringStream(fullLines.join("\n")))
+            : notFound(),
+      );
+
+      const result = await service.getLogs("bot-1", {
+        lookbackDays: 7,
+        limit: 3,
+        offset: 0,
+      });
+
+      expect(result.success).toBe(true);
+      // Tail yielded only 2 of the needed 4 entries, so the day is re-read
+      // in full and the newest 3 lines are returned
+      expect(result.data!.entries.map((e) => e.content)).toEqual([
+        "line-5",
+        "line-4",
+        "line-3",
+      ]);
+      expect(result.data!.hasMore).toBe(true);
+    });
+
     it("should prefer an explicit date over lookbackDays", async () => {
       mockFiles({
         "logs/bot-1/20260401.log": '{"message":"explicit-date"}',

--- a/api/src/logs/__tests__/logs.service.spec.ts
+++ b/api/src/logs/__tests__/logs.service.spec.ts
@@ -1099,6 +1099,199 @@ describe("LogsService", () => {
     });
   });
 
+  describe("getLogs - lookbackDays (latest mode)", () => {
+    /** Local-time YYYYMMDD for N days ago, matching the service's day bucketing. */
+    function localDateStr(daysAgo: number): string {
+      const d = new Date();
+      d.setDate(d.getDate() - daysAgo);
+      return (
+        d.getFullYear().toString() +
+        String(d.getMonth() + 1).padStart(2, "0") +
+        String(d.getDate()).padStart(2, "0")
+      );
+    }
+
+    /** Mock MinIO so each logs/bot-1/<date>.log resolves to the given content. */
+    function mockFiles(files: Record<string, string>) {
+      const notFound = () => {
+        const err: any = new Error("NoSuchKey");
+        err.code = "NoSuchKey";
+        return Promise.reject(err);
+      };
+      mockMinioClient.getObject.mockImplementation(
+        (_bucket: string, path: string) =>
+          files[path] !== undefined
+            ? Promise.resolve(stringStream(files[path]))
+            : notFound(),
+      );
+      mockMinioClient.statObject.mockImplementation(
+        (_bucket: string, path: string) =>
+          files[path] !== undefined
+            ? Promise.resolve({
+                size: Buffer.byteLength(files[path], "utf-8"),
+              })
+            : notFound(),
+      );
+    }
+
+    it("should return newest-first entries across day files without a date param", async () => {
+      const today = localDateStr(0);
+      const older = localDateStr(2);
+      mockFiles({
+        [`logs/bot-1/${older}.log`]: '{"message":"old-1"}\n{"message":"old-2"}',
+        [`logs/bot-1/${today}.log`]: '{"message":"new-1"}\n{"message":"new-2"}',
+      });
+
+      const result = await service.getLogs("bot-1", {
+        lookbackDays: 7,
+        limit: 10,
+        offset: 0,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data!.entries.map((e) => e.content)).toEqual([
+        "new-2",
+        "new-1",
+        "old-2",
+        "old-1",
+      ]);
+      // Days with no log file are skipped, not errors
+      expect(result.data!.hasMore).toBe(false);
+    });
+
+    it("should return the newest `limit` metric entries across days", async () => {
+      const metric = (day: string, n: number) =>
+        `{"_metric":"signal","run":"${day}-${n}","timestamp":"2026-01-01T0${n}:00:00Z"}`;
+      const today = localDateStr(0);
+      const yesterday = localDateStr(1);
+      const older = localDateStr(2);
+      mockFiles({
+        [`logs/bot-1/${today}.log`]: [metric("t", 1), metric("t", 2)].join("\n"),
+        [`logs/bot-1/${yesterday}.log`]: [metric("y", 1), metric("y", 2)].join("\n"),
+        [`logs/bot-1/${older}.log`]: [metric("o", 1), metric("o", 2)].join("\n"),
+      });
+
+      const result = await service.getLogs("bot-1", {
+        lookbackDays: 7,
+        limit: 3,
+        offset: 0,
+        type: "metrics",
+      });
+
+      expect(result.success).toBe(true);
+      // Unlike date-range metric queries, latest mode respects limit
+      expect(result.data!.entries.map((e) => e.content)).toEqual([
+        metric("t", 2),
+        metric("t", 1),
+        metric("y", 2),
+      ]);
+      expect(result.data!.hasMore).toBe(true);
+    });
+
+    it("should stop scanning older days once enough entries are collected", async () => {
+      const today = localDateStr(0);
+      const yesterday = localDateStr(1);
+      mockFiles({
+        [`logs/bot-1/${today}.log`]:
+          '{"message":"a"}\n{"message":"b"}\n{"message":"c"}',
+        [`logs/bot-1/${yesterday}.log`]: '{"message":"y"}',
+      });
+
+      const result = await service.getLogs("bot-1", {
+        lookbackDays: 7,
+        limit: 2,
+        offset: 0,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data!.entries.map((e) => e.content)).toEqual(["c", "b"]);
+      expect(result.data!.hasMore).toBe(true);
+      // Only today's file was opened; older days were never touched
+      const touchedPaths = [
+        ...mockMinioClient.statObject.mock.calls,
+        ...mockMinioClient.getObject.mock.calls,
+      ].map((call: any[]) => call[1]);
+      expect(touchedPaths).not.toContain(`logs/bot-1/${yesterday}.log`);
+    });
+
+    it("should apply offset across the lookback window for pagination", async () => {
+      const today = localDateStr(0);
+      const yesterday = localDateStr(1);
+      mockFiles({
+        [`logs/bot-1/${today}.log`]: '{"message":"t1"}\n{"message":"t2"}',
+        [`logs/bot-1/${yesterday}.log`]: '{"message":"y1"}\n{"message":"y2"}',
+      });
+
+      const result = await service.getLogs("bot-1", {
+        lookbackDays: 7,
+        limit: 2,
+        offset: 2,
+      });
+
+      expect(result.success).toBe(true);
+      // Newest-first flat order is [t2, t1, y2, y1]; offset 2 -> [y2, y1]
+      expect(result.data!.entries.map((e) => e.content)).toEqual(["y2", "y1"]);
+      expect(result.data!.hasMore).toBe(false);
+    });
+
+    it("should return chronological order when sort=asc", async () => {
+      const today = localDateStr(0);
+      const yesterday = localDateStr(1);
+      mockFiles({
+        [`logs/bot-1/${today}.log`]: '{"message":"t1"}\n{"message":"t2"}',
+        [`logs/bot-1/${yesterday}.log`]: '{"message":"y1"}\n{"message":"y2"}',
+      });
+
+      const result = await service.getLogs("bot-1", {
+        lookbackDays: 7,
+        limit: 10,
+        offset: 0,
+        sort: "asc",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data!.entries.map((e) => e.content)).toEqual([
+        "y1",
+        "y2",
+        "t1",
+        "t2",
+      ]);
+    });
+
+    it("should prefer an explicit date over lookbackDays", async () => {
+      mockFiles({
+        "logs/bot-1/20260401.log": '{"message":"explicit-date"}',
+      });
+
+      const result = await service.getLogs("bot-1", {
+        date: "20260401",
+        lookbackDays: 7,
+        limit: 10,
+        offset: 0,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data!.entries).toHaveLength(1);
+      expect(result.data!.entries[0].content).toBe("explicit-date");
+      expect(result.data!.entries[0].date).toBe("20260401");
+    });
+
+    it("should return empty entries when no day in the window has logs", async () => {
+      mockFiles({});
+
+      const result = await service.getLogs("bot-1", {
+        lookbackDays: 7,
+        limit: 10,
+        offset: 0,
+        type: "metrics",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data!.entries).toEqual([]);
+      expect(result.data!.hasMore).toBe(false);
+    });
+  });
+
   describe("getLogs - auth and validation", () => {
     it("should return failure when user is not authenticated", async () => {
       const unauthService = new LogsService(

--- a/api/src/logs/dto/get-logs-query.dto.ts
+++ b/api/src/logs/dto/get-logs-query.dto.ts
@@ -1,6 +1,10 @@
 import { IsOptional, IsString, IsInt, IsIn, Min, Max } from "class-validator";
 import { Transform } from "class-transformer";
 
+// Number() (unlike parseInt) rejects trailing garbage ("30days" -> NaN) and
+// preserves decimals ("1.5" -> 1.5) so @IsInt can reject both.
+const toStrictNumber = ({ value }: { value: string }) => Number(value);
+
 export class GetLogsQueryDto {
   @IsOptional()
   @IsString()
@@ -11,21 +15,21 @@ export class GetLogsQueryDto {
   dateRange?: string;
 
   @IsOptional()
-  @Transform(({ value }) => parseInt(value))
+  @Transform(toStrictNumber)
   @IsInt()
   @Min(1)
   @Max(90)
   lookbackDays?: number;
 
   @IsOptional()
-  @Transform(({ value }) => parseInt(value))
+  @Transform(toStrictNumber)
   @IsInt()
   @Min(1)
   @Max(2000)
   limit?: number;
 
   @IsOptional()
-  @Transform(({ value }) => parseInt(value))
+  @Transform(toStrictNumber)
   @IsInt()
   @Min(0)
   offset?: number;

--- a/api/src/logs/dto/get-logs-query.dto.ts
+++ b/api/src/logs/dto/get-logs-query.dto.ts
@@ -14,6 +14,13 @@ export class GetLogsQueryDto {
   @Transform(({ value }) => parseInt(value))
   @IsInt()
   @Min(1)
+  @Max(90)
+  lookbackDays?: number;
+
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value))
+  @IsInt()
+  @Min(1)
   @Max(2000)
   limit?: number;
 

--- a/api/src/logs/logs.controller.ts
+++ b/api/src/logs/logs.controller.ts
@@ -76,6 +76,7 @@ export class LogsController {
     const result = await this.logsService.getLogs(botId, {
       date: query.date,
       dateRange: query.dateRange,
+      lookbackDays: query.lookbackDays,
       limit: query.limit || 100,
       offset: query.offset || 0,
       type: query.type,

--- a/api/src/logs/logs.service.ts
+++ b/api/src/logs/logs.service.ts
@@ -158,12 +158,32 @@ export class LogsService {
         );
       } else {
         // Raw logs can be huge; tail keeps only the newest lines per day.
-        await this.tailFilteredLogs(
+        const truncated = await this.tailFilteredLogs(
           logPath,
           date,
           { ...query, offset: 0, limit: maxNeeded },
           dayEntries,
         );
+        if (truncated && dayEntries.length < maxNeeded) {
+          // The tail window held fewer lines than needed (very long lines
+          // or a deep offset). Skipping the rest of the day would silently
+          // splice in older days' entries, so re-read the whole day capped
+          // the same way the dateRange desc path caps its reads.
+          dayEntries.length = 0;
+          await this.streamFilteredLogs(
+            logPath,
+            date,
+            { ...query, offset: 0, limit: Math.max(maxNeeded, 10000) },
+            dayEntries,
+            { count: 0 },
+          );
+        }
+      }
+      // Keep only the newest maxNeeded lines per day so a huge day (many
+      // metrics, or the full-read fallback above) can't grow the working
+      // set beyond ~2x maxNeeded.
+      if (dayEntries.length > maxNeeded) {
+        dayEntries.splice(0, dayEntries.length - maxNeeded);
       }
       collected = dayEntries.concat(collected);
       if (collected.length >= maxNeeded) break;
@@ -297,17 +317,19 @@ export class LogsService {
     }
   }
 
+  /** @returns true when the file was larger than the tail window, i.e. the
+   *  read may have skipped earlier lines from this day. */
   private async tailFilteredLogs(
     logPath: string,
     logDate: string,
     query: LogsQuery,
     entries: LogEntry[],
-  ): Promise<void> {
+  ): Promise<boolean> {
     let stat: { size: number };
     try {
       stat = await this.minioClient.statObject(this.logBucket, logPath);
     } catch (error: unknown) {
-      if (LogsService.isNotFoundError(error)) return;
+      if (LogsService.isNotFoundError(error)) return false;
       throw error;
     }
 
@@ -326,7 +348,7 @@ export class LogsService {
           : await this.minioClient.getObject(this.logBucket, logPath);
     } catch (error: unknown) {
       // File may have been deleted between stat and read
-      if (LogsService.isNotFoundError(error)) return;
+      if (LogsService.isNotFoundError(error)) return false;
       throw error;
     }
 
@@ -365,6 +387,8 @@ export class LogsService {
     if (query.type !== "metrics" && entries.length > query.limit) {
       entries.splice(0, entries.length - query.limit);
     }
+
+    return start > 0;
   }
 
   private normalizeLine(line: string, logDate: string): LogEntry {

--- a/api/src/logs/logs.service.ts
+++ b/api/src/logs/logs.service.ts
@@ -11,6 +11,9 @@ import * as Minio from "minio";
 export interface LogsQuery {
   date?: string;
   dateRange?: string;
+  // Latest mode: no fixed window - walk day files backwards from today
+  // (up to lookbackDays) until `limit` entries are found, newest-first.
+  lookbackDays?: number;
   limit: number;
   offset: number;
   type?: "all" | "metrics";
@@ -57,6 +60,17 @@ export class LogsService {
     const botResult = await this.botService.findOneByUserId(uid, botId);
     if (!botResult.success) {
       return Failure("Bot not found or access denied");
+    }
+
+    // Latest mode: no explicit window - serve the newest entries regardless
+    // of when the bot last ran (scheduled bots may not have run today).
+    if (!query.date && !query.dateRange && query.lookbackDays) {
+      try {
+        return Ok(await this.getLatestLogs(botId, query));
+      } catch (error: unknown) {
+        this.logger.error({ err: error }, "Error fetching latest logs");
+        return Failure(`Failed to fetch logs: ${errorMessage(error)}`);
+      }
     }
 
     // Generate date list from query
@@ -110,6 +124,73 @@ export class LogsService {
       this.logger.error({ err: error }, "Error fetching logs");
       return Failure(`Failed to fetch logs: ${errorMessage(error)}`);
     }
+  }
+
+  /**
+   * Latest mode: walk day files newest-first (today back through
+   * lookbackDays) and collect entries until offset+limit+1 are found. The
+   * +1 sentinel lets hasMore reflect real data instead of guessing whether
+   * unscanned days would have contributed anything.
+   */
+  private async getLatestLogs(
+    botId: string,
+    query: LogsQuery,
+  ): Promise<{ entries: LogEntry[]; hasMore: boolean }> {
+    const dates = this.generateLookbackDates(query.lookbackDays!);
+    const maxNeeded = query.offset + query.limit + 1;
+
+    // Chronological accumulator: each older day is prepended as a block, so
+    // reversing at the end yields newest-first without per-entry timestamps
+    // (day files are already time-ordered internally).
+    let collected: LogEntry[] = [];
+    for (const date of dates) {
+      const logPath = `logs/${botId}/${date}.log`;
+      const dayEntries: LogEntry[] = [];
+      if (query.type === "metrics") {
+        // Metric lines are sparse; stream the whole day file. Offset is
+        // deliberately zeroed - pagination applies to the flattened result.
+        await this.streamFilteredLogs(
+          logPath,
+          date,
+          { ...query, offset: 0 },
+          dayEntries,
+          { count: 0 },
+        );
+      } else {
+        // Raw logs can be huge; tail keeps only the newest lines per day.
+        await this.tailFilteredLogs(
+          logPath,
+          date,
+          { ...query, offset: 0, limit: maxNeeded },
+          dayEntries,
+        );
+      }
+      collected = dayEntries.concat(collected);
+      if (collected.length >= maxNeeded) break;
+    }
+
+    const newestFirst = collected.reverse();
+    const afterOffset = newestFirst.slice(query.offset);
+    const hasMore = afterOffset.length > query.limit;
+    const entries = afterOffset.slice(0, query.limit);
+    if (query.sort === "asc") entries.reverse();
+    return { entries, hasMore };
+  }
+
+  /** Newest-first YYYYMMDD list: today back through `days` days (local time,
+   *  matching the runtime's day bucketing of log files). */
+  private generateLookbackDates(days: number): string[] {
+    const dates: string[] = [];
+    const current = new Date();
+    for (let i = 0; i < days; i++) {
+      dates.push(
+        current.getFullYear().toString() +
+          (current.getMonth() + 1).toString().padStart(2, "0") +
+          current.getDate().toString().padStart(2, "0"),
+      );
+      current.setDate(current.getDate() - 1);
+    }
+    return dates;
   }
 
   private async streamFilteredLogs(

--- a/frontend/src/components/bot/__tests__/interval-picker.test.tsx
+++ b/frontend/src/components/bot/__tests__/interval-picker.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import {
   IntervalPicker,
   LIVE_INTERVAL,
+  LATEST_INTERVAL,
   DEFAULT_DAY_INTERVAL,
   DEFAULT_INTERVAL,
   computeInterval,
@@ -180,6 +181,62 @@ describe("IntervalPicker", () => {
     );
 
     expect(screen.getByRole("button", { name: /custom/i })).toBeInTheDocument();
+  });
+
+  it("should render Latest button when showLatest is true", () => {
+    render(
+      <IntervalPicker
+        value={LATEST_INTERVAL}
+        onChange={mockOnChange}
+        showLatest
+      />,
+    );
+
+    expect(screen.getByText("Latest")).toBeInTheDocument();
+  });
+
+  it("should not render Latest button when showLatest is omitted", () => {
+    render(
+      <IntervalPicker value={DEFAULT_DAY_INTERVAL} onChange={mockOnChange} />,
+    );
+
+    expect(screen.queryByText("Latest")).not.toBeInTheDocument();
+  });
+
+  it("should call onChange with latest interval when Latest clicked", () => {
+    render(
+      <IntervalPicker
+        value={DEFAULT_DAY_INTERVAL}
+        onChange={mockOnChange}
+        showLatest
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Latest"));
+
+    expect(mockOnChange).toHaveBeenCalledWith(LATEST_INTERVAL);
+  });
+
+  it("should highlight Latest when active", () => {
+    render(
+      <IntervalPicker
+        value={LATEST_INTERVAL}
+        onChange={mockOnChange}
+        showLatest
+      />,
+    );
+
+    const latestButton = screen.getByText("Latest").closest("button");
+    expect(latestButton?.className).toContain("bg-secondary");
+  });
+
+  describe("LATEST_INTERVAL constant", () => {
+    it("should have type 'latest' and empty start/end", () => {
+      expect(LATEST_INTERVAL.type).toBe("latest");
+      expect(LATEST_INTERVAL.label).toBe("latest");
+      expect(LATEST_INTERVAL.start).toBe("");
+      expect(LATEST_INTERVAL.end).toBe("");
+    });
   });
 
   describe("LIVE_INTERVAL constant", () => {

--- a/frontend/src/components/bot/bot-dashboard-loader.tsx
+++ b/frontend/src/components/bot/bot-dashboard-loader.tsx
@@ -102,6 +102,8 @@ interface BotDashboardLoaderProps {
   dateRange?: { start: string; end: string };
   /** Stream metric events live via SSE (realtime bots) instead of polling */
   streaming?: boolean;
+  /** Latest mode: newest metrics across a lookback window (scheduled bots) */
+  latest?: boolean;
   refreshInterval?: number;
   className?: string;
 }
@@ -119,6 +121,7 @@ export const BotDashboardLoader = React.memo(function BotDashboardLoader({
   version,
   dateRange,
   streaming = false,
+  latest = false,
   refreshInterval = 30000,
   className,
 }: BotDashboardLoaderProps) {
@@ -254,6 +257,7 @@ export const BotDashboardLoader = React.memo(function BotDashboardLoader({
       <BotEventsProvider
         botId={botId}
         streaming={streaming}
+        latest={latest}
         autoRefresh={refreshInterval > 0}
         refreshInterval={refreshInterval || undefined}
         dateRange={dateRange}

--- a/frontend/src/components/bot/interval-picker.tsx
+++ b/frontend/src/components/bot/interval-picker.tsx
@@ -9,20 +9,21 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { CalendarIcon, Clock, Radio } from "lucide-react";
+import { CalendarIcon, Clock, History, Radio } from "lucide-react";
 import type { DateRange } from "react-day-picker";
 
 export interface IntervalValue {
-  type: "live" | "range";
+  type: "live" | "range" | "latest";
   label: string;
-  start: string; // YYYYMMDD or ISO datetime (empty for "live")
-  end: string; // YYYYMMDD or ISO datetime (empty for "live")
+  start: string; // YYYYMMDD or ISO datetime (empty for "live"/"latest")
+  end: string; // YYYYMMDD or ISO datetime (empty for "live"/"latest")
 }
 
 interface IntervalPickerProps {
   value: IntervalValue;
   onChange: (value: IntervalValue) => void;
   showLive?: boolean;
+  showLatest?: boolean;
 }
 
 function formatDate(date: Date): string {
@@ -72,12 +73,22 @@ export const LIVE_INTERVAL: IntervalValue = {
   end: "",
 };
 
+/** Latest mode: the bot's most recent output regardless of when it ran.
+ *  Default for scheduled bots, whose last run is rarely inside any fixed
+ *  window (nightly/weekly crons). */
+export const LATEST_INTERVAL: IntervalValue = {
+  type: "latest",
+  label: "latest",
+  start: "",
+  end: "",
+};
+
 /** Default interval: last 1 day */
 export const DEFAULT_DAY_INTERVAL: IntervalValue = computeInterval("1d", {
   days: 1,
 });
 
-/** Default interval for scheduled bots: last 1 hour */
+/** 1h preset (initial state before the bot type resolves) */
 export const DEFAULT_INTERVAL: IntervalValue = computeInterval("1h", {
   hours: 1,
 });
@@ -86,6 +97,7 @@ export function IntervalPicker({
   value,
   onChange,
   showLive = false,
+  showLatest = false,
 }: IntervalPickerProps) {
   const [calendarOpen, setCalendarOpen] = useState(false);
   const [range, setRange] = useState<DateRange | undefined>(undefined);
@@ -121,6 +133,22 @@ export function IntervalPicker({
         >
           <Radio className="h-3 w-3 mr-1" />
           Live
+        </Button>
+      )}
+
+      {showLatest && (
+        <Button
+          variant={value.label === "latest" ? "secondary" : "ghost"}
+          size="sm"
+          className={cn(
+            "h-7 px-2.5 text-xs font-mono",
+            value.label === "latest" &&
+              "bg-secondary text-secondary-foreground",
+          )}
+          onClick={() => onChange(LATEST_INTERVAL)}
+        >
+          <History className="h-3 w-3 mr-1" />
+          Latest
         </Button>
       )}
 

--- a/frontend/src/components/dashboard/bot-detail-panel.tsx
+++ b/frontend/src/components/dashboard/bot-detail-panel.tsx
@@ -22,7 +22,7 @@ import {
   IntervalPicker,
   IntervalValue,
   LIVE_INTERVAL,
-  DEFAULT_INTERVAL,
+  LATEST_INTERVAL,
 } from "@/components/bot/interval-picker";
 import { RefreshSelector, shouldHideRefreshSelector } from "@/components/bot/refresh-selector";
 import {
@@ -34,7 +34,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { useBotLogs } from "@/hooks/use-bot-logs";
+import { useBotLogs, DEFAULT_LOOKBACK_DAYS } from "@/hooks/use-bot-logs";
 import { BotService, Bot as ApiBotType } from "@/lib/api/api-client";
 import { getErrorMessage } from "@/lib/axios";
 import { shouldUseLogStreaming } from "@/lib/bot-utils";
@@ -87,11 +87,12 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
   const useStreaming = shouldUseLogStreaming(bot);
 
   // Interval picker state (shared by dashboard + console)
-  // Realtime bots default to live mode; scheduled bots default to 1d range.
+  // Realtime bots default to live mode; scheduled bots default to latest
+  // mode (their last run is rarely inside any fixed window).
   // Note: bot is null at mount, so useStreaming is initially false. The
   // useEffect below corrects the interval once the bot loads.
   const [interval, setInterval_] = useState<IntervalValue>(
-    useStreaming ? LIVE_INTERVAL : DEFAULT_INTERVAL,
+    useStreaming ? LIVE_INTERVAL : LATEST_INTERVAL,
   );
   const streamingInitialized = useRef(false);
 
@@ -103,7 +104,7 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
   useEffect(() => {
     if (!streamingInitialized.current && bot) {
       streamingInitialized.current = true;
-      setInterval_(useStreaming ? LIVE_INTERVAL : DEFAULT_INTERVAL);
+      setInterval_(useStreaming ? LIVE_INTERVAL : LATEST_INTERVAL);
     }
   }, [useStreaming, bot]);
 
@@ -117,6 +118,17 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
     streaming: useStreaming,
     autoRefresh: !useStreaming && refreshInterval > 0,
     refreshInterval,
+    // Scheduled bots start in latest mode: newest lines across the lookback
+    // window instead of today's (possibly empty) file. Streaming bots keep
+    // the hook's default query (SSE provides freshness).
+    initialQuery: useStreaming
+      ? undefined
+      : {
+          limit: 1000,
+          offset: 0,
+          sort: "desc",
+          lookbackDays: DEFAULT_LOOKBACK_DAYS,
+        },
   });
 
   const handleIntervalChange = (val: IntervalValue) => {
@@ -124,6 +136,8 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
     if (val.type === "live") {
       // Clear date filter so SSE streams all logs
       logsHook.setDateFilter(null);
+    } else if (val.type === "latest") {
+      logsHook.setLatestFilter();
     } else {
       logsHook.setDateRangeFilter(val.start, val.end);
     }
@@ -460,6 +474,7 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
           interval={interval}
           onIntervalChange={handleIntervalChange}
           showLive={useStreaming}
+          showLatest={!useStreaming}
           refreshInterval={refreshInterval}
           onRefreshIntervalChange={setRefreshInterval}
           sort={sortOrder}
@@ -555,7 +570,7 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
 
         {/* Interval Picker + Refresh Selector */}
         <div className="px-4 lg:px-6 flex flex-wrap items-center gap-4">
-          <IntervalPicker value={interval} onChange={handleIntervalChange} showLive={useStreaming} />
+          <IntervalPicker value={interval} onChange={handleIntervalChange} showLive={useStreaming} showLatest={!useStreaming} />
           <RefreshSelector value={refreshInterval} onChange={setRefreshInterval} hidden={shouldHideRefreshSelector(useStreaming, interval.label)} />
         </div>
 
@@ -573,6 +588,7 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
                 customBotId={customBotId}
                 version={bot.config.version}
                 dateRange={interval.type === "range" ? { start: interval.start, end: interval.end } : undefined}
+                latest={interval.type === "latest"}
                 streaming={useStreaming}
                 refreshInterval={refreshInterval}
                 className=""

--- a/frontend/src/components/dashboard/mobile-bot-detail.tsx
+++ b/frontend/src/components/dashboard/mobile-bot-detail.tsx
@@ -68,6 +68,7 @@ interface MobileBotDetailProps {
   interval: IntervalValue;
   onIntervalChange: (value: IntervalValue) => void;
   showLive?: boolean;
+  showLatest?: boolean;
   refreshInterval: number;
   onRefreshIntervalChange: (ms: number) => void;
   sort?: "asc" | "desc";
@@ -102,6 +103,7 @@ export function MobileBotDetail({
   interval,
   onIntervalChange,
   showLive,
+  showLatest,
   refreshInterval,
   onRefreshIntervalChange,
   sort,
@@ -139,7 +141,7 @@ export function MobileBotDetail({
 
       {/* Interval Picker + Refresh Selector */}
       <div className="px-3 py-2 border-b space-y-1.5">
-        <IntervalPicker value={interval} onChange={onIntervalChange} showLive={showLive} />
+        <IntervalPicker value={interval} onChange={onIntervalChange} showLive={showLive} showLatest={showLatest} />
         <RefreshSelector value={refreshInterval} onChange={onRefreshIntervalChange} hidden={shouldHideRefreshSelector(!!showLive, interval.label)} />
       </div>
 
@@ -169,6 +171,7 @@ export function MobileBotDetail({
                   ? { start: interval.start, end: interval.end }
                   : undefined
               }
+              latest={interval.type === "latest"}
               streaming={showLive}
               refreshInterval={refreshInterval}
               className=""

--- a/frontend/src/contexts/bot-events-context.tsx
+++ b/frontend/src/contexts/bot-events-context.tsx
@@ -46,6 +46,8 @@ interface BotEventsProviderProps {
   botId: string;
   /** Stream events live via SSE (realtime bots) instead of polling */
   streaming?: boolean;
+  /** Latest mode: newest metrics across a lookback window (scheduled bots) */
+  latest?: boolean;
   autoRefresh?: boolean;
   refreshInterval?: number;
   dateRange?: { start: string; end: string };
@@ -59,6 +61,7 @@ export function BotEventsProvider({
   children,
   botId,
   streaming = false,
+  latest = false,
   autoRefresh = true,
   refreshInterval = 30000,
   dateRange,
@@ -66,6 +69,7 @@ export function BotEventsProvider({
   const { events, loading, error, utils, refresh } = useBotEvents({
     botId,
     streaming,
+    latest,
     autoRefresh,
     refreshInterval,
     dateRange,

--- a/frontend/src/hooks/__tests__/use-bot-events.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-events.test.ts
@@ -296,6 +296,23 @@ describe("useBotEvents", () => {
       expect(mockSetLatestFilter).toHaveBeenCalled();
     });
 
+    it("clears the filter when switching to neither latest nor range (live)", () => {
+      const { rerender } = renderHook(
+        ({ latest, dateRange }: any) =>
+          useBotEvents({ botId: "bot-123", latest, dateRange }),
+        {
+          initialProps: {
+            latest: false,
+            dateRange: { start: "20240102", end: "20240102" },
+          } as any,
+        },
+      );
+
+      rerender({ latest: false, dateRange: undefined });
+
+      expect(mockSetDateFilter).toHaveBeenCalledWith(null);
+    });
+
     it("refetches when a range is selected on a bot with no prior range (live dashboards)", () => {
       const { rerender } = renderHook(
         ({ dateRange }: any) => useBotEvents({ botId: "bot-123", dateRange }),

--- a/frontend/src/hooks/__tests__/use-bot-events.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-events.test.ts
@@ -2,9 +2,10 @@ import { renderHook, waitFor, act } from "@testing-library/react";
 import { useBotEvents } from "../use-bot-events";
 import { useBotLogs } from "../use-bot-logs";
 
-// Mock the useBotLogs hook
+// Mock the useBotLogs hook (keep the real constant's value in the mock)
 jest.mock("../use-bot-logs", () => ({
   useBotLogs: jest.fn(),
+  DEFAULT_LOOKBACK_DAYS: 30,
 }));
 
 // Mock event parser
@@ -118,6 +119,7 @@ describe("useBotEvents", () => {
   const mockRefresh = jest.fn();
   const mockSetDateFilter = jest.fn();
   const mockSetDateRangeFilter = jest.fn();
+  const mockSetLatestFilter = jest.fn();
   const mockExportLogs = jest.fn();
 
   beforeEach(() => {
@@ -132,6 +134,7 @@ describe("useBotEvents", () => {
       loadMore: jest.fn(),
       setDateFilter: mockSetDateFilter,
       setDateRangeFilter: mockSetDateRangeFilter,
+      setLatestFilter: mockSetLatestFilter,
       exportLogs: mockExportLogs,
     });
   });
@@ -218,6 +221,135 @@ describe("useBotEvents", () => {
         "20240102",
         "20240102",
       );
+    });
+  });
+
+  describe("latest mode", () => {
+    it("builds a lookback query instead of a date window", () => {
+      renderHook(() => useBotEvents({ botId: "bot-123", latest: true }));
+
+      expect(mockUseBotLogs).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialQuery: {
+            limit: 100,
+            offset: 0,
+            type: "metrics",
+            sort: "desc",
+            lookbackDays: 30,
+          },
+        }),
+      );
+    });
+
+    it("ignores dateRange while latest mode is active", () => {
+      renderHook(() =>
+        useBotEvents({
+          botId: "bot-123",
+          latest: true,
+          dateRange: { start: "20240101", end: "20240131" },
+        }),
+      );
+
+      expect(mockUseBotLogs).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialQuery: expect.objectContaining({ lookbackDays: 30 }),
+        }),
+      );
+      const initialQuery = (mockUseBotLogs.mock.calls[0][0] as any)
+        .initialQuery;
+      expect(initialQuery.dateRange).toBeUndefined();
+    });
+
+    it("switches to a range query when latest mode is turned off", () => {
+      const { rerender } = renderHook(
+        ({ latest, dateRange }: any) =>
+          useBotEvents({ botId: "bot-123", latest, dateRange }),
+        { initialProps: { latest: true, dateRange: undefined } as any },
+      );
+
+      rerender({
+        latest: false,
+        dateRange: { start: "20240102", end: "20240102" },
+      });
+
+      expect(mockSetDateRangeFilter).toHaveBeenCalledWith(
+        "20240102",
+        "20240102",
+      );
+      expect(mockSetLatestFilter).not.toHaveBeenCalled();
+    });
+
+    it("switches back to a lookback query when latest mode is turned on", () => {
+      const { rerender } = renderHook(
+        ({ latest, dateRange }: any) =>
+          useBotEvents({ botId: "bot-123", latest, dateRange }),
+        {
+          initialProps: {
+            latest: false,
+            dateRange: { start: "20240102", end: "20240102" },
+          } as any,
+        },
+      );
+
+      rerender({ latest: true, dateRange: undefined });
+
+      expect(mockSetLatestFilter).toHaveBeenCalled();
+    });
+
+    it("refetches when a range is selected on a bot with no prior range (live dashboards)", () => {
+      const { rerender } = renderHook(
+        ({ dateRange }: any) => useBotEvents({ botId: "bot-123", dateRange }),
+        { initialProps: { dateRange: undefined } as any },
+      );
+
+      rerender({ dateRange: { start: "20240102", end: "20240103" } });
+
+      expect(mockSetDateRangeFilter).toHaveBeenCalledWith(
+        "20240102",
+        "20240103",
+      );
+    });
+  });
+
+  describe("event ordering", () => {
+    it("sorts parsed events chronologically regardless of fetch order", () => {
+      const { parseEvents } = jest.requireMock("@/lib/events/event-parser");
+      // Simulate a newest-first (sort=desc) API response: parseEvents
+      // preserves input order, so events arrive newest-first here.
+      (parseEvents as jest.Mock).mockReturnValueOnce([
+        {
+          timestamp: new Date("2026-07-14T23:40:00Z"),
+          type: "metric",
+          data: { _metric: "signal", run: "newest" },
+          metricType: "signal",
+          raw: "newest",
+        },
+        {
+          timestamp: new Date("2026-07-11T23:40:00Z"),
+          type: "metric",
+          data: { _metric: "signal", run: "middle" },
+          metricType: "signal",
+          raw: "middle",
+        },
+        {
+          timestamp: new Date("2026-07-09T23:40:00Z"),
+          type: "metric",
+          data: { _metric: "signal", run: "oldest" },
+          metricType: "signal",
+          raw: "oldest",
+        },
+      ]);
+
+      const { result } = renderHook(() => useBotEvents({ botId: "bot-123" }));
+
+      expect(result.current.events.map((e) => e.raw)).toEqual([
+        "oldest",
+        "middle",
+        "newest",
+      ]);
+      // latest() takes the last element, so chronological order makes it
+      // return the genuinely newest event
+      expect(result.current.utils.latest("signal")?.raw).toBe("newest");
     });
   });
 

--- a/frontend/src/hooks/__tests__/use-bot-logs.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-logs.test.ts
@@ -806,6 +806,114 @@ describe("useBotLogs", () => {
     expect(calledUrl).toContain("offset=10");
   });
 
+  describe("latest mode (lookbackDays)", () => {
+    beforeEach(() => {
+      mockAuthFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [], total: 0, hasMore: false }),
+      } as Response);
+    });
+
+    it("sends lookbackDays instead of defaulting date to today", async () => {
+      renderHook(() =>
+        useBotLogs({
+          botId: "bot-1",
+          initialQuery: { limit: 100, offset: 0, sort: "desc", lookbackDays: 30 },
+        }),
+      );
+
+      await waitFor(() => {
+        expect(mockAuthFetch).toHaveBeenCalled();
+      });
+
+      const url = mockAuthFetch.mock.calls[0][0] as string;
+      expect(url).toContain("lookbackDays=30");
+      expect(url).not.toContain("date=");
+    });
+
+    it("setLatestFilter clears date filters and queries by lookback", async () => {
+      const { result } = renderHook(() => useBotLogs({ botId: "bot-1" }));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      act(() => {
+        result.current.setDateRangeFilter("20260401", "20260403");
+      });
+      await waitFor(() => {
+        expect(result.current.query.dateRange).toBe("20260401-20260403");
+      });
+
+      mockAuthFetch.mockClear();
+      act(() => {
+        result.current.setLatestFilter();
+      });
+
+      await waitFor(() => {
+        expect(mockAuthFetch).toHaveBeenCalled();
+      });
+
+      const url = mockAuthFetch.mock.calls[0][0] as string;
+      expect(url).toContain("lookbackDays=");
+      expect(url).not.toContain("dateRange=");
+      expect(url).not.toContain("date=");
+    });
+
+    it("setDateRangeFilter clears lookbackDays from the query", async () => {
+      const { result } = renderHook(() =>
+        useBotLogs({
+          botId: "bot-1",
+          initialQuery: { limit: 100, offset: 0, lookbackDays: 30 },
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      mockAuthFetch.mockClear();
+      act(() => {
+        result.current.setDateRangeFilter("20260401", "20260403");
+      });
+
+      await waitFor(() => {
+        expect(mockAuthFetch).toHaveBeenCalled();
+      });
+
+      const url = mockAuthFetch.mock.calls[0][0] as string;
+      expect(url).toContain("dateRange=20260401-20260403");
+      expect(url).not.toContain("lookbackDays=");
+      expect(result.current.query.lookbackDays).toBeUndefined();
+    });
+
+    it("setDateFilter clears lookbackDays from the query", async () => {
+      const { result } = renderHook(() =>
+        useBotLogs({
+          botId: "bot-1",
+          initialQuery: { limit: 100, offset: 0, lookbackDays: 30 },
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      mockAuthFetch.mockClear();
+      act(() => {
+        result.current.setDateFilter("20260401");
+      });
+
+      await waitFor(() => {
+        expect(mockAuthFetch).toHaveBeenCalled();
+      });
+
+      const url = mockAuthFetch.mock.calls[0][0] as string;
+      expect(url).toContain("date=20260401");
+      expect(url).not.toContain("lookbackDays=");
+    });
+  });
+
   it("should include sort=desc in URL by default", async () => {
     mockAuthFetch.mockResolvedValue({
       ok: true,

--- a/frontend/src/hooks/use-bot-events.ts
+++ b/frontend/src/hooks/use-bot-events.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useCallback, useEffect, useRef } from "react";
-import { useBotLogs } from "./use-bot-logs";
+import { useBotLogs, DEFAULT_LOOKBACK_DAYS } from "./use-bot-logs";
 import {
   BotEvent,
   parseEvents,
@@ -17,6 +17,10 @@ interface UseBotEventsOptions {
   autoRefresh?: boolean;
   refreshInterval?: number;
   dateRange?: { start: string; end: string };
+  /** Latest mode: fetch the newest metrics across a lookback window instead
+   *  of a fixed date window (scheduled bots that don't run every day).
+   *  Takes precedence over dateRange. */
+  latest?: boolean;
 }
 
 interface BotEventUtils {
@@ -84,18 +88,29 @@ export function useBotEvents({
   autoRefresh = false,
   refreshInterval = 30000,
   dateRange,
+  latest = false,
 }: UseBotEventsOptions): UseBotEventsReturn {
-  // Build initial query from dateRange; always request metrics type
-  const initialQuery = dateRange
+  // Build initial query; always request metrics type. Latest mode asks for
+  // the newest metrics across a lookback window so scheduled bots show their
+  // last known state even when they haven't run inside any fixed window.
+  const initialQuery = latest
     ? {
-        dateRange: dateRange.start.includes("T")
-          ? `${dateRange.start}--${dateRange.end}`
-          : `${dateRange.start}-${dateRange.end}`,
         limit: 100,
         offset: 0,
         type: "metrics" as const,
+        sort: "desc" as const,
+        lookbackDays: DEFAULT_LOOKBACK_DAYS,
       }
-    : { limit: 100, offset: 0, type: "metrics" as const };
+    : dateRange
+      ? {
+          dateRange: dateRange.start.includes("T")
+            ? `${dateRange.start}--${dateRange.end}`
+            : `${dateRange.start}-${dateRange.end}`,
+          limit: 100,
+          offset: 0,
+          type: "metrics" as const,
+        }
+      : { limit: 100, offset: 0, type: "metrics" as const };
 
   // With streaming, metric history still loads via REST (type=metrics) and
   // new lines append live over SSE; non-metric lines are filtered out by
@@ -107,6 +122,7 @@ export function useBotEvents({
     refresh,
     setDateFilter,
     setDateRangeFilter,
+    setLatestFilter,
     exportLogs,
   } = useBotLogs({
     botId,
@@ -116,15 +132,24 @@ export function useBotEvents({
     initialQuery,
   });
 
-  // Refetch when dateRange changes
-  const prevDateRange = useRef(dateRange);
+  // Refetch when the query mode changes after mount: latest <-> range, or a
+  // different range. A signature comparison covers every transition,
+  // including range selected on a bot that had no range before.
+  const querySignature = latest
+    ? "latest"
+    : dateRange
+      ? `range:${dateRange.start}--${dateRange.end}`
+      : "none";
+  const prevSignature = useRef(querySignature);
   useEffect(() => {
-    const prev = prevDateRange.current;
-    prevDateRange.current = dateRange;
-    if (!dateRange || !prev) return;
-    if (prev.start === dateRange.start && prev.end === dateRange.end) return;
-    setDateRangeFilter(dateRange.start, dateRange.end);
-  }, [dateRange, setDateRangeFilter]);
+    if (prevSignature.current === querySignature) return;
+    prevSignature.current = querySignature;
+    if (latest) {
+      setLatestFilter();
+    } else if (dateRange) {
+      setDateRangeFilter(dateRange.start, dateRange.end);
+    }
+  }, [querySignature, latest, dateRange, setLatestFilter, setDateRangeFilter]);
 
   // Parse raw logs into events
   // Ensure timestamps are always Date objects for SDK compatibility
@@ -138,10 +163,18 @@ export function useBotEvents({
 
     // Ensure all events have a valid timestamp (SDK expects Date, not null)
     // Use current time as fallback for events without timestamps
-    return parsedEvents.map((event) => ({
+    const stamped = parsedEvents.map((event) => ({
       ...event,
       timestamp: event.timestamp ?? new Date(),
     }));
+
+    // The API returns newest-first for desc queries but every event util
+    // (latest, extractTimeSeries, groupByRun) assumes chronological order.
+    // Stable-sort here so utils are correct regardless of fetch order;
+    // fallback-stamped events share "now" and keep their relative order.
+    return stamped.sort(
+      (a, b) => a.timestamp.getTime() - b.timestamp.getTime(),
+    );
   }, [rawLogs]);
 
   // Create bound utilities

--- a/frontend/src/hooks/use-bot-events.ts
+++ b/frontend/src/hooks/use-bot-events.ts
@@ -148,8 +148,19 @@ export function useBotEvents({
       setLatestFilter();
     } else if (dateRange) {
       setDateRangeFilter(dateRange.start, dateRange.end);
+    } else {
+      // Neither mode active (e.g. back to live): clear any stale filter so
+      // streaming/default fetching resumes
+      setDateFilter(null);
     }
-  }, [querySignature, latest, dateRange, setLatestFilter, setDateRangeFilter]);
+  }, [
+    querySignature,
+    latest,
+    dateRange,
+    setLatestFilter,
+    setDateRangeFilter,
+    setDateFilter,
+  ]);
 
   // Parse raw logs into events
   // Ensure timestamps are always Date objects for SDK compatibility

--- a/frontend/src/hooks/use-bot-logs.ts
+++ b/frontend/src/hooks/use-bot-logs.ts
@@ -32,6 +32,9 @@ import { validateSSEAuth } from "@/lib/sse/sse-auth";
 export interface LogsQuery {
   date?: string;
   dateRange?: string;
+  /** Latest mode: newest entries across the last N days, regardless of when
+   *  the bot last ran. Ignored when date/dateRange is set. */
+  lookbackDays?: number;
   limit?: number;
   offset?: number;
   type?: string;
@@ -72,11 +75,15 @@ export interface UseBotLogsReturn {
   updateQuery: (params: Partial<LogsQuery>) => void;
   setDateFilter: (date: string | null) => void;
   setDateRangeFilter: (start: string, end: string) => void;
+  setLatestFilter: () => void;
   exportLogs: () => void;
 }
 
 const MAX_LOG_ENTRIES = 10000;
 const DEFAULT_QUERY: LogsQuery = { limit: 1000, offset: 0, sort: "desc" };
+/** How far back latest mode is willing to scan for a bot's most recent
+ *  output. Scheduled bots that run weekly stay well inside this window. */
+export const DEFAULT_LOOKBACK_DAYS = 30;
 
 const entryKey = (l: LogEntry) => `${l.date}|${l.content}`;
 
@@ -215,6 +222,8 @@ export const useBotLogs = ({
           searchParams.set("dateRange", queryParams.dateRange);
         } else if (queryParams.date) {
           searchParams.set("date", queryParams.date);
+        } else if (queryParams.lookbackDays) {
+          searchParams.set("lookbackDays", queryParams.lookbackDays.toString());
         } else {
           searchParams.set(
             "date",
@@ -501,6 +510,7 @@ export const useBotLogs = ({
       updateQuery({
         date: date || undefined,
         dateRange: undefined,
+        lookbackDays: undefined,
       });
     },
     [updateQuery],
@@ -513,10 +523,19 @@ export const useBotLogs = ({
       updateQuery({
         dateRange: `${startDate}${separator}${endDate}`,
         date: undefined,
+        lookbackDays: undefined,
       });
     },
     [updateQuery],
   );
+
+  const setLatestFilter = useCallback(() => {
+    updateQuery({
+      date: undefined,
+      dateRange: undefined,
+      lookbackDays: DEFAULT_LOOKBACK_DAYS,
+    });
+  }, [updateQuery]);
 
   const refresh = useCallback(() => {
     const refreshQuery = { ...query, offset: 0 };
@@ -605,6 +624,7 @@ export const useBotLogs = ({
     updateQuery,
     setDateFilter,
     setDateRangeFilter,
+    setLatestFilter,
     exportLogs,
   };
 };


### PR DESCRIPTION
## Problem

Scheduled bots run on cron windows (nightly/weekly), but the dashboard page defaulted to a **1h** interval. At any other time of day the metric cards all showed `-` and the console sat on "Waiting for logs..." even though the last run's data existed in storage. Verified live against production: the vgrsi NVDA bot had emitted `vgrsi_signal`/`position` metrics at 23:40 the night before, and the dashboard was blank at 09:49.

Widening the range exposed a second bug: with 7d selected the dashboard rendered **July 9** values while July 14 data was present, because `eventUtils.latest()` takes the last array element assuming chronological order, but desc/range fetches return newest-first.

## Changes

**API**
- `GET /logs/:botId` accepts `lookbackDays` (1-90). With no `date`/`dateRange`, the service walks day files newest-first from today and collects entries until `offset+limit+1` are found (the +1 sentinel makes `hasMore` honest). Newest-first response; `sort=asc` supported. Metrics queries respect `limit` in this mode; raw log queries tail each day file to bound reads. Explicit `date`/`dateRange` always wins.

**Frontend**
- New **Latest** interval mode in the picker (History icon), shown for scheduled bots the way Live is shown for realtime bots, and now the scheduled-bot default. Cards and console open with the bot's most recent output regardless of when it last ran. Presets (1h...30d) and Custom ranges behave exactly as before, so historical/temporal queries are unaffected.
- `useBotEvents` now sorts parsed events chronologically before binding the event utils, fixing `latest()`/time-series/run-grouping on newest-first responses (all modes, including existing range queries).
- Mode transitions (latest <-> range) refetch via a query-signature effect; this also fixes range selection on live-bot dashboards being silently ignored when no previous range existed.

## Tests
- API: 8 new service tests for lookback semantics + controller passthrough (555 total pass)
- Frontend: new behavior-grouped tests for lookback queries, filter transitions, event ordering, and the Latest picker button (590 total pass)
- Both `yarn build`s pass

## Notes
- `BotEventsContextValue` (public SDK contract) is unchanged; `BotEventsProvider` gains an optional `latest` prop.
- Not yet verified end-to-end against a running stack; unit/integration coverage above. Follow-up candidate: CLI `the0 bot logs` could use `lookbackDays` instead of defaulting to today (it currently prints "No logs found" for bots that didn't run today).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Latest” interval for viewing recent bot logs and metrics across a configurable lookback window.
  * Latest mode searches up to 90 days of history, supports sorting, pagination, metric filtering, and missing log days.
  * Added controls for switching between live, latest, and custom date-range views.
* **Bug Fixes**
  * Events now consistently appear in chronological order regardless of fetch order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->