### PR TITLE
feat: resizable bot list sidebar on the dashboard

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -7,6 +7,42 @@ global.TextEncoder = TextEncoder;
 //@ts-ignore
 global.TextDecoder = TextDecoder;
 
+// Stub ResizeObserver (not implemented in jsdom; used by react-resizable-panels)
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+// Stub DOMRect (not implemented in jsdom; used by react-resizable-panels)
+// @ts-ignore
+global.DOMRect = class DOMRect {
+  x = 0;
+  y = 0;
+  width = 0;
+  height = 0;
+  top = 0;
+  right = 0;
+  bottom = 0;
+  left = 0;
+  constructor(x = 0, y = 0, width = 0, height = 0) {
+    this.x = x;
+    this.y = y;
+    this.width = width;
+    this.height = height;
+    this.top = y;
+    this.left = x;
+    this.right = x + width;
+    this.bottom = y + height;
+  }
+  static fromRect(rect: any = {}) {
+    return new DOMRect(rect.x, rect.y, rect.width, rect.height);
+  }
+  toJSON() {
+    return { ...this };
+  }
+};
+
 // Mock matchMedia for tests
 Object.defineProperty(window, "matchMedia", {
   writable: true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,6 +66,7 @@
     "react-dom": "19.1.0",
     "react-markdown": "^10.1.0",
     "react-plotly.js": "^2.6.0",
+    "react-resizable-panels": "^4.12.2",
     "react-syntax-highlighter": "^15.6.1",
     "react-virtuoso": "^4.18.3",
     "remark-gfm": "^4.0.1",

--- a/frontend/src/app/dashboard/layout.tsx
+++ b/frontend/src/app/dashboard/layout.tsx
@@ -10,6 +10,7 @@ import {
   useDashboardBots,
 } from "@/contexts/dashboard-bots-context";
 import { BotListPanel } from "@/components/dashboard/bot-list-panel";
+import { ResizableSidebarLayout } from "@/components/dashboard/resizable-sidebar-layout";
 import { useMediaQuery } from "@/hooks/use-media-query";
 
 function DashboardInner({ children }: { children: ReactNode }) {
@@ -35,19 +36,22 @@ function DashboardInner({ children }: { children: ReactNode }) {
     );
   }
 
-  // Desktop: side panel + content
+  // Desktop: resizable side panel + content
   if (isDesktop) {
     return (
-      <div className="flex h-[calc(100vh-3rem)]">
-        <aside className="w-[220px] border-r flex-shrink-0">
-          <BotListPanel
-            bots={bots}
-            activeBotId={activeBotId}
-            onSelectBot={handleSelectBot}
-            className="h-full"
-          />
-        </aside>
-        <main className="flex-1 overflow-auto">{children}</main>
+      <div className="h-[calc(100vh-3rem)]">
+        <ResizableSidebarLayout
+          sidebar={
+            <BotListPanel
+              bots={bots}
+              activeBotId={activeBotId}
+              onSelectBot={handleSelectBot}
+              className="h-full"
+            />
+          }
+        >
+          <main className="h-full overflow-auto">{children}</main>
+        </ResizableSidebarLayout>
       </div>
     );
   }

--- a/frontend/src/components/dashboard/__tests__/resizable-sidebar-layout.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/resizable-sidebar-layout.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ResizableSidebarLayout } from "../resizable-sidebar-layout";
+
+function renderLayout() {
+  return render(
+    <ResizableSidebarLayout sidebar={<div data-testid="sidebar-content" />}>
+      <div data-testid="main-content" />
+    </ResizableSidebarLayout>,
+  );
+}
+
+describe("ResizableSidebarLayout", () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("renders the sidebar and main content", () => {
+    renderLayout();
+
+    expect(screen.getByTestId("sidebar-content")).toBeInTheDocument();
+    expect(screen.getByTestId("main-content")).toBeInTheDocument();
+  });
+
+  it("renders a keyboard-accessible resize handle between the panels", () => {
+    renderLayout();
+
+    // react-resizable-panels renders the Separator with role="separator"
+    // and a tabIndex so it can be resized via arrow keys
+    const separator = screen.getByRole("separator");
+    expect(separator).toBeInTheDocument();
+    expect(separator).toHaveAttribute("tabindex");
+  });
+
+  it("restores a saved sidebar layout from localStorage", () => {
+    // useDefaultLayout persists under react-resizable-panels:<id>; seeding
+    // it simulates a user who resized the sidebar on a previous visit
+    window.localStorage.setItem(
+      "react-resizable-panels:dashboard-bot-list",
+      JSON.stringify({ "bot-list": 30, "dashboard-main": 70 }),
+    );
+
+    renderLayout();
+
+    // Panels expose their id as data-testid; flex-grow carries the layout
+    const sidebarPanel = screen.getByTestId("bot-list");
+    expect(sidebarPanel.style.flexGrow).toBe("30");
+  });
+});

