### PR TITLE
fix(example-bots): add GitHub Packages auth to typescript example .npmrc

### DIFF
--- a/example-bots/README.md
+++ b/example-bots/README.md
@@ -136,17 +136,27 @@ The CLI automatically:
 
 ## SDK Installation
 
-The examples use `@the0/react` from GitHub Packages:
+The TypeScript examples use `@alexanderwanyoike/the0-node` from GitHub Packages:
 
 ```json
 {
   "dependencies": {
-    "@the0/react": "^0.1.0"
+    "@alexanderwanyoike/the0-node": "^0.3.1"
   }
 }
 ```
 
 Configure `.npmrc` for GitHub Packages:
 ```
-@the0:registry=https://npm.pkg.github.com
+@alexanderwanyoike:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+GitHub Packages requires authentication even for public packages, so set
+`GITHUB_TOKEN` to a personal access token with the `read:packages` scope
+before installing:
+
+```bash
+export GITHUB_TOKEN=ghp_...
+yarn install
 ```

--- a/example-bots/typescript-price-alerts/.npmrc
+++ b/example-bots/typescript-price-alerts/.npmrc
@@ -1,1 +1,2 @@
 @alexanderwanyoike:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}


### PR DESCRIPTION
## Summary
- Add `//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}` to the typescript-price-alerts `.npmrc` - GitHub Packages requires auth even for public packages, so `yarn install` previously failed with a 401
- Fix the stale `example-bots/README.md` SDK section: correct scope (`@alexanderwanyoike`, not `@the0`), correct package (`the0-node`), and document the `GITHUB_TOKEN` (read:packages) requirement

No secret is committed; `${GITHUB_TOKEN}` is env-var interpolation.

## Test plan
- [ ] `yarn install` in `example-bots/typescript-price-alerts` succeeds with a `read:packages` token exported
- [ ] Docs-only otherwise; no build surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TypeScript SDK installation instructions to use the latest package and registry scope.
  * Added guidance for configuring GitHub Packages authentication with a `GITHUB_TOKEN` that has package-read access.
  * Included an example command for setting the token before installing dependencies.

* **Chores**
  * Updated npm configuration to authenticate package downloads through GitHub Packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->