### PR TITLE
feat(api): expose bot state and bot query tools via MCP

### DIFF
--- a/api/src/mcp/__tests__/mcp.controller.spec.ts
+++ b/api/src/mcp/__tests__/mcp.controller.spec.ts
@@ -108,6 +108,9 @@ describe("McpController", () => {
         expect(toolNames).toContain("bot_delete");
         expect(toolNames).toContain("logs_get");
         expect(toolNames).toContain("logs_summary");
+        expect(toolNames).toContain("bot_state_list");
+        expect(toolNames).toContain("bot_state_get");
+        expect(toolNames).toContain("bot_query");
         expect(toolNames).toContain("custom_bot_list");
         expect(toolNames).toContain("custom_bot_get");
         expect(toolNames).toContain("custom_bot_schema");

--- a/api/src/mcp/__tests__/mcp.service.spec.ts
+++ b/api/src/mcp/__tests__/mcp.service.spec.ts
@@ -410,6 +410,14 @@ describe("McpService", () => {
         expect(result.content[0].text).toContain("Authentication required");
       });
 
+      it("should require a bot_id", async () => {
+        const result = await service.handleToolCall("bot_state_list", {}, userId);
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("bot_id");
+        expect(botStateService.listKeys).not.toHaveBeenCalled();
+      });
+
       it("should list state keys for a bot", async () => {
         botStateService.listKeys.mockResolvedValue(
           Ok([{ key: "positions", size: 128 }]),
@@ -471,6 +479,25 @@ describe("McpService", () => {
 
         expect(result.isError).toBe(true);
         expect(result.content[0].text).toContain("Authentication required");
+      });
+
+      it("should require a bot_id and key", async () => {
+        const missingKey = await service.handleToolCall(
+          "bot_state_get",
+          { bot_id: "bot-123" },
+          userId,
+        );
+        const missingBotId = await service.handleToolCall(
+          "bot_state_get",
+          { key: "positions" },
+          userId,
+        );
+
+        expect(missingKey.isError).toBe(true);
+        expect(missingKey.content[0].text).toContain("key");
+        expect(missingBotId.isError).toBe(true);
+        expect(missingBotId.content[0].text).toContain("bot_id");
+        expect(botStateService.getKey).not.toHaveBeenCalled();
       });
 
       it("should return the state value for a key", async () => {
@@ -561,6 +588,18 @@ describe("McpService", () => {
 
         expect(result.isError).toBe(true);
         expect(result.content[0].text).toContain("query_path");
+      });
+
+      it("should require a bot_id", async () => {
+        const result = await service.handleToolCall(
+          "bot_query",
+          { query_path: "/positions" },
+          userId,
+        );
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("bot_id");
+        expect(botQueryService.executeQuery).not.toHaveBeenCalled();
       });
 
       it("should surface query failures", async () => {

--- a/api/src/mcp/__tests__/mcp.service.spec.ts
+++ b/api/src/mcp/__tests__/mcp.service.spec.ts
@@ -1,9 +1,12 @@
 import { Test, TestingModule } from "@nestjs/testing";
+import { ModuleRef } from "@nestjs/core";
 import { McpService } from "../mcp.service";
 import { BotRepository } from "@/bot/bot.repository";
 import { CustomBotService } from "@/custom-bot/custom-bot.service";
 import { LogsService } from "@/logs/logs.service";
 import { ApiKeyService } from "@/api-key/api-key.service";
+import { BotStateService } from "@/bot-state/bot-state.service";
+import { BotQueryService } from "@/bot-query/bot-query.service";
 import { Ok, Failure } from "@/common/result";
 import { createMockLogger } from "@/test/mock-logger";
 import { PinoLogger } from "nestjs-pino";
@@ -15,6 +18,9 @@ describe("McpService", () => {
   let customBotService: jest.Mocked<CustomBotService>;
   let logsService: jest.Mocked<LogsService>;
   let apiKeyService: jest.Mocked<ApiKeyService>;
+  let botStateService: { listKeys: jest.Mock; getKey: jest.Mock };
+  let botQueryService: { executeQuery: jest.Mock };
+  let moduleRef: { registerRequestByContextId: jest.Mock; resolve: jest.Mock };
 
   const userId = "user-123";
 
@@ -83,6 +89,26 @@ describe("McpService", () => {
       validateApiKey: jest.fn(),
     };
 
+    const mockBotStateService = {
+      listKeys: jest.fn(),
+      getKey: jest.fn(),
+    };
+
+    const mockBotQueryService = {
+      executeQuery: jest.fn(),
+    };
+
+    const mockModuleRef = {
+      registerRequestByContextId: jest.fn(),
+      resolve: jest
+        .fn()
+        .mockImplementation(async (provider: unknown) =>
+          provider === BotStateService
+            ? mockBotStateService
+            : mockBotQueryService,
+        ),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         McpService,
@@ -106,6 +132,10 @@ describe("McpService", () => {
           provide: PinoLogger,
           useValue: createMockLogger(),
         },
+        {
+          provide: ModuleRef,
+          useValue: mockModuleRef,
+        },
       ],
     }).compile();
 
@@ -114,6 +144,9 @@ describe("McpService", () => {
     customBotService = module.get(CustomBotService);
     logsService = module.get(LogsService);
     apiKeyService = module.get(ApiKeyService);
+    botStateService = mockBotStateService;
+    botQueryService = mockBotQueryService;
+    moduleRef = mockModuleRef;
   });
 
   describe("handleToolCall", () => {
@@ -273,7 +306,9 @@ describe("McpService", () => {
 
     describe("logs_get", () => {
       it("should return bot logs", async () => {
-        logsService.getLogs.mockResolvedValue(Ok({ entries: [mockLogEntry], hasMore: false }));
+        logsService.getLogs.mockResolvedValue(
+          Ok({ entries: [mockLogEntry], hasMore: false }),
+        );
 
         const result = await service.handleToolCall(
           "logs_get",
@@ -289,7 +324,9 @@ describe("McpService", () => {
       });
 
       it("should cap limit at 500", async () => {
-        logsService.getLogs.mockResolvedValue(Ok({ entries: [], hasMore: false }));
+        logsService.getLogs.mockResolvedValue(
+          Ok({ entries: [], hasMore: false }),
+        );
 
         await service.handleToolCall(
           "logs_get",
@@ -312,7 +349,9 @@ describe("McpService", () => {
 
     describe("logs_summary", () => {
       it("should return log summary", async () => {
-        logsService.getLogs.mockResolvedValue(Ok({ entries: [mockLogEntry], hasMore: false }));
+        logsService.getLogs.mockResolvedValue(
+          Ok({ entries: [mockLogEntry], hasMore: false }),
+        );
 
         const result = await service.handleToolCall(
           "logs_summary",
@@ -329,11 +368,25 @@ describe("McpService", () => {
 
       it("should count errors in logs", async () => {
         const logsWithErrors = [
-          { date: "20251202", content: "something went wrong with error", timestamp: "2025-12-02T10:00:00Z" },
-          { date: "20251202", content: "success message", timestamp: "2025-12-02T10:01:00Z" },
-          { date: "20251202", content: "task failed to complete", timestamp: "2025-12-02T10:02:00Z" },
+          {
+            date: "20251202",
+            content: "something went wrong with error",
+            timestamp: "2025-12-02T10:00:00Z",
+          },
+          {
+            date: "20251202",
+            content: "success message",
+            timestamp: "2025-12-02T10:01:00Z",
+          },
+          {
+            date: "20251202",
+            content: "task failed to complete",
+            timestamp: "2025-12-02T10:02:00Z",
+          },
         ];
-        logsService.getLogs.mockResolvedValue(Ok({ entries: logsWithErrors, hasMore: false }));
+        logsService.getLogs.mockResolvedValue(
+          Ok({ entries: logsWithErrors, hasMore: false }),
+        );
 
         const result = await service.handleToolCall(
           "logs_summary",
@@ -344,6 +397,188 @@ describe("McpService", () => {
         const data = JSON.parse(result.content[0].text);
         // 2 logs contain error keywords: "error" and "failed"
         expect(data.error_count).toBe(2);
+      });
+    });
+
+    describe("bot_state_list", () => {
+      it("should require authentication", async () => {
+        const result = await service.handleToolCall("bot_state_list", {
+          bot_id: "bot-123",
+        });
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("Authentication required");
+      });
+
+      it("should list state keys for a bot", async () => {
+        botStateService.listKeys.mockResolvedValue(
+          Ok([{ key: "positions", size: 128 }]),
+        );
+
+        const result = await service.handleToolCall(
+          "bot_state_list",
+          { bot_id: "bot-123" },
+          userId,
+        );
+
+        expect(result.isError).toBeUndefined();
+        expect(botStateService.listKeys).toHaveBeenCalledWith("bot-123");
+        const data = JSON.parse(result.content[0].text);
+        expect(data.bot_id).toBe("bot-123");
+        expect(data.keys).toEqual([{ key: "positions", size: 128 }]);
+      });
+
+      it("should resolve the state service in a request context carrying the calling user", async () => {
+        botStateService.listKeys.mockResolvedValue(Ok([]));
+
+        await service.handleToolCall(
+          "bot_state_list",
+          { bot_id: "bot-123" },
+          userId,
+        );
+
+        expect(moduleRef.registerRequestByContextId).toHaveBeenCalledWith(
+          { user: { uid: userId } },
+          expect.anything(),
+        );
+      });
+
+      it("should surface access errors", async () => {
+        botStateService.listKeys.mockResolvedValue(
+          Failure({
+            code: "BOT_NOT_FOUND",
+            message: "Bot not found or access denied",
+          }),
+        );
+
+        const result = await service.handleToolCall(
+          "bot_state_list",
+          { bot_id: "bot-999" },
+          userId,
+        );
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("access denied");
+      });
+    });
+
+    describe("bot_state_get", () => {
+      it("should require authentication", async () => {
+        const result = await service.handleToolCall("bot_state_get", {
+          bot_id: "bot-123",
+          key: "positions",
+        });
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("Authentication required");
+      });
+
+      it("should return the state value for a key", async () => {
+        botStateService.getKey.mockResolvedValue(Ok({ qty: 10 }));
+
+        const result = await service.handleToolCall(
+          "bot_state_get",
+          { bot_id: "bot-123", key: "positions" },
+          userId,
+        );
+
+        expect(result.isError).toBeUndefined();
+        expect(botStateService.getKey).toHaveBeenCalledWith(
+          "bot-123",
+          "positions",
+        );
+        const data = JSON.parse(result.content[0].text);
+        expect(data.bot_id).toBe("bot-123");
+        expect(data.key).toBe("positions");
+        expect(data.value).toEqual({ qty: 10 });
+      });
+
+      it("should surface invalid key errors", async () => {
+        botStateService.getKey.mockResolvedValue(
+          Failure({ code: "INVALID_KEY", message: "Invalid state key" }),
+        );
+
+        const result = await service.handleToolCall(
+          "bot_state_get",
+          { bot_id: "bot-123", key: "../etc/passwd" },
+          userId,
+        );
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("Invalid state key");
+      });
+    });
+
+    describe("bot_query", () => {
+      it("should require authentication", async () => {
+        const result = await service.handleToolCall("bot_query", {
+          bot_id: "bot-123",
+          query_path: "/positions",
+        });
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("Authentication required");
+      });
+
+      it("should execute a query against a running bot", async () => {
+        botQueryService.executeQuery.mockResolvedValue(
+          Ok({
+            status: "success",
+            data: { price: 42 },
+            duration: 5,
+            timestamp: "2026-07-18T10:00:00Z",
+          }),
+        );
+
+        const result = await service.handleToolCall(
+          "bot_query",
+          {
+            bot_id: "bot-123",
+            query_path: "/positions",
+            params: { symbol: "AAPL" },
+            timeout_sec: 10,
+          },
+          userId,
+        );
+
+        expect(result.isError).toBeUndefined();
+        expect(botQueryService.executeQuery).toHaveBeenCalledWith("bot-123", {
+          queryPath: "/positions",
+          params: { symbol: "AAPL" },
+          timeoutSec: 10,
+        });
+        const data = JSON.parse(result.content[0].text);
+        expect(data.status).toBe("success");
+        expect(data.data).toEqual({ price: 42 });
+      });
+
+      it("should require a query path", async () => {
+        const result = await service.handleToolCall(
+          "bot_query",
+          { bot_id: "bot-123" },
+          userId,
+        );
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("query_path");
+      });
+
+      it("should surface query failures", async () => {
+        botQueryService.executeQuery.mockResolvedValue(
+          Failure({
+            code: "QUERY_FAILED",
+            message: "Query failed: bot not running",
+          }),
+        );
+
+        const result = await service.handleToolCall(
+          "bot_query",
+          { bot_id: "bot-123", query_path: "/positions" },
+          userId,
+        );
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("bot not running");
       });
     });
 

--- a/api/src/mcp/mcp.controller.ts
+++ b/api/src/mcp/mcp.controller.ts
@@ -323,6 +323,71 @@ export class McpController {
         },
       },
 
+      // Bot State Tools
+      {
+        name: "bot_state_list",
+        description:
+          "List the persisted state keys for a bot instance (with sizes)",
+        inputSchema: {
+          type: "object",
+          properties: {
+            bot_id: {
+              type: "string",
+              description: "The bot instance ID",
+            },
+          },
+          required: ["bot_id"],
+        },
+      },
+      {
+        name: "bot_state_get",
+        description:
+          "Get the value of a specific persisted state key for a bot instance",
+        inputSchema: {
+          type: "object",
+          properties: {
+            bot_id: {
+              type: "string",
+              description: "The bot instance ID",
+            },
+            key: {
+              type: "string",
+              description: "The state key name",
+            },
+          },
+          required: ["bot_id", "key"],
+        },
+      },
+
+      // Bot Query Tools
+      {
+        name: "bot_query",
+        description:
+          "Execute a query against a running realtime bot's query endpoint",
+        inputSchema: {
+          type: "object",
+          properties: {
+            bot_id: {
+              type: "string",
+              description: "The bot instance ID",
+            },
+            query_path: {
+              type: "string",
+              description: "Query path exposed by the bot (e.g. /positions)",
+            },
+            params: {
+              type: "object",
+              description: "Query parameters (optional)",
+            },
+            timeout_sec: {
+              type: "number",
+              description: "Query timeout in seconds (default: 30)",
+            },
+          },
+          required: ["bot_id", "query_path"],
+        },
+      },
+
       // Custom Bot Tools
       {
         name: "custom_bot_list",

--- a/api/src/mcp/mcp.module.ts
+++ b/api/src/mcp/mcp.module.ts
@@ -6,9 +6,19 @@ import { CustomBotModule } from "@/custom-bot/custom-bot.module";
 import { LogsModule } from "@/logs/logs.module";
 import { ApiKeyModule } from "@/api-key/api-key.module";
 import { LoggerModule } from "@/logger/logger.module";
+import { BotStateModule } from "@/bot-state/bot-state.module";
+import { BotQueryModule } from "@/bot-query/bot-query.module";
 
 @Module({
-  imports: [BotModule, CustomBotModule, LogsModule, ApiKeyModule, LoggerModule],
+  imports: [
+    BotModule,
+    CustomBotModule,
+    LogsModule,
+    ApiKeyModule,
+    LoggerModule,
+    BotStateModule,
+    BotQueryModule,
+  ],
   controllers: [McpController],
   providers: [McpService],
   exports: [McpService],

--- a/api/src/mcp/mcp.service.ts
+++ b/api/src/mcp/mcp.service.ts
@@ -667,6 +667,9 @@ export class McpService {
     if (!userId) {
       throw new Error("Authentication required");
     }
+    if (!input.bot_id) {
+      throw new Error("bot_id is required");
+    }
     const botStateService = await this.resolveForUser(BotStateService, userId);
     const result = await botStateService.listKeys(input.bot_id);
     if (!result.success) {
@@ -678,6 +681,12 @@ export class McpService {
   private async handleBotStateGet(input: BotStateGetInput, userId?: string) {
     if (!userId) {
       throw new Error("Authentication required");
+    }
+    if (!input.bot_id) {
+      throw new Error("bot_id is required");
+    }
+    if (!input.key) {
+      throw new Error("key is required");
     }
     const botStateService = await this.resolveForUser(BotStateService, userId);
     const result = await botStateService.getKey(input.bot_id, input.key);
@@ -691,6 +700,9 @@ export class McpService {
   private async handleBotQuery(input: BotQueryInput, userId?: string) {
     if (!userId) {
       throw new Error("Authentication required");
+    }
+    if (!input.bot_id) {
+      throw new Error("bot_id is required");
     }
     if (!input.query_path) {
       throw new Error("query_path is required");

--- a/api/src/mcp/mcp.service.ts
+++ b/api/src/mcp/mcp.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Type } from "@nestjs/common";
+import { ContextIdFactory, ModuleRef } from "@nestjs/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import {
   CallToolRequestSchema,
@@ -11,6 +12,9 @@ import {
   BotUpdateInput,
   BotDeleteInput,
   BotGetInput,
+  BotStateListInput,
+  BotStateGetInput,
+  BotQueryInput,
   LogsGetInput,
   CustomBotGetInput,
   CustomBotSchemaInput,
@@ -19,6 +23,8 @@ import { BotRepository } from "@/bot/bot.repository";
 import { CustomBotService } from "@/custom-bot/custom-bot.service";
 import { LogsService } from "@/logs/logs.service";
 import { ApiKeyService } from "@/api-key/api-key.service";
+import { BotStateService } from "@/bot-state/bot-state.service";
+import { BotQueryService } from "@/bot-query/bot-query.service";
 
 @Injectable()
 export class McpService {
@@ -30,8 +36,27 @@ export class McpService {
     private readonly logsService: LogsService,
     private readonly apiKeyService: ApiKeyService,
     private readonly logger: PinoLogger,
+    private readonly moduleRef: ModuleRef,
   ) {
     this.initializeServer();
+  }
+
+  /**
+   * Resolve a request-scoped service under a synthetic request context that
+   * carries the MCP caller's identity. The bot-state and bot-query services
+   * enforce ownership by reading request.user, so this makes their existing
+   * authorization apply to MCP calls exactly as it does to HTTP requests.
+   */
+  private async resolveForUser<T>(
+    provider: Type<T>,
+    userId: string,
+  ): Promise<T> {
+    const contextId = ContextIdFactory.create();
+    this.moduleRef.registerRequestByContextId(
+      { user: { uid: userId } },
+      contextId,
+    );
+    return this.moduleRef.resolve(provider, contextId, { strict: false });
   }
 
   private initializeServer() {
@@ -200,6 +225,71 @@ export class McpService {
         },
       },
 
+      // Bot State Tools
+      {
+        name: MCP_TOOL_NAMES.BOT_STATE_LIST,
+        description:
+          "List the persisted state keys for a bot instance (with sizes)",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            bot_id: {
+              type: "string",
+              description: "The bot instance ID",
+            },
+          },
+          required: ["bot_id"],
+        },
+      },
+      {
+        name: MCP_TOOL_NAMES.BOT_STATE_GET,
+        description:
+          "Get the value of a specific persisted state key for a bot instance",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            bot_id: {
+              type: "string",
+              description: "The bot instance ID",
+            },
+            key: {
+              type: "string",
+              description: "The state key name",
+            },
+          },
+          required: ["bot_id", "key"],
+        },
+      },
+
+      // Bot Query Tools
+      {
+        name: MCP_TOOL_NAMES.BOT_QUERY,
+        description:
+          "Execute a query against a running realtime bot's query endpoint",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            bot_id: {
+              type: "string",
+              description: "The bot instance ID",
+            },
+            query_path: {
+              type: "string",
+              description: "Query path exposed by the bot (e.g. /positions)",
+            },
+            params: {
+              type: "object",
+              description: "Query parameters (optional)",
+            },
+            timeout_sec: {
+              type: "number",
+              description: "Query timeout in seconds (default: 30)",
+            },
+          },
+          required: ["bot_id", "query_path"],
+        },
+      },
+
       // Custom Bot Tools
       {
         name: MCP_TOOL_NAMES.CUSTOM_BOT_LIST,
@@ -312,6 +402,27 @@ export class McpService {
           );
           break;
 
+        case MCP_TOOL_NAMES.BOT_STATE_LIST:
+          result = await this.handleBotStateList(
+            args as unknown as BotStateListInput,
+            userId,
+          );
+          break;
+
+        case MCP_TOOL_NAMES.BOT_STATE_GET:
+          result = await this.handleBotStateGet(
+            args as unknown as BotStateGetInput,
+            userId,
+          );
+          break;
+
+        case MCP_TOOL_NAMES.BOT_QUERY:
+          result = await this.handleBotQuery(
+            args as unknown as BotQueryInput,
+            userId,
+          );
+          break;
+
         case MCP_TOOL_NAMES.CUSTOM_BOT_LIST:
           result = await this.handleCustomBotList();
           break;
@@ -393,8 +504,11 @@ export class McpService {
       throw new Error("Authentication required");
     }
 
-    const { name: configName, type: configType, version: configVersion } =
-      input.config;
+    const {
+      name: configName,
+      type: configType,
+      version: configVersion,
+    } = input.config;
 
     if (!configName || !configType || !configVersion) {
       throw new Error(
@@ -546,6 +660,51 @@ export class McpService {
       },
       last_entry: logs.length > 0 ? logs[0] : null,
     };
+  }
+
+  // Bot State Handlers
+  private async handleBotStateList(input: BotStateListInput, userId?: string) {
+    if (!userId) {
+      throw new Error("Authentication required");
+    }
+    const botStateService = await this.resolveForUser(BotStateService, userId);
+    const result = await botStateService.listKeys(input.bot_id);
+    if (!result.success) {
+      throw new Error(result.error?.message || "Failed to list state keys");
+    }
+    return { bot_id: input.bot_id, keys: result.data };
+  }
+
+  private async handleBotStateGet(input: BotStateGetInput, userId?: string) {
+    if (!userId) {
+      throw new Error("Authentication required");
+    }
+    const botStateService = await this.resolveForUser(BotStateService, userId);
+    const result = await botStateService.getKey(input.bot_id, input.key);
+    if (!result.success) {
+      throw new Error(result.error?.message || "Failed to get state value");
+    }
+    return { bot_id: input.bot_id, key: input.key, value: result.data };
+  }
+
+  // Bot Query Handlers
+  private async handleBotQuery(input: BotQueryInput, userId?: string) {
+    if (!userId) {
+      throw new Error("Authentication required");
+    }
+    if (!input.query_path) {
+      throw new Error("query_path is required");
+    }
+    const botQueryService = await this.resolveForUser(BotQueryService, userId);
+    const result = await botQueryService.executeQuery(input.bot_id, {
+      queryPath: input.query_path,
+      params: input.params,
+      timeoutSec: input.timeout_sec,
+    });
+    if (!result.success) {
+      throw new Error(result.error?.message || "Failed to execute query");
+    }
+    return result.data;
   }
 
   // Custom Bot Handlers

--- a/api/src/mcp/mcp.types.ts
+++ b/api/src/mcp/mcp.types.ts
@@ -33,6 +33,22 @@ export interface LogsGetInput {
   limit?: number;
 }
 
+export interface BotStateListInput {
+  bot_id: string;
+}
+
+export interface BotStateGetInput {
+  bot_id: string;
+  key: string;
+}
+
+export interface BotQueryInput {
+  bot_id: string;
+  query_path: string;
+  params?: Record<string, unknown>;
+  timeout_sec?: number;
+}
+
 export interface CustomBotListInput {
   // No parameters needed
 }
@@ -109,6 +125,13 @@ export const MCP_TOOL_NAMES = {
   // Logs
   LOGS_GET: "logs_get",
   LOGS_SUMMARY: "logs_summary",
+
+  // Bot State
+  BOT_STATE_LIST: "bot_state_list",
+  BOT_STATE_GET: "bot_state_get",
+
+  // Bot Query
+  BOT_QUERY: "bot_query",
 
   // Custom Bot
   CUSTOM_BOT_LIST: "custom_bot_list",

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -109,7 +109,7 @@ claude
 
 ## Available Tools
 
-the0's MCP server exposes 14 tools organized into five categories:
+the0's MCP server exposes 14 tools organized into six categories:
 
 ### Authentication
 

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -109,7 +109,7 @@ claude
 
 ## Available Tools
 
-the0's MCP server exposes 11 tools organized into three categories:
+the0's MCP server exposes 14 tools organized into five categories:
 
 ### Authentication
 
@@ -133,6 +133,19 @@ the0's MCP server exposes 11 tools organized into three categories:
 |------|-------------|------------|
 | `logs_get` | Get execution logs for a bot | `bot_id`, optional: `date`, `date_range`, `limit` |
 | `logs_summary` | Get log statistics | `bot_id` |
+
+### Bot State
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `bot_state_list` | List the persisted state keys for a bot (with sizes) | `bot_id` |
+| `bot_state_get` | Get the value of a specific state key | `bot_id`, `key` |
+
+### Bot Queries
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `bot_query` | Execute a query against a running realtime bot | `bot_id`, `query_path`, optional: `params`, `timeout_sec` |
 
 ### Custom Bots
 


### PR DESCRIPTION
## Summary
- Adds three MCP tools: `bot_state_list` (persisted state keys with sizes), `bot_state_get` (value of a state key), and `bot_query` (execute a query against a running realtime bot)
- Closes item 13 of the MCP coverage backlog: AI agents can now inspect bot state and query live bots, not just read logs and manage deployments
- Updates the MCP integration docs page (14 tools, five categories)

## Design note
`BotStateService` and `BotQueryService` are request-scoped and enforce bot ownership by reading `request.user`, while `McpService` is a singleton receiving `userId` explicitly. Rather than duplicating authorization in MCP handlers, they resolve the services via `ModuleRef.registerRequestByContextId` with a synthetic request context carrying the MCP caller's identity, so the services' existing ownership checks apply to MCP calls exactly as they do to HTTP.

## Test plan
- [x] TDD: 12 new tests written first (auth required, happy paths, ownership context registration, error surfacing, query_path validation)
- [x] Full API suite green: 575/575
- [x] `yarn build` clean
- [ ] Manual: `bot_state_list`/`bot_state_get`/`bot_query` against a live bot via MCP endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new MCP tools to list and retrieve persisted bot state.
  * Added an MCP tool to execute queries against running bots, supporting optional parameters and timeouts.
  * Expanded the MCP tool catalog to 14 tools across six categories.
* **Documentation**
  * Updated the MCP integration guide to document the new bot state and query tools.
* **Tests**
  * Enhanced MCP controller/service test coverage for the new tools and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->