--- a/frontend/src/components/dashboard/bot-list-item.tsx
+++ b/frontend/src/components/dashboard/bot-list-item.tsx
@@ -34,7 +34,9 @@ export function BotListItem({ bot, isActive, onClick }: BotListItemProps) {
           )}
         />
         <div className="min-w-0 flex-1">
-          <p className="text-sm font-medium truncate">{name}</p>
+          <p className="text-sm font-medium truncate" title={name}>
+            {name}
+          </p>
           {symbol && (
             <p className="text-xs text-muted-foreground font-mono truncate">
               {symbol}

--- a/frontend/src/components/dashboard/resizable-sidebar-layout.tsx
+++ b/frontend/src/components/dashboard/resizable-sidebar-layout.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { ReactNode } from "react";
+import {
+  Group,
+  Panel,
+  Separator,
+  useDefaultLayout,
+} from "react-resizable-panels";
+import { cn } from "@/lib/utils";
+
+interface ResizableSidebarLayoutProps {
+  sidebar: ReactNode;
+  children: ReactNode;
+  className?: string;
+}
+
+// The library's default storage is a bare `localStorage` reference, which
+// throws during SSR of client components; substitute a no-op there so the
+// server renders the default layout and the client restores the saved one.
+const ssrSafeStorage =
+  typeof window === "undefined"
+    ? { getItem: () => null, setItem: () => {} }
+    : window.localStorage;
+
+/**
+ * Desktop dashboard shell: a resizable bot-list sidebar next to the main
+ * content. The sidebar width is draggable (and keyboard-resizable via the
+ * separator) and persists across reloads.
+ */
+export function ResizableSidebarLayout({
+  sidebar,
+  children,
+  className,
+}: ResizableSidebarLayoutProps) {
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+    id: "dashboard-bot-list",
+    storage: ssrSafeStorage,
+  });
+
+  return (
+    <Group
+      orientation="horizontal"
+      defaultLayout={defaultLayout}
+      onLayoutChanged={onLayoutChanged}
+      className={cn("h-full", className)}
+    >
+      <Panel
+        id="bot-list"
+        defaultSize={280}
+        minSize={220}
+        maxSize={480}
+        className="border-r"
+      >
+        {sidebar}
+      </Panel>
+      {/* Invisible until hovered/focused; the sidebar's border-r draws the
+          resting divider line. -mx widens the grab area past the 1px line. */}
+      <Separator className="relative z-10 w-1 -mx-0.5 bg-transparent transition-colors hover:bg-primary/40 focus-visible:bg-primary/40 focus-visible:outline-none" />
+      <Panel id="dashboard-main">{children}</Panel>
+    </Group>
+  );
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7687,6 +7687,11 @@ react-remove-scroll@^2.6.3:
     use-callback-ref "^1.3.3"
     use-sidecar "^1.1.3"
 
+react-resizable-panels@^4.12.2:
+  version "4.12.2"
+  resolved "https://registry.yarnpkg.com/react-resizable-panels/-/react-resizable-panels-4.12.2.tgz#8402870ef686757c683235496e82771f0fb7f820"
+  integrity sha512-NwY5LCo4WrxVvDh0xoMML6EMLPONP/8ckKcIdpnojxexoatZdjLiRqLJQjQK5CPkd4SYiB/2M5BVrjZBQtOO7Q==
+
 react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
   version "2.2.3"
   resolved "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz"


### PR DESCRIPTION
## Problem

The dashboard bot list is a fixed `w-[220px]` aside, so real-world bot names like `trading-cocktail-paper-vgrsi-nvda` truncate with no way to see them.

## Changes

- New `ResizableSidebarLayout` (react-resizable-panels v4) replaces the fixed aside on desktop:
  - Drag the divider to resize; the separator is also keyboard-accessible (`role=separator`, arrow keys)
  - Pixel clamps: min 220px, max 480px, default 280px
  - Width persists across reloads via `useDefaultLayout` + localStorage (stable id `dashboard-bot-list`); SSR-safe no-op storage on the server
  - Separator is invisible at rest (the sidebar's border stays the divider) and highlights on hover/focus
- Truncated bot names in the list now expose a `title` tooltip
- jsdom stubs for `ResizeObserver`/`DOMRect` in `jest.setup.ts` (required by the panels library)

## Tests

- New component tests: renders both slots, keyboard-accessible separator, restores persisted layout from localStorage
- Full suite: 578 pass; `yarn build` passes

## Notes

- Mobile/tablet layout unchanged (sidebar only exists at >=1280px)
- Not verified against a running stack; drag interaction itself is library behavior, structure and persistence covered by tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a resizable sidebar to the desktop dashboard.
  * Sidebar width adjustments can be dragged and are preserved across page reloads.
  * Added accessible keyboard support for the sidebar resize control.
  * Long bot names now display their full text on hover.

* **Tests**
  * Added coverage for sidebar rendering, resizing controls, and saved layout restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->