### PR TITLE
fix(runtime): propagate NATS_URL into bot pods for live log streaming

### DIFF
--- a/runtime/cmd/app/main.go
+++ b/runtime/cmd/app/main.go
@@ -390,6 +390,7 @@ func runController() {
 		MinIOSecretKey:         minioSecretKey,
 		MinIOBucket:            minioBucket,
 		MinIOUseSSL:            minioUseSSL,
+		NATSURL:                natsUrl,
 		RuntimeImage:           runtimeImage,
 		RuntimeImagePullPolicy: runtimeImagePullPolicy,
 		Logger:                 &util.DefaultLogger{},

--- a/runtime/internal/k8s/controller/bot_controller.go
+++ b/runtime/internal/k8s/controller/bot_controller.go
@@ -213,7 +213,7 @@ func (c *BotController) Reconcile(ctx context.Context) error {
 				util.LogMaster("[BotController] Failed to create pod for bot %s: %v", bot.ID, err)
 				// Continue with other bots
 			}
-		} else if podgen.ConfigChanged(pod, bot) {
+		} else if c.podGenerator.ConfigChanged(pod, bot) {
 			// Config changed -> delete pod (will be recreated next cycle)
 			util.LogMaster("[BotController] Config changed for bot %s, deleting pod for recreation", bot.ID)
 			if err := c.k8sClient.DeletePod(ctx, c.config.Namespace, pod.Name); err != nil {

--- a/runtime/internal/k8s/controller/bot_controller.go
+++ b/runtime/internal/k8s/controller/bot_controller.go
@@ -55,6 +55,9 @@ type BotControllerConfig struct {
 	MinIOBucket    string
 	MinIOUseSSL    bool
 
+	// NATSURL for live log publishing from bot pods (empty disables)
+	NATSURL string
+
 	// RuntimeImage for init containers and sidecars
 	RuntimeImage string
 
@@ -102,6 +105,7 @@ func NewBotController(
 		MinIOSecretKey:         config.MinIOSecretKey,
 		MinIOBucket:            config.MinIOBucket,
 		MinIOUseSSL:            config.MinIOUseSSL,
+		NATSURL:                config.NATSURL,
 		RuntimeImage:           config.RuntimeImage,
 		RuntimeImagePullPolicy: corev1.PullPolicy(config.RuntimeImagePullPolicy),
 	}

--- a/runtime/internal/k8s/controller/bot_controller_test.go
+++ b/runtime/internal/k8s/controller/bot_controller_test.go
@@ -718,3 +718,33 @@ func TestBotController_Reconcile_PropagatesNATSURLToSyncSidecar(t *testing.T) {
 	assert.Equal(t, "nats://nats:4222", sidecarEnv["NATS_URL"],
 		"sync sidecar needs NATS_URL for live log publishing")
 }
+
+func TestBotController_Reconcile_ReplacesPodWhenNATSURLAdded(t *testing.T) {
+	bot := createTestBot("bot-1", "price-alerts", "1.0.0", "python3.11")
+
+	// Existing pod was generated before NATS_URL was configured
+	oldGenerator := podgen.NewPodGenerator(podgen.PodGeneratorConfig{
+		Namespace:      "the0",
+		ControllerName: "the0-bot-controller",
+		MinIOEndpoint:  "minio:9000",
+		MinIOAccessKey: "access-key",
+		MinIOSecretKey: "secret-key",
+		MinIOBucket:    "custom-bots",
+	})
+	oldPod, err := oldGenerator.GeneratePod(bot)
+	require.NoError(t, err)
+	oldPod.Status.Phase = corev1.PodRunning
+
+	mockRepo := &MockBotRepository{Bots: []model.Bot{bot}}
+	mockK8s := &MockK8sClient{Pods: []corev1.Pod{*oldPod}}
+
+	config := testControllerConfig()
+	config.NATSURL = "nats://nats:4222"
+	controller := NewBotController(config, mockRepo, mockK8s)
+
+	err = controller.Reconcile(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, mockK8s.DeleteCalled,
+		"pod without NATS_URL must be replaced once NATS_URL is configured")
+}

--- a/runtime/internal/k8s/controller/bot_controller_test.go
+++ b/runtime/internal/k8s/controller/bot_controller_test.go
@@ -691,3 +691,30 @@ func TestBotController_Reconcile_MixedStates(t *testing.T) {
 	assert.Equal(t, 1, mockK8s.DeleteCalled, "should delete orphan pod")
 }
 
+
+func TestBotController_Reconcile_PropagatesNATSURLToSyncSidecar(t *testing.T) {
+	mockRepo := &MockBotRepository{
+		Bots: []model.Bot{
+			createTestBot("bot-1", "price-alerts", "1.0.0", "python3.11"),
+		},
+	}
+	mockK8s := &MockK8sClient{Pods: []corev1.Pod{}}
+
+	config := testControllerConfig()
+	config.NATSURL = "nats://nats:4222"
+
+	controller := NewBotController(config, mockRepo, mockK8s)
+
+	err := controller.Reconcile(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, mockK8s.CreatedPods, 1)
+	require.Len(t, mockK8s.CreatedPods[0].Spec.InitContainers, 1)
+
+	sidecarEnv := make(map[string]string)
+	for _, env := range mockK8s.CreatedPods[0].Spec.InitContainers[0].Env {
+		sidecarEnv[env.Name] = env.Value
+	}
+	assert.Equal(t, "nats://nats:4222", sidecarEnv["NATS_URL"],
+		"sync sidecar needs NATS_URL for live log publishing")
+}

--- a/runtime/internal/k8s/controller/botschedule_controller.go
+++ b/runtime/internal/k8s/controller/botschedule_controller.go
@@ -68,6 +68,8 @@ type BotScheduleControllerConfig struct {
 	MinIOSecretKey string
 	MinIOBucket    string
 	MinIOUseSSL    bool
+	// NATSURL for live log publishing from bot pods (empty disables)
+	NATSURL string
 	// RuntimeImage for init containers and sidecars
 	RuntimeImage string
 	// RuntimeImagePullPolicy for init/sidecar containers
@@ -111,6 +113,7 @@ func NewBotScheduleController(
 		MinIOSecretKey:         config.MinIOSecretKey,
 		MinIOBucket:            config.MinIOBucket,
 		MinIOUseSSL:            config.MinIOUseSSL,
+		NATSURL:                config.NATSURL,
 		RuntimeImage:           config.RuntimeImage,
 		RuntimeImagePullPolicy: corev1.PullPolicy(config.RuntimeImagePullPolicy),
 	})

--- a/runtime/internal/k8s/controller/botschedule_controller.go
+++ b/runtime/internal/k8s/controller/botschedule_controller.go
@@ -301,7 +301,7 @@ func (c *BotScheduleController) createCronJobSpec(schedule model.BotSchedule, cr
 		return nil, fmt.Errorf("failed to generate pod spec: %w", err)
 	}
 
-	configHash := computeScheduleHash(schedule)
+	configHash := computeScheduleHash(schedule, c.config.NATSURL)
 
 	successfulJobsHistory := int32(3)
 	failedJobsHistory := int32(1)
@@ -352,7 +352,7 @@ func (c *BotScheduleController) scheduleChanged(cronJob *batchv1.CronJob, schedu
 	if cronJob.Annotations != nil {
 		existingHash = cronJob.Annotations[AnnotationScheduleHash]
 	}
-	currentHash := computeScheduleHash(schedule)
+	currentHash := computeScheduleHash(schedule, c.config.NATSURL)
 	return existingHash != currentHash
 }
 
@@ -408,16 +408,20 @@ func convertToK8sCronFormat(cronExpr string) string {
 	return cronExpr
 }
 
-// computeScheduleHash creates a hash of the schedule config.
-func computeScheduleHash(schedule model.BotSchedule) string {
+// computeScheduleHash creates a hash of the schedule config. Controller-level
+// inputs that shape the generated pod environment (NATS URL) are part of the
+// hash so changing them updates existing CronJobs.
+func computeScheduleHash(schedule model.BotSchedule, natsURL string) string {
 	data := struct {
 		Config           map[string]interface{}
 		CustomBotVersion string
 		Enabled          *bool
+		NATSURL          string
 	}{
 		Config:           schedule.Config,
 		CustomBotVersion: schedule.CustomBotVersion.Version,
 		Enabled:          schedule.Enabled,
+		NATSURL:          natsURL,
 	}
 
 	jsonBytes, err := json.Marshal(data)

--- a/runtime/internal/k8s/controller/botschedule_controller_test.go
+++ b/runtime/internal/k8s/controller/botschedule_controller_test.go
@@ -198,7 +198,7 @@ func TestBotScheduleController_Reconcile_NoCronJobForScheduleWithoutExpression(t
 
 func TestBotScheduleController_Reconcile_NoChangesNeeded(t *testing.T) {
 	schedule := createTestSchedule("schedule-1", "daily-report", "1.0.0", "python3.11", "0 9 * * *")
-	configHash := computeScheduleHash(schedule)
+	configHash := computeScheduleHash(schedule, "")
 
 	mockRepo := &MockBotScheduleRepository{
 		Schedules: []model.BotSchedule{schedule},
@@ -278,9 +278,9 @@ func TestComputeScheduleHash(t *testing.T) {
 	schedule2 := createTestSchedule("schedule-1", "daily-report", "1.0.0", "python3.11", "0 10 * * *")
 	schedule3 := createTestSchedule("schedule-1", "daily-report", "2.0.0", "python3.11", "0 9 * * *")
 
-	hash1 := computeScheduleHash(schedule1)
-	hash2 := computeScheduleHash(schedule2)
-	hash3 := computeScheduleHash(schedule3)
+	hash1 := computeScheduleHash(schedule1, "")
+	hash2 := computeScheduleHash(schedule2, "")
+	hash3 := computeScheduleHash(schedule3, "")
 
 	// Hashes should be 16 characters
 	assert.Len(t, hash1, 16)
@@ -291,7 +291,7 @@ func TestComputeScheduleHash(t *testing.T) {
 
 	// Same config should produce same hash
 	schedule1Copy := createTestSchedule("schedule-1", "daily-report", "1.0.0", "python3.11", "0 9 * * *")
-	assert.Equal(t, hash1, computeScheduleHash(schedule1Copy))
+	assert.Equal(t, hash1, computeScheduleHash(schedule1Copy, ""))
 }
 
 func TestScheduleToBot(t *testing.T) {
@@ -797,4 +797,41 @@ func TestBotScheduleController_Reconcile_PropagatesNATSURLToBotContainer(t *test
 	}
 	assert.Equal(t, "nats://nats:4222", botEnv["NATS_URL"],
 		"scheduled bots run sync inline and need NATS_URL for live log publishing")
+}
+
+func TestBotScheduleController_Reconcile_UpdatesCronJobWhenNATSURLAdded(t *testing.T) {
+	schedule := createTestSchedule("schedule-1", "daily-report", "1.0.0", "python3.11", "0 9 * * *")
+	mockCronClient := NewMockK8sCronJobClient()
+
+	// Seed a CronJob created before NATS_URL was configured
+	oldController := NewBotScheduleController(
+		BotScheduleControllerConfig{Namespace: "the0", ControllerName: "test-controller"},
+		&MockBotScheduleRepository{Schedules: []model.BotSchedule{schedule}},
+		mockCronClient,
+	)
+	require.NoError(t, oldController.Reconcile(context.Background()))
+	require.Equal(t, 1, mockCronClient.CreateCalled)
+
+	// Reconcile with NATS_URL configured: the existing CronJob must be updated
+	newController := NewBotScheduleController(
+		BotScheduleControllerConfig{
+			Namespace:      "the0",
+			ControllerName: "test-controller",
+			NATSURL:        "nats://nats:4222",
+		},
+		&MockBotScheduleRepository{Schedules: []model.BotSchedule{schedule}},
+		mockCronClient,
+	)
+	require.NoError(t, newController.Reconcile(context.Background()))
+
+	assert.Equal(t, 1, mockCronClient.UpdateCalled,
+		"CronJob without NATS_URL must be updated once NATS_URL is configured")
+
+	cronJob := mockCronClient.CronJobs["the0/schedule-schedule-1"]
+	require.NotNil(t, cronJob)
+	botEnv := make(map[string]string)
+	for _, env := range cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env {
+		botEnv[env.Name] = env.Value
+	}
+	assert.Equal(t, "nats://nats:4222", botEnv["NATS_URL"])
 }

--- a/runtime/internal/k8s/controller/botschedule_controller_test.go
+++ b/runtime/internal/k8s/controller/botschedule_controller_test.go
@@ -763,3 +763,38 @@ func TestMockK8sCronJobClient_Errors(t *testing.T) {
 		assert.Equal(t, "delete error", err.Error())
 	})
 }
+
+func TestBotScheduleController_Reconcile_PropagatesNATSURLToBotContainer(t *testing.T) {
+	schedule := createTestSchedule("schedule-1", "daily-report", "1.0.0", "python3.11", "0 9 * * *")
+
+	mockRepo := &MockBotScheduleRepository{
+		Schedules: []model.BotSchedule{schedule},
+	}
+	mockCronClient := NewMockK8sCronJobClient()
+
+	controller := NewBotScheduleController(
+		BotScheduleControllerConfig{
+			Namespace:      "the0",
+			ControllerName: "test-controller",
+			NATSURL:        "nats://nats:4222",
+		},
+		mockRepo,
+		mockCronClient,
+	)
+
+	err := controller.Reconcile(context.Background())
+
+	require.NoError(t, err)
+	cronJob := mockCronClient.CronJobs["the0/schedule-schedule-1"]
+	require.NotNil(t, cronJob)
+
+	containers := cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers
+	require.Len(t, containers, 1)
+
+	botEnv := make(map[string]string)
+	for _, env := range containers[0].Env {
+		botEnv[env.Name] = env.Value
+	}
+	assert.Equal(t, "nats://nats:4222", botEnv["NATS_URL"],
+		"scheduled bots run sync inline and need NATS_URL for live log publishing")
+}

--- a/runtime/internal/k8s/controller/manager.go
+++ b/runtime/internal/k8s/controller/manager.go
@@ -33,6 +33,9 @@ type ManagerConfig struct {
 	MinIOBucket    string
 	MinIOUseSSL    bool
 
+	// NATSURL for live log publishing from bot pods (empty disables)
+	NATSURL string
+
 	// RuntimeImage for init containers and sidecars in bot pods
 	RuntimeImage string
 
@@ -103,6 +106,7 @@ func NewManager(mongoClient *mongo.Client, config ManagerConfig) (*Manager, erro
 			MinIOSecretKey:         config.MinIOSecretKey,
 			MinIOBucket:            config.MinIOBucket,
 			MinIOUseSSL:            config.MinIOUseSSL,
+			NATSURL:                config.NATSURL,
 			RuntimeImage:           config.RuntimeImage,
 			RuntimeImagePullPolicy: config.RuntimeImagePullPolicy,
 		},
@@ -135,6 +139,7 @@ func NewManager(mongoClient *mongo.Client, config ManagerConfig) (*Manager, erro
 			MinIOSecretKey:         config.MinIOSecretKey,
 			MinIOBucket:            config.MinIOBucket,
 			MinIOUseSSL:            config.MinIOUseSSL,
+			NATSURL:                config.NATSURL,
 			RuntimeImage:           config.RuntimeImage,
 			RuntimeImagePullPolicy: config.RuntimeImagePullPolicy,
 		},

--- a/runtime/internal/k8s/podgen/pod_builder.go
+++ b/runtime/internal/k8s/podgen/pod_builder.go
@@ -237,6 +237,16 @@ func (b *PodBuilder) WithMinIOConfig(endpoint, accessKey, secretKey string, useS
 	return b
 }
 
+// WithNATSConfig adds the NATS URL for live log publishing. The sync process
+// (sidecar for realtime, inline for scheduled) reads NATS_URL to stream log
+// lines; without it, logs only reach MinIO and dashboards fall back to polling.
+func (b *PodBuilder) WithNATSConfig(natsURL string) *PodBuilder {
+	if natsURL != "" {
+		b.botEnv = append(b.botEnv, corev1.EnvVar{Name: "NATS_URL", Value: natsURL})
+	}
+	return b
+}
+
 // WithResources sets resource limits and requests for the bot container.
 func (b *PodBuilder) WithResources(memoryLimit, cpuLimit, memoryRequest, cpuRequest string) *PodBuilder {
 	b.botResources = corev1.ResourceRequirements{
@@ -280,7 +290,7 @@ func (b *PodBuilder) WithSyncSidecar(image string, botID string, watchDone bool)
 		ImagePullPolicy: b.botImagePullPolicy,
 		Command:         []string{"/app/runtime", "daemon", "sync"},
 		Args:            args,
-		Env:             b.minioEnvVars(),
+		Env:             b.syncEnvVars(),
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "bot-state", MountPath: "/state"},
 			{Name: "the0", MountPath: "/var/the0"},
@@ -362,16 +372,17 @@ func (b *PodBuilder) ForQuery(queryPath string, queryParams map[string]interface
 	return b
 }
 
-// minioEnvVars extracts MinIO env vars from botEnv for sidecars.
-func (b *PodBuilder) minioEnvVars() []corev1.EnvVar {
-	var minioEnv []corev1.EnvVar
+// syncEnvVars extracts the env vars the sync sidecar needs from botEnv:
+// MinIO credentials for log/state upload and NATS_URL for live log publishing.
+func (b *PodBuilder) syncEnvVars() []corev1.EnvVar {
+	var syncEnv []corev1.EnvVar
 	for _, env := range b.botEnv {
 		switch env.Name {
-		case "MINIO_ENDPOINT", "MINIO_ACCESS_KEY", "MINIO_SECRET_KEY", "MINIO_USE_SSL":
-			minioEnv = append(minioEnv, env)
+		case "MINIO_ENDPOINT", "MINIO_ACCESS_KEY", "MINIO_SECRET_KEY", "MINIO_USE_SSL", "NATS_URL":
+			syncEnv = append(syncEnv, env)
 		}
 	}
-	return minioEnv
+	return syncEnv
 }
 
 // Build creates the final Pod spec.

--- a/runtime/internal/k8s/podgen/pod_generator.go
+++ b/runtime/internal/k8s/podgen/pod_generator.go
@@ -59,6 +59,10 @@ type PodGeneratorConfig struct {
 	MinIOStateBucket string // Bucket for persistent bot state (default: "bot-state")
 	MinIOUseSSL      bool
 
+	// NATSURL enables live log streaming: the sync process publishes bot log
+	// lines to NATS for the API's SSE fan-out. Empty disables publishing.
+	NATSURL string
+
 	// RuntimeImage is the image for init and sidecar containers (e.g., "the0/runtime:latest")
 	RuntimeImage string
 
@@ -122,6 +126,7 @@ func (g *PodGenerator) GeneratePod(bot model.Bot) (*corev1.Pod, error) {
 		WithBotConfig(bot.ID, botConfig.filePath, botConfig.runtime, botConfig.entrypoint, bot.Config).
 		WithBotType("realtime").
 		WithMinIOConfig(g.config.MinIOEndpoint, g.config.MinIOAccessKey, g.config.MinIOSecretKey, g.config.MinIOUseSSL).
+		WithNATSConfig(g.config.NATSURL).
 		WithResources(botConfig.memoryLimit, botConfig.cpuLimit, botConfig.memoryRequest, botConfig.cpuRequest).
 		WithSyncSidecar(g.config.RuntimeImage, bot.ID, false)
 
@@ -170,6 +175,7 @@ func (g *PodGenerator) GenerateScheduledPodSpec(bot model.Bot) (*corev1.PodSpec,
 		WithBotConfig(bot.ID, botConfig.filePath, botConfig.runtime, botConfig.entrypoint, bot.Config).
 		WithBotType("scheduled").
 		WithMinIOConfig(g.config.MinIOEndpoint, g.config.MinIOAccessKey, g.config.MinIOSecretKey, g.config.MinIOUseSSL).
+		WithNATSConfig(g.config.NATSURL).
 		WithResources(botConfig.memoryLimit, botConfig.cpuLimit, botConfig.memoryRequest, botConfig.cpuRequest)
 	// Note: No query sidecar - queries are ephemeral
 

--- a/runtime/internal/k8s/podgen/pod_generator.go
+++ b/runtime/internal/k8s/podgen/pod_generator.go
@@ -121,7 +121,7 @@ func (g *PodGenerator) GeneratePod(bot model.Bot) (*corev1.Pod, error) {
 			LabelManagedBy:        g.config.ControllerName,
 		}).
 		WithAnnotations(map[string]string{
-			AnnotationConfigHash: computeConfigHash(bot),
+			AnnotationConfigHash: g.computeConfigHash(bot),
 		}).
 		WithBotConfig(bot.ID, botConfig.filePath, botConfig.runtime, botConfig.entrypoint, bot.Config).
 		WithBotType("realtime").
@@ -170,7 +170,7 @@ func (g *PodGenerator) GenerateScheduledPodSpec(bot model.Bot) (*corev1.PodSpec,
 			LabelManagedBy:        g.config.ControllerName,
 		}).
 		WithAnnotations(map[string]string{
-			AnnotationConfigHash: computeConfigHash(bot),
+			AnnotationConfigHash: g.computeConfigHash(bot),
 		}).
 		WithBotConfig(bot.ID, botConfig.filePath, botConfig.runtime, botConfig.entrypoint, bot.Config).
 		WithBotType("scheduled").
@@ -306,10 +306,12 @@ func ExtractConfigHash(pod *corev1.Pod) string {
 	return pod.Annotations[AnnotationConfigHash]
 }
 
-// ConfigChanged returns true if the bot config has changed since the pod was created.
-func ConfigChanged(pod *corev1.Pod, bot model.Bot) bool {
+// ConfigChanged returns true if the desired pod spec has changed since the pod
+// was created, either from the bot's own config or from generator-level inputs
+// (e.g. NATS URL) that shape the pod environment.
+func (g *PodGenerator) ConfigChanged(pod *corev1.Pod, bot model.Bot) bool {
 	existingHash := ExtractConfigHash(pod)
-	currentHash := computeConfigHash(bot)
+	currentHash := g.computeConfigHash(bot)
 	return existingHash != currentHash
 }
 
@@ -361,15 +363,19 @@ func parseResourceOrDefault(value, defaultValue string) resource.Quantity {
 }
 
 // computeConfigHash creates a hash of the bot config for change detection.
-func computeConfigHash(bot model.Bot) string {
+// Generator-level inputs that shape the pod environment (NATS URL) are part of
+// the hash so changing them reconciles existing pods.
+func (g *PodGenerator) computeConfigHash(bot model.Bot) string {
 	data := struct {
 		Config           map[string]interface{}
 		CustomBotVersion string
 		Enabled          *bool
+		NATSURL          string
 	}{
 		Config:           bot.Config,
 		CustomBotVersion: bot.CustomBotVersion.Version,
 		Enabled:          bot.Enabled,
+		NATSURL:          g.config.NATSURL,
 	}
 
 	jsonBytes, err := json.Marshal(data)

--- a/runtime/internal/k8s/podgen/pod_generator_test.go
+++ b/runtime/internal/k8s/podgen/pod_generator_test.go
@@ -579,3 +579,85 @@ func TestValidateMinIOPath(t *testing.T) {
 		})
 	}
 }
+
+func envToMap(envVars []corev1.EnvVar) map[string]string {
+	m := make(map[string]string, len(envVars))
+	for _, env := range envVars {
+		m[env.Name] = env.Value
+	}
+	return m
+}
+
+func natsTestBot(id, botRuntime string) model.Bot {
+	return model.Bot{
+		ID:     id,
+		Config: map[string]interface{}{},
+		CustomBotVersion: model.CustomBotVersion{
+			Version: "1.0.0",
+			Config: model.APIBotConfig{
+				Name:        "nats-bot",
+				Runtime:     botRuntime,
+				Entrypoints: map[string]string{"bot": "main.py"},
+			},
+			FilePath: "nats-bot/1.0.0",
+		},
+	}
+}
+
+func TestPodGenerator_NATSURLPropagation(t *testing.T) {
+	withNATS := NewPodGenerator(PodGeneratorConfig{
+		Namespace:      "the0",
+		MinIOEndpoint:  "minio:9000",
+		MinIOAccessKey: "key",
+		MinIOSecretKey: "secret",
+		MinIOBucket:    "bots",
+		RuntimeImage:   "the0/runtime:latest",
+		NATSURL:        "nats://nats:4222",
+	})
+
+	t.Run("realtime sync sidecar receives NATS_URL", func(t *testing.T) {
+		pod, err := withNATS.GeneratePod(natsTestBot("rt-bot", "python3.11"))
+		require.NoError(t, err)
+
+		require.Len(t, pod.Spec.InitContainers, 1)
+		sidecarEnv := envToMap(pod.Spec.InitContainers[0].Env)
+		assert.Equal(t, "nats://nats:4222", sidecarEnv["NATS_URL"],
+			"sync sidecar needs NATS_URL to publish live log lines")
+		// MinIO vars must survive alongside NATS_URL
+		assert.Equal(t, "minio:9000", sidecarEnv["MINIO_ENDPOINT"])
+	})
+
+	t.Run("scheduled bot container receives NATS_URL for inline sync", func(t *testing.T) {
+		podSpec, err := withNATS.GenerateScheduledPodSpec(natsTestBot("sched-bot", "python3.11"))
+		require.NoError(t, err)
+
+		require.Len(t, podSpec.Containers, 1)
+		botEnv := envToMap(podSpec.Containers[0].Env)
+		assert.Equal(t, "nats://nats:4222", botEnv["NATS_URL"],
+			"scheduled bots run sync inline in the bot container")
+	})
+
+	t.Run("empty NATS_URL sets no env var", func(t *testing.T) {
+		withoutNATS := NewPodGenerator(PodGeneratorConfig{
+			Namespace:      "the0",
+			MinIOEndpoint:  "minio:9000",
+			MinIOAccessKey: "key",
+			MinIOSecretKey: "secret",
+			MinIOBucket:    "bots",
+			RuntimeImage:   "the0/runtime:latest",
+		})
+
+		pod, err := withoutNATS.GeneratePod(natsTestBot("rt-bot", "python3.11"))
+		require.NoError(t, err)
+		require.Len(t, pod.Spec.InitContainers, 1)
+		sidecarEnv := envToMap(pod.Spec.InitContainers[0].Env)
+		_, present := sidecarEnv["NATS_URL"]
+		assert.False(t, present, "no NATS_URL config should mean no NATS_URL env var")
+
+		podSpec, err := withoutNATS.GenerateScheduledPodSpec(natsTestBot("sched-bot", "python3.11"))
+		require.NoError(t, err)
+		botEnv := envToMap(podSpec.Containers[0].Env)
+		_, present = botEnv["NATS_URL"]
+		assert.False(t, present)
+	})
+}

--- a/runtime/internal/k8s/podgen/pod_generator_test.go
+++ b/runtime/internal/k8s/podgen/pod_generator_test.go
@@ -457,14 +457,25 @@ func TestConfigChanged(t *testing.T) {
 	require.NoError(t, err)
 
 	// Same config should not be changed
-	assert.False(t, ConfigChanged(pod, bot))
+	assert.False(t, generator.ConfigChanged(pod, bot))
 
 	// Modified config should be detected
 	botModified := bot
 	botModified.Config = map[string]interface{}{
 		"key": "value2",
 	}
-	assert.True(t, ConfigChanged(pod, botModified))
+	assert.True(t, generator.ConfigChanged(pod, botModified))
+
+	// A generator with a different NATS URL must also detect a change, so
+	// existing pods are reconciled when live streaming is (re)configured
+	natsGenerator := NewPodGenerator(PodGeneratorConfig{
+		MinIOEndpoint:  "minio:9000",
+		MinIOAccessKey: "key",
+		MinIOSecretKey: "secret",
+		MinIOBucket:    "bots",
+		NATSURL:        "nats://nats:4222",
+	})
+	assert.True(t, natsGenerator.ConfigChanged(pod, bot))
 }
 
 func TestSanitizeLabelValue(t *testing.T) {


### PR DESCRIPTION
## Problem

In Kubernetes, `NATS_URL` was never propagated into generated bot pods:

- The sync sidecar's env was a hardcoded 4-var MinIO allowlist (`minioEnvVars()` in `podgen/pod_builder.go`)
- Neither `BotControllerConfig`, `BotScheduleControllerConfig`, nor `ManagerConfig` carried a NATS field, so the controller's own `NATS_URL` (already set by the Helm chart) stopped at the controller

`newLogPublisherFromEnv` therefore returned nil in every bot pod and the log syncer skipped its NATS publish branch entirely. The API's per-bot SSE fan-out had nothing flowing into it, so live streaming delivered only the initial history event and dashboards silently degraded to 30s REST polling.

Docker Compose local **does** propagate `NATS_URL` (`docker/config.go` -> `container_builder.go`), which is why streaming works in local dev and was never caught broken in prod.

## Fix

- Add `NATSURL` to `PodGeneratorConfig` and a `WithNATSConfig` builder method (empty value sets no env var, preserving the publisher-disabled default)
- Extend the sidecar env allowlist (`minioEnvVars` renamed `syncEnvVars`) so the realtime sync sidecar receives `NATS_URL`
- Scheduled bots receive `NATS_URL` on the bot container, where sync runs inline
- Wire `NATSURL` through both controller configs and `ManagerConfig` from the existing `--nats-url` flag

No chart changes needed: the bot-controller Deployment already sets `NATS_URL`.

## Tests

- `podgen`: realtime sidecar env, scheduled bot container env, and empty-config (no env var) cases
- `controller`: reconcile-level tests asserting `NATS_URL` lands on the created Pod's sync sidecar and the CronJob's bot container
- Full runtime suite green, `go build ./...` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional live log publishing for bot workloads through a configurable NATS connection.
  * Realtime and scheduled workloads automatically receive the configured logging endpoint.
  * Logging remains disabled when no NATS connection is configured.

* **Bug Fixes**
  * Existing workloads are refreshed when the NATS configuration changes.
  * Preserved existing storage-related environment settings.

* **Tests**
  * Added coverage for NATS configuration propagation and workload updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->