### PR TITLE
fix(frontend): stop dashboards unmounting into loading screens on refresh

### DIFF
--- a/frontend/src/components/dashboard/bot-detail-panel.tsx
+++ b/frontend/src/components/dashboard/bot-detail-panel.tsx
@@ -113,6 +113,16 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
   // exactly once (no polling-then-streaming flip).
   const hookBotId = bot !== null ? botId : "";
 
+  // Stable identity: an inline literal here defeats React.memo on
+  // BotDashboardLoader and remounts the dashboard on every panel render
+  const dashboardDateRange = useMemo(
+    () =>
+      interval.type === "range"
+        ? { start: interval.start, end: interval.end }
+        : undefined,
+    [interval],
+  );
+
   const logsHook = useBotLogs({
     botId: hookBotId,
     streaming: useStreaming,
@@ -587,7 +597,7 @@ export function BotDetailPanel({ botId }: BotDetailPanelProps) {
                 botId={botId}
                 customBotId={customBotId}
                 version={bot.config.version}
-                dateRange={interval.type === "range" ? { start: interval.start, end: interval.end } : undefined}
+                dateRange={dashboardDateRange}
                 latest={interval.type === "latest"}
                 streaming={useStreaming}
                 refreshInterval={refreshInterval}

--- a/frontend/src/components/dashboard/mobile-bot-detail.tsx
+++ b/frontend/src/components/dashboard/mobile-bot-detail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useMemo } from "react";
 import { useRouter } from "next/navigation";
 import moment from "moment";
 import { Button } from "@/components/ui/button";
@@ -111,6 +111,16 @@ export function MobileBotDetail({
 }: MobileBotDetailProps) {
   const router = useRouter();
 
+  // Stable identity: an inline literal here defeats React.memo on
+  // BotDashboardLoader and remounts the dashboard on every render
+  const dashboardDateRange = useMemo(
+    () =>
+      interval.type === "range"
+        ? { start: interval.start, end: interval.end }
+        : undefined,
+    [interval],
+  );
+
   return (
     <div className="flex flex-col h-[calc(100vh-3rem)]">
       {/* Header with back arrow */}
@@ -159,18 +169,21 @@ export function MobileBotDetail({
           </TabsTrigger>
         </TabsList>
 
-        <TabsContent value="dashboard" className="flex-1 m-0 overflow-auto">
+        {/* forceMount keeps the dashboard alive across tab switches:
+            without it, every Console/Details round-trip re-imports the
+            bundle, reconnects SSE, and refetches history */}
+        <TabsContent
+          value="dashboard"
+          forceMount
+          className="flex-1 m-0 overflow-auto data-[state=inactive]:hidden"
+        >
           {bot.config.hasFrontend && customBotId ? (
             <BotDashboardLoader
               key={botId}
               botId={botId}
               customBotId={customBotId}
               version={bot.config.version}
-              dateRange={
-                interval.type === "range"
-                  ? { start: interval.start, end: interval.end }
-                  : undefined
-              }
+              dateRange={dashboardDateRange}
               latest={interval.type === "latest"}
               streaming={showLive}
               refreshInterval={refreshInterval}

--- a/frontend/src/contexts/__tests__/bot-events-context.test.tsx
+++ b/frontend/src/contexts/__tests__/bot-events-context.test.tsx
@@ -145,6 +145,66 @@ describe("BotEventsContext", () => {
       expect(screen.getByTestId("fetching")).toHaveTextContent("false");
     });
 
+    it("suppresses error while data is on screen (background refresh failure)", () => {
+      const { useBotEvents } = require("@/hooks/use-bot-events");
+      useBotEvents.mockReturnValueOnce({
+        events: mockEvents,
+        loading: false,
+        isFetching: false,
+        error: "network blip",
+        utils: mockUtils,
+        refresh: mockRefresh,
+        setDateFilter: mockSetDateFilter,
+        setDateRangeFilter: mockSetDateRangeFilter,
+        exportLogs: mockExportLogs,
+        rawLogs: [],
+      });
+
+      const TestComponent = () => {
+        const context = useBotEventsContext();
+        return <span data-testid="error">{String(context.error)}</span>;
+      };
+
+      render(
+        <BotEventsProvider botId="bot-123">
+          <TestComponent />
+        </BotEventsProvider>,
+      );
+
+      // A transient refresh failure must not blank a dashboard that has
+      // data: naive `if (error)` early-returns in bot frontends stay safe
+      expect(screen.getByTestId("error")).toHaveTextContent("null");
+    });
+
+    it("exposes error when there is nothing to render (initial load failure)", () => {
+      const { useBotEvents } = require("@/hooks/use-bot-events");
+      useBotEvents.mockReturnValueOnce({
+        events: [],
+        loading: false,
+        isFetching: false,
+        error: "boom",
+        utils: mockUtils,
+        refresh: mockRefresh,
+        setDateFilter: mockSetDateFilter,
+        setDateRangeFilter: mockSetDateRangeFilter,
+        exportLogs: mockExportLogs,
+        rawLogs: [],
+      });
+
+      const TestComponent = () => {
+        const context = useBotEventsContext();
+        return <span data-testid="error">{String(context.error)}</span>;
+      };
+
+      render(
+        <BotEventsProvider botId="bot-123">
+          <TestComponent />
+        </BotEventsProvider>,
+      );
+
+      expect(screen.getByTestId("error")).toHaveTextContent("boom");
+    });
+
     it("passes autoRefresh prop to useBotEvents", () => {
       const { useBotEvents } = require("@/hooks/use-bot-events");
 

--- a/frontend/src/contexts/__tests__/bot-events-context.test.tsx
+++ b/frontend/src/contexts/__tests__/bot-events-context.test.tsx
@@ -51,6 +51,7 @@ jest.mock("@/hooks/use-bot-events", () => ({
   useBotEvents: jest.fn(() => ({
     events: mockEvents,
     loading: false,
+    isFetching: false,
     error: null,
     utils: mockUtils,
     refresh: mockRefresh,
@@ -103,6 +104,45 @@ describe("BotEventsContext", () => {
       expect(screen.getByTestId("bot-id")).toHaveTextContent("test-bot-id");
       expect(screen.getByTestId("event-count")).toHaveTextContent("2");
       expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+
+    it("keeps the context value referentially stable when hook results are unchanged", () => {
+      const captured: unknown[] = [];
+      const TestComponent = () => {
+        captured.push(useBotEventsContext());
+        return null;
+      };
+
+      const { rerender } = render(
+        <BotEventsProvider botId="bot-123">
+          <TestComponent />
+        </BotEventsProvider>,
+      );
+      rerender(
+        <BotEventsProvider botId="bot-123">
+          <TestComponent />
+        </BotEventsProvider>,
+      );
+
+      expect(captured.length).toBeGreaterThanOrEqual(2);
+      // A provider re-render with identical hook output must not hand
+      // consumers a new value object (it would re-render every chart)
+      expect(captured[captured.length - 1]).toBe(captured[0]);
+    });
+
+    it("exposes isFetching for background refresh indicators", () => {
+      const TestComponent = () => {
+        const context = useBotEventsContext();
+        return <span data-testid="fetching">{String(context.isFetching)}</span>;
+      };
+
+      render(
+        <BotEventsProvider botId="bot-123">
+          <TestComponent />
+        </BotEventsProvider>,
+      );
+
+      expect(screen.getByTestId("fetching")).toHaveTextContent("false");
     });
 
     it("passes autoRefresh prop to useBotEvents", () => {

--- a/frontend/src/contexts/bot-events-context.tsx
+++ b/frontend/src/contexts/bot-events-context.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import React, { createContext, useContext, ReactNode } from "react";
+import React, { createContext, useContext, useMemo, ReactNode } from "react";
 import { useBotEvents, BotEvent, BotEventUtils } from "@/hooks/use-bot-events";
 
 interface BotEventsContextValue {
   /** Parsed bot events */
   events: BotEvent[];
-  /** Loading state */
+  /** True only while there is nothing to render yet. Background refreshes
+   *  keep this false so dashboards don't unmount into a loading screen. */
   loading: boolean;
+  /** True while a background refresh is in flight (subtle indicators) */
+  isFetching: boolean;
   /** Error message if any */
   error: string | null;
   /** Event utilities bound to current events */
@@ -66,7 +69,7 @@ export function BotEventsProvider({
   refreshInterval = 30000,
   dateRange,
 }: BotEventsProviderProps) {
-  const { events, loading, error, utils, refresh } = useBotEvents({
+  const { events, loading, isFetching, error, utils, refresh } = useBotEvents({
     botId,
     streaming,
     latest,
@@ -75,17 +78,23 @@ export function BotEventsProvider({
     dateRange,
   });
 
+  // Memoized so a provider re-render with unchanged hook output doesn't hand
+  // every consumer (each chart in a bot dashboard) a new value object
+  const value = useMemo(
+    () => ({
+      events,
+      loading,
+      isFetching,
+      error,
+      utils,
+      refresh,
+      botId,
+    }),
+    [events, loading, isFetching, error, utils, refresh, botId],
+  );
+
   return (
-    <BotEventsContext.Provider
-      value={{
-        events,
-        loading,
-        error,
-        utils,
-        refresh,
-        botId,
-      }}
-    >
+    <BotEventsContext.Provider value={value}>
       {children}
     </BotEventsContext.Provider>
   );

--- a/frontend/src/contexts/bot-events-context.tsx
+++ b/frontend/src/contexts/bot-events-context.tsx
@@ -11,7 +11,10 @@ interface BotEventsContextValue {
   loading: boolean;
   /** True while a background refresh is in flight (subtle indicators) */
   isFetching: boolean;
-  /** Error message if any */
+  /** Set only when there is nothing to render (initial load failed).
+   *  Background refresh failures keep this null so a naive `if (error)`
+   *  early-return can't blank a dashboard that has data on screen; they
+   *  surface through toasts and the connection indicator instead. */
   error: string | null;
   /** Event utilities bound to current events */
   utils: BotEventUtils;
@@ -78,6 +81,10 @@ export function BotEventsProvider({
     dateRange,
   });
 
+  // Errors only reach bot frontends when there is nothing to render: this is
+  // what makes the naive `if (error) return <Error/>` pattern safe to write
+  const displayError = events.length === 0 ? error : null;
+
   // Memoized so a provider re-render with unchanged hook output doesn't hand
   // every consumer (each chart in a bot dashboard) a new value object
   const value = useMemo(
@@ -85,12 +92,12 @@ export function BotEventsProvider({
       events,
       loading,
       isFetching,
-      error,
+      error: displayError,
       utils,
       refresh,
       botId,
     }),
-    [events, loading, isFetching, error, utils, refresh, botId],
+    [events, loading, isFetching, displayError, utils, refresh, botId],
   );
 
   return (

--- a/frontend/src/hooks/__tests__/use-bot-events.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-events.test.ts
@@ -125,6 +125,7 @@ describe("useBotEvents", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseBotLogs.mockReturnValue({
+      isFetching: false,
       logs: mockLogs,
       loading: false,
       error: null,
@@ -330,6 +331,22 @@ describe("useBotEvents", () => {
 
   describe("event ordering", () => {
     it("sorts parsed events chronologically regardless of fetch order", () => {
+      // Single raw entry so the (per-entry) parser is invoked exactly once
+      mockUseBotLogs.mockReturnValue({
+        isFetching: false,
+        logs: [{ date: "2026-07-14T23:40:00Z", content: "desc batch" }],
+        loading: false,
+        error: null,
+        hasMore: false,
+        total: 1,
+        refresh: mockRefresh,
+        loadMore: jest.fn(),
+        setDateFilter: mockSetDateFilter,
+        setDateRangeFilter: mockSetDateRangeFilter,
+        setLatestFilter: mockSetLatestFilter,
+        exportLogs: mockExportLogs,
+      } as any);
+
       const { parseEvents } = jest.requireMock("@/lib/events/event-parser");
       // Simulate a newest-first (sort=desc) API response: parseEvents
       // preserves input order, so events arrive newest-first here.
@@ -395,9 +412,70 @@ describe("useBotEvents", () => {
     });
   });
 
+  describe("event parsing efficiency", () => {
+    it("reuses parsed events for unchanged log entries when new entries append", () => {
+      const entryA = { date: "2024-01-01T10:00:00Z", content: "Log line A" };
+      const entryB = { date: "2024-01-01T10:01:00Z", content: "Log line B" };
+      const baseReturn = {
+        isFetching: false,
+        loading: false,
+        error: null,
+        hasMore: false,
+        total: 1,
+        refresh: mockRefresh,
+        loadMore: jest.fn(),
+        setDateFilter: mockSetDateFilter,
+        setDateRangeFilter: mockSetDateRangeFilter,
+        setLatestFilter: mockSetLatestFilter,
+        exportLogs: mockExportLogs,
+      };
+
+      mockUseBotLogs.mockReturnValue({ ...baseReturn, logs: [entryA] } as any);
+      const { result, rerender } = renderHook(() =>
+        useBotEvents({ botId: "bot-123" }),
+      );
+      const firstEvent = result.current.events[0];
+      expect(firstEvent).toBeDefined();
+
+      // SSE append: same entryA object, plus a new entry. The already-parsed
+      // event for entryA must keep its identity so charts and memoized
+      // consumers don't see every event as new on every appended line.
+      mockUseBotLogs.mockReturnValue({
+        ...baseReturn,
+        logs: [entryA, entryB],
+      } as any);
+      rerender();
+
+      expect(result.current.events.length).toBe(2);
+      expect(result.current.events[0]).toBe(firstEvent);
+    });
+  });
+
   describe("loading state", () => {
+    it("passes isFetching through from useBotLogs for background refreshes", () => {
+      mockUseBotLogs.mockReturnValue({
+        isFetching: true,
+        logs: [],
+        loading: false,
+        error: null,
+        hasMore: false,
+        total: 0,
+        refresh: mockRefresh,
+        loadMore: jest.fn(),
+        setDateFilter: mockSetDateFilter,
+        setDateRangeFilter: mockSetDateRangeFilter,
+        exportLogs: mockExportLogs,
+      });
+
+      const { result } = renderHook(() => useBotEvents({ botId: "bot-123" }));
+
+      expect(result.current.isFetching).toBe(true);
+      expect(result.current.loading).toBe(false);
+    });
+
     it("returns loading state from useBotLogs", () => {
       mockUseBotLogs.mockReturnValue({
+      isFetching: false,
         logs: [],
         loading: true,
         error: null,
@@ -425,6 +503,7 @@ describe("useBotEvents", () => {
   describe("error state", () => {
     it("returns error from useBotLogs", () => {
       mockUseBotLogs.mockReturnValue({
+      isFetching: false,
         logs: [],
         loading: false,
         error: "Failed to fetch logs",
@@ -628,6 +707,7 @@ describe("useBotEvents", () => {
 
       // Simulate events change
       mockUseBotLogs.mockReturnValue({
+      isFetching: false,
         logs: [
           { date: "20240101", content: "[2024-01-01 12:00:00] INFO: New log" },
         ],
@@ -653,6 +733,7 @@ describe("useBotEvents", () => {
   describe("empty state", () => {
     it("handles empty logs array", () => {
       mockUseBotLogs.mockReturnValue({
+      isFetching: false,
         logs: [],
         loading: false,
         error: null,

--- a/frontend/src/hooks/__tests__/use-bot-logs.test.ts
+++ b/frontend/src/hooks/__tests__/use-bot-logs.test.ts
@@ -1887,4 +1887,144 @@ describe("useBotLogs", () => {
       });
     });
   });
+
+  describe("background refresh loading semantics", () => {
+    const logsResponse = {
+      ok: true,
+      json: async () => ({
+        data: [{ date: "20260406", content: "Log" }],
+        total: 1,
+        hasMore: false,
+      }),
+    } as Response;
+
+    it("keeps loading false when a polling tick refetches after data has loaded", async () => {
+      jest.useFakeTimers();
+      try {
+        // First fetch resolves immediately; the polling fetch hangs so we can
+        // observe state while it is in flight
+        let resolvePoll: (r: Response) => void;
+        mockAuthFetch
+          .mockResolvedValueOnce(logsResponse)
+          .mockImplementationOnce(
+            () => new Promise<Response>((r) => (resolvePoll = r)),
+          );
+
+        const { result } = renderHook(() =>
+          useBotLogs({
+            botId: "bot-1",
+            autoRefresh: true,
+            refreshInterval: 30000,
+          }),
+        );
+
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(0);
+        });
+        expect(result.current.loading).toBe(false);
+        expect(result.current.logs.length).toBe(1);
+
+        // Fire the polling tick; its fetch is now in flight
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(30000);
+        });
+
+        expect(result.current.loading).toBe(false);
+        expect(result.current.isFetching).toBe(true);
+        // Stale data must remain visible during the background refetch
+        expect(result.current.logs.length).toBe(1);
+
+        await act(async () => {
+          resolvePoll!(logsResponse);
+          await jest.advanceTimersByTimeAsync(0);
+        });
+        expect(result.current.isFetching).toBe(false);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("keeps loading false during manual refresh once data has loaded", async () => {
+      mockAuthFetch.mockResolvedValue(logsResponse);
+
+      const { result } = renderHook(() => useBotLogs({ botId: "bot-1" }));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      act(() => {
+        result.current.refresh();
+      });
+
+      expect(result.current.loading).toBe(false);
+
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
+    });
+
+    it("keeps loading false on filter change once data has loaded (stale-while-revalidate)", async () => {
+      mockAuthFetch.mockResolvedValue(logsResponse);
+
+      const { result } = renderHook(() => useBotLogs({ botId: "bot-1" }));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      act(() => {
+        result.current.setDateRangeFilter("20260401", "20260403");
+      });
+
+      expect(result.current.loading).toBe(false);
+
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
+    });
+
+    it("sets loading again when the bot changes (no stale data across bots)", async () => {
+      mockAuthFetch.mockResolvedValue(logsResponse);
+
+      const { result, rerender } = renderHook(
+        ({ botId }) => useBotLogs({ botId }),
+        { initialProps: { botId: "bot-1" } },
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      rerender({ botId: "bot-2" });
+
+      expect(result.current.loading).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+    });
+
+    it("recovers full loading state when the initial fetch fails (no data to show)", async () => {
+      mockAuthFetch.mockRejectedValueOnce(new Error("network down"));
+
+      const { result } = renderHook(() => useBotLogs({ botId: "bot-1" }));
+
+      await waitFor(() => {
+        expect(result.current.error).toBe("network down");
+      });
+
+      // With no data yet, a retry is an initial load again, not a background one
+      mockAuthFetch.mockResolvedValue(logsResponse);
+      act(() => {
+        result.current.refresh();
+      });
+      expect(result.current.loading).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+      expect(result.current.logs.length).toBe(1);
+    });
+  });
 });

--- a/frontend/src/hooks/use-bot-events.ts
+++ b/frontend/src/hooks/use-bot-events.ts
@@ -60,8 +60,10 @@ interface BotEventUtils {
 interface UseBotEventsReturn {
   /** Parsed bot events */
   events: BotEvent[];
-  /** Loading state */
+  /** True only while there is nothing to render yet (initial load) */
   loading: boolean;
+  /** True while a background refresh is in flight */
+  isFetching: boolean;
   /** Error message if any */
   error: string | null;
   /** Event utilities bound to current events */
@@ -118,6 +120,7 @@ export function useBotEvents({
   const {
     logs: rawLogs,
     loading,
+    isFetching,
     error,
     refresh,
     setDateFilter,
@@ -162,30 +165,45 @@ export function useBotEvents({
     setDateFilter,
   ]);
 
+  // Per-entry parse cache keyed by log entry identity. Appends (SSE lines,
+  // pagination) preserve existing entry objects, so only new entries are
+  // parsed and already-parsed events keep their identity - without this,
+  // every arriving line re-parsed the whole buffer (up to 10k entries) and
+  // handed consumers all-new event objects. Replace fetches create fresh
+  // entry objects, which correctly miss the cache; WeakMap lets the old
+  // generation be GC'd.
+  const parseCacheRef = useRef(
+    new WeakMap<object, (BotEvent & { timestamp: Date })[]>(),
+  );
+
   // Parse raw logs into events
   // Ensure timestamps are always Date objects for SDK compatibility
   const events = useMemo(() => {
-    // Convert raw logs to the format expected by parseEvents
-    const logEntries = rawLogs.map((log) => ({
-      date: log.date,
-      content: log.content,
-    }));
-    const parsedEvents = parseEvents(logEntries);
+    const cache = parseCacheRef.current;
+    const all: (BotEvent & { timestamp: Date })[] = [];
 
-    // Ensure all events have a valid timestamp (SDK expects Date, not null)
-    // Use current time as fallback for events without timestamps
-    const stamped = parsedEvents.map((event) => ({
-      ...event,
-      timestamp: event.timestamp ?? new Date(),
-    }));
+    for (const log of rawLogs) {
+      let parsed = cache.get(log);
+      if (!parsed) {
+        // Fallback-stamp events without timestamps at parse time (SDK expects
+        // Date, not null); caching also keeps that fallback stable instead of
+        // drifting to "now" on every re-render
+        parsed = parseEvents([
+          { date: log.date, content: log.content, timestamp: log.timestamp },
+        ]).map((event) => ({
+          ...event,
+          timestamp: event.timestamp ?? new Date(),
+        }));
+        cache.set(log, parsed);
+      }
+      all.push(...parsed);
+    }
 
     // The API returns newest-first for desc queries but every event util
     // (latest, extractTimeSeries, groupByRun) assumes chronological order.
     // Stable-sort here so utils are correct regardless of fetch order;
-    // fallback-stamped events share "now" and keep their relative order.
-    return stamped.sort(
-      (a, b) => a.timestamp.getTime() - b.timestamp.getTime(),
-    );
+    // fallback-stamped events share their parse time and keep relative order.
+    return all.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
   }, [rawLogs]);
 
   // Create bound utilities
@@ -216,6 +234,7 @@ export function useBotEvents({
   return {
     events,
     loading,
+    isFetching,
     error,
     utils,
     refresh,

--- a/frontend/src/hooks/use-bot-logs.ts
+++ b/frontend/src/hooks/use-bot-logs.ts
@@ -59,7 +59,13 @@ interface UseBotLogsProps {
 
 export interface UseBotLogsReturn {
   logs: LogEntry[];
+  /** True only while there is nothing to render yet (initial load / bot
+   *  switch). Background refetches keep this false so consumers can keep
+   *  showing stale data instead of unmounting into a loading screen. */
   loading: boolean;
+  /** True while any replace fetch is in flight, including background
+   *  refreshes. Use for subtle "updating" indicators. */
+  isFetching: boolean;
   error: string | null;
   hasMore: boolean;
   total: number;
@@ -108,6 +114,7 @@ export const useBotLogs = ({
 }: UseBotLogsProps): UseBotLogsReturn => {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [loading, setLoading] = useState(false);
+  const [isFetching, setIsFetching] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState<LogsQuery>(initialQuery);
   const [hasMore, setHasMore] = useState(false);
@@ -125,6 +132,10 @@ export const useBotLogs = ({
 
   const restAbortRef = useRef<AbortController | null>(null);
   const pollingRef = useRef<NodeJS.Timeout | null>(null);
+  // True once a replace fetch has delivered data for the current bot. While
+  // set, replace fetches are background refreshes: they must not flip
+  // `loading` (which would unmount dashboards into their loading screen).
+  const hasDataRef = useRef(false);
   // Latest fetchLogs so the polling interval never calls a stale closure
   const fetchLogsRef = useRef<(q?: LogsQuery, m?: false | "append" | "prepend") => Promise<boolean>>(null!);
   // Skip polling overwrites while the user has explicitly paginated
@@ -211,7 +222,12 @@ export const useBotLogs = ({
       if (!merge) historyLoadedRef.current = false;
 
       try {
-        if (!merge) setLoading(true);
+        if (!merge) {
+          setIsFetching(true);
+          // Full loading state only when there is nothing to render yet;
+          // once data exists, refetches are stale-while-revalidate
+          if (!hasDataRef.current) setLoading(true);
+        }
         setError(null);
         if (!user) {
           throw new Error("User not authenticated");
@@ -274,6 +290,7 @@ export const useBotLogs = ({
           setHasEarlierLogs(result.hasMore);
         } else {
           historyLoadedRef.current = true;
+          hasDataRef.current = true;
           earlierOffsetRef.current = queryParams.limit || 100;
           setLogs(expanded.slice(-MAX_LOG_ENTRIES));
           // Merge in any live updates that arrived while the fetch was in
@@ -323,6 +340,7 @@ export const useBotLogs = ({
       } finally {
         if (!controller.signal.aborted) {
           setLoading(false);
+          setIsFetching(false);
           setLoadingEarlier(false);
         }
       }
@@ -387,6 +405,7 @@ export const useBotLogs = ({
     setLoading(true);
     paginatedRef.current = false;
     historyLoadedRef.current = false;
+    hasDataRef.current = false;
     pendingUpdatesRef.current = [];
 
     fetchLogsRef.current(startQuery);
@@ -609,6 +628,7 @@ export const useBotLogs = ({
   return {
     logs,
     loading,
+    isFetching,
     error,
     hasMore,
     total,


### PR DESCRIPTION
Part of the dashboard realtime overhaul (PR 1 of the series; PR 0 is #314).

## Problem

Every background refetch called `setLoading(true)` in `use-bot-logs`, and the documented bot-frontend pattern early-returns on `loading` - so every custom dashboard fully unmounted into "Loading events..." and remounted on each 30s polling tick. Charts lost state and re-animated from zero: the 'AWS console refresh' feel. Even pure SSE mode flickered: the context value was an unmemoized literal, every arriving line re-parsed the whole buffer into all-new event objects, and inline `{start, end}` literals defeated `React.memo` on the dashboard loader. On mobile, tab round-trips fully remounted the dashboard.

## Changes

- **`loading` now means "nothing to render yet"** (initial load / bot switch only). New **`isFetching`** flag covers in-flight background refreshes (stale-while-revalidate). Failed initial loads still show full loading on retry. This mirrors the console's existing `loading && logs.length === 0` guard, applied at the source so all existing bot dashboards benefit without code changes.
- **Memoized `BotEventsProvider` value**; `isFetching` exposed through the context (additive to the SDK contract).
- **Per-entry parse cache (WeakMap)**: appended SSE lines no longer re-parse the whole buffer (up to 10k entries); parsed events keep identity across appends so memoized chart consumers work.
- **Stable `dateRange` identity** in bot-detail-panel and mobile-bot-detail.
- **Mobile: dashboard tab `forceMount`** so Console/Details round-trips no longer re-import the bundle, reconnect SSE, and refetch history.

## Tests

TDD throughout: new behavior-named test groups for background refresh loading semantics (5 cases), context value referential stability, isFetching passthrough, and parse-cache identity. Full frontend suite: 603 tests green. `yarn build` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard views now preserve their state when switching tabs.
  * Existing bot event data remains visible during background refreshes instead of showing a full loading state.
  * Refresh errors are suppressed when previously loaded events are available, while initial-load errors remain visible.
  * Bot events maintain stable ordering and rendering during updates.

* **Performance**
  * Reduced unnecessary dashboard and event-list updates during refreshes.

* **Tests**
  * Expanded coverage for loading states, refresh behavior, error handling, event sorting, and state preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->