### PR TITLE
fix: log pipeline hygiene for live streaming

### DIFF
--- a/api/src/logs/__tests__/logs.service.spec.ts
+++ b/api/src/logs/__tests__/logs.service.spec.ts
@@ -191,7 +191,7 @@ describe("LogsService", () => {
       expect(result.data!.entries[2].content).toContain("line-7");
     });
 
-    it("should return all metrics ignoring limit when type=metrics", async () => {
+    it("should return the newest `limit` metrics and report hasMore when type=metrics", async () => {
       const lines = [
         '{"level":"info","msg":"noise"}',
         '{"_metric":true,"name":"m1","value":1}',
@@ -202,7 +202,7 @@ describe("LogsService", () => {
         '{"_metric":true,"name":"m4","value":4}',
       ].join("\n");
 
-      mockMinioClient.getObject.mockResolvedValue(stringStream(lines));
+      mockMinioClient.getObject.mockImplementation(() => stringStream(lines));
 
       const result = await service.getLogs("bot-1", {
         date: "20260401",
@@ -212,8 +212,13 @@ describe("LogsService", () => {
       });
 
       expect(result.success).toBe(true);
-      // All 4 metrics returned despite limit=2
-      expect(result.data!.entries).toHaveLength(4);
+      // Default sort is desc: newest 2 of the 4 metrics, with hasMore
+      // signalling the older ones are reachable via offset
+      expect(result.data!.entries.map((e) => e.content)).toEqual([
+        '{"_metric":true,"name":"m4","value":4}',
+        '{"_metric":true,"name":"m3","value":3}',
+      ]);
+      expect(result.data!.hasMore).toBe(true);
     });
 
     it("should combine offset and type=metrics filtering", async () => {
@@ -753,7 +758,7 @@ describe("LogsService", () => {
       expect(mockMinioClient.getObject).toHaveBeenCalled();
     });
 
-    it("should return all metrics without limit when type=metrics", async () => {
+    it("should respect limit for metrics scattered through a large file", async () => {
       // 200 lines: 150 noise + 50 metrics scattered throughout
       const lines = Array.from({ length: 200 }, (_, i) =>
         i % 4 === 0
@@ -761,7 +766,7 @@ describe("LogsService", () => {
           : `{"level":"info","message":"noise-${i}"}`,
       ).join("\n") + "\n";
 
-      mockMinioClient.getObject.mockResolvedValue(stringStream(lines));
+      mockMinioClient.getObject.mockImplementation(() => stringStream(lines));
 
       const result = await service.getLogs("bot-1", {
         date: "20260401",
@@ -771,8 +776,10 @@ describe("LogsService", () => {
       });
 
       expect(result.success).toBe(true);
-      // Should return all 50 metrics, not just 10
-      expect(result.data!.entries.length).toBe(50);
+      // Newest 10 of the 50 metrics; the rest are reachable via offset
+      expect(result.data!.entries.length).toBe(10);
+      expect(result.data!.entries[0].content).toContain("metric-196");
+      expect(result.data!.hasMore).toBe(true);
     });
 
     it("should still respect limit for non-metrics queries", async () => {
@@ -1341,6 +1348,120 @@ describe("LogsService", () => {
       expect(result.success).toBe(true);
       expect(result.data!.entries).toEqual([]);
       expect(result.data!.hasMore).toBe(false);
+    });
+  });
+
+  describe("getLogs - metrics pagination", () => {
+    const metricLine = (n: number) =>
+      `{"_metric":true,"name":"m${n}","value":${n}}`;
+
+    it("should page backwards through metric history with offset (desc)", async () => {
+      const lines = Array.from({ length: 5 }, (_, i) => metricLine(i + 1)).join(
+        "\n",
+      );
+      mockMinioClient.getObject.mockImplementation(() => stringStream(lines));
+
+      const page1 = await service.getLogs("bot-1", {
+        date: "20260401",
+        limit: 2,
+        offset: 0,
+        type: "metrics",
+      });
+      expect(page1.success).toBe(true);
+      expect(page1.data!.entries.map((e) => e.content)).toEqual([
+        metricLine(5),
+        metricLine(4),
+      ]);
+      expect(page1.data!.hasMore).toBe(true);
+
+      const page2 = await service.getLogs("bot-1", {
+        date: "20260401",
+        limit: 2,
+        offset: 2,
+        type: "metrics",
+      });
+      expect(page2.data!.entries.map((e) => e.content)).toEqual([
+        metricLine(3),
+        metricLine(2),
+      ]);
+      expect(page2.data!.hasMore).toBe(true);
+
+      const page3 = await service.getLogs("bot-1", {
+        date: "20260401",
+        limit: 2,
+        offset: 4,
+        type: "metrics",
+      });
+      expect(page3.data!.entries.map((e) => e.content)).toEqual([
+        metricLine(1),
+      ]);
+      expect(page3.data!.hasMore).toBe(false);
+    });
+
+    it("should report hasMore false when all metrics fit in one page", async () => {
+      const lines = [metricLine(1), metricLine(2), metricLine(3)].join("\n");
+      mockMinioClient.getObject.mockImplementation(() => stringStream(lines));
+
+      const result = await service.getLogs("bot-1", {
+        date: "20260401",
+        limit: 10,
+        offset: 0,
+        type: "metrics",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data!.entries).toHaveLength(3);
+      expect(result.data!.hasMore).toBe(false);
+    });
+
+    it("should respect limit and report hasMore for asc metric queries", async () => {
+      const lines = Array.from({ length: 4 }, (_, i) => metricLine(i + 1)).join(
+        "\n",
+      );
+      mockMinioClient.getObject.mockImplementation(() => stringStream(lines));
+
+      const result = await service.getLogs("bot-1", {
+        date: "20260401",
+        limit: 2,
+        offset: 0,
+        type: "metrics",
+        sort: "asc",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data!.entries.map((e) => e.content)).toEqual([
+        metricLine(1),
+        metricLine(2),
+      ]);
+      expect(result.data!.hasMore).toBe(true);
+    });
+
+    it("should paginate metrics across a date range", async () => {
+      const day1 = ['{"level":"info","message":"noise"}', metricLine(1)].join(
+        "\n",
+      );
+      const day2 = [metricLine(2), metricLine(3)].join("\n");
+      mockMinioClient.getObject.mockImplementation(
+        (_bucket: string, path: string) =>
+          Promise.resolve(
+            stringStream(path.includes("20260401") ? day1 : day2),
+          ),
+      );
+
+      const result = await service.getLogs("bot-1", {
+        dateRange: "20260401-20260402",
+        limit: 2,
+        offset: 0,
+        type: "metrics",
+      });
+
+      expect(result.success).toBe(true);
+      // Newest-first across days: day2's metrics come first
+      expect(result.data!.entries.map((e) => e.content)).toEqual([
+        metricLine(3),
+        metricLine(2),
+      ]);
+      expect(result.data!.hasMore).toBe(true);
     });
   });
 

--- a/api/src/logs/logs.service.ts
+++ b/api/src/logs/logs.service.ts
@@ -86,6 +86,11 @@ export class LogsService {
 
       const sortOrder = query.sort || "desc";
 
+      // For metrics we know the exact filtered count before truncation, so
+      // hasMore can be computed precisely instead of the >=limit heuristic
+      // used for raw logs (whose streams stop early at the limit).
+      let metricsHasMore = false;
+
       if (dates.length === 1 && query.type !== "metrics" && !query.startTime) {
         // Single date, non-metrics: tail for latest entries (returns newest-first)
         const logPath = `logs/${botId}/${dates[0]}.log`;
@@ -94,7 +99,7 @@ export class LogsService {
       } else {
         // Multi-date or metrics: stream from start (returns oldest-first)
         const skipped = { count: 0 };
-        if (sortOrder === "desc" && query.type !== "metrics") {
+        if (sortOrder === "desc") {
           // For desc on the stream path, read entries in chronological order,
           // reverse to newest-first, then apply offset and limit.
           // Cap total reads to prevent memory exhaustion on huge ranges.
@@ -106,19 +111,28 @@ export class LogsService {
             if (entries.length >= maxRead) break;
           }
           entries.reverse();
+          metricsHasMore = entries.length > query.offset + query.limit;
           entries.splice(0, query.offset);
           if (entries.length > query.limit) entries.length = query.limit;
         } else {
           for (const date of dates) {
             const logPath = `logs/${botId}/${date}.log`;
             await this.streamFilteredLogs(logPath, date, query, entries, skipped);
+            // Metric streams don't stop at the limit mid-file (the whole day
+            // is read), so one extra entry past the limit is the hasMore
+            // sentinel; raw-log streams stop exactly at the limit.
+            if (entries.length > query.limit) break;
             if (query.type !== "metrics" && entries.length >= query.limit) break;
           }
-          if (sortOrder === "desc") entries.reverse();
+          metricsHasMore = entries.length > query.limit;
+          if (entries.length > query.limit) entries.length = query.limit;
         }
       }
 
-      const hasMore = query.type !== "metrics" && entries.length >= query.limit;
+      const hasMore =
+        query.type === "metrics"
+          ? metricsHasMore
+          : entries.length >= query.limit;
       return Ok({ entries, hasMore });
     } catch (error: unknown) {
       this.logger.error({ err: error }, "Error fetching logs");

--- a/runtime/internal/daemon/logs_syncer.go
+++ b/runtime/internal/daemon/logs_syncer.go
@@ -187,22 +187,24 @@ func adjustChunkToNewlineBoundary(file *os.File, buf []byte, n int, offset int64
 	return chunkSize, nil
 }
 
-// uploadChunk uploads a log chunk to MinIO and publishes it to NATS.
+// uploadChunk publishes a log chunk to NATS and uploads it to MinIO.
+// NATS goes first: live SSE viewers care about latency, while the MinIO
+// append is O(day-file-size) and can fail transiently — neither should
+// delay or suppress the live stream. An upload failure keeps lastOffset in
+// place so the chunk is re-uploaded on the next Sync (durability never drops
+// data); that retry also re-publishes to NATS, which is accepted
+// at-least-once behavior for the live stream.
 func (l *LogsSyncer) uploadChunk(ctx context.Context, content string) error {
-	syncCtx, cancel := context.WithTimeout(ctx, l.uploadTimeout)
-	defer cancel()
-
-	if err := l.logUploader.AppendBotLogs(syncCtx, l.botID, content); err != nil {
-		return err
-	}
-
 	if l.natsPublisher != nil {
 		if err := l.natsPublisher.Publish(l.botID, content); err != nil {
 			l.logger.Info("Failed to publish logs to NATS", "error", err.Error())
 		}
 	}
 
-	return nil
+	syncCtx, cancel := context.WithTimeout(ctx, l.uploadTimeout)
+	defer cancel()
+
+	return l.logUploader.AppendBotLogs(syncCtx, l.botID, content)
 }
 
 // Close cleans up all owned resources (uploader and publisher).

--- a/runtime/internal/daemon/logs_syncer_test.go
+++ b/runtime/internal/daemon/logs_syncer_test.go
@@ -355,6 +355,91 @@ func TestLogsSyncer_Sync_WithNATSPublisher(t *testing.T) {
 	assert.Equal(t, content, mockPublisher.PublishCalls[0].Content)
 }
 
+// orderRecordingUploader and orderRecordingPublisher share a slice to record
+// the relative order of publish vs upload calls within a chunk.
+type orderRecordingUploader struct {
+	order *[]string
+	err   error
+}
+
+func (o *orderRecordingUploader) AppendBotLogs(ctx context.Context, botID, content string) error {
+	*o.order = append(*o.order, "upload")
+	return o.err
+}
+func (o *orderRecordingUploader) StoreFinalLogs(ctx context.Context, botID, content string) error {
+	return nil
+}
+func (o *orderRecordingUploader) Close() error { return nil }
+
+type orderRecordingPublisher struct {
+	order *[]string
+}
+
+func (o *orderRecordingPublisher) Publish(botID string, content string) error {
+	*o.order = append(*o.order, "publish")
+	return nil
+}
+func (o *orderRecordingPublisher) Close() error { return nil }
+
+func TestLogsSyncer_Sync_PublishesToNATSBeforeUpload(t *testing.T) {
+	tmpDir := t.TempDir()
+	logFile := filepath.Join(tmpDir, "bot.log")
+	require.NoError(t, os.WriteFile(logFile, []byte("line 1\n"), 0644))
+
+	var order []string
+	uploader := &orderRecordingUploader{order: &order}
+	publisher := &orderRecordingPublisher{order: &order}
+	syncer := NewLogsSyncer("bot-1", tmpDir, uploader, publisher, &util.DefaultLogger{})
+
+	synced := syncer.Sync(context.Background())
+
+	assert.True(t, synced)
+	assert.Equal(t, []string{"publish", "upload"}, order,
+		"NATS publish (liveness) must happen before MinIO upload (durability)")
+}
+
+func TestLogsSyncer_Sync_PublishesToNATSWhenUploadFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	logFile := filepath.Join(tmpDir, "bot.log")
+
+	content := "important live line\n"
+	require.NoError(t, os.WriteFile(logFile, []byte(content), 0644))
+
+	mockUploader := &MockMinIOLogger{AppendError: assert.AnError}
+	mockPublisher := &MockLogPublisher{}
+	syncer := NewLogsSyncer("bot-1", tmpDir, mockUploader, mockPublisher, &util.DefaultLogger{})
+
+	synced := syncer.Sync(context.Background())
+
+	assert.False(t, synced, "sync reports failure so durability is retried")
+	require.Len(t, mockPublisher.PublishCalls, 1,
+		"chunk must still reach live viewers when MinIO upload fails")
+	assert.Equal(t, content, mockPublisher.PublishCalls[0].Content)
+}
+
+func TestLogsSyncer_Sync_RetriesUploadOfSameChunkAfterFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	logFile := filepath.Join(tmpDir, "bot.log")
+
+	content := "line to retry\n"
+	require.NoError(t, os.WriteFile(logFile, []byte(content), 0644))
+
+	mockUploader := &MockMinIOLogger{AppendError: assert.AnError}
+	mockPublisher := &MockLogPublisher{}
+	syncer := NewLogsSyncer("bot-1", tmpDir, mockUploader, mockPublisher, &util.DefaultLogger{})
+
+	// First sync: upload fails, offset must not advance
+	assert.False(t, syncer.Sync(context.Background()))
+	require.Len(t, mockUploader.AppendCalls, 1)
+
+	// Upload recovers: the same chunk is uploaded again so durability never
+	// drops data (the re-publish to NATS is accepted at-least-once behavior)
+	mockUploader.AppendError = nil
+	assert.True(t, syncer.Sync(context.Background()))
+	require.Len(t, mockUploader.AppendCalls, 2)
+	assert.Equal(t, content, mockUploader.AppendCalls[1].Content)
+}
+
 func TestLogsSyncer_Sync_NATSPublishError(t *testing.T) {
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "bot.log")

--- a/runtime/internal/daemon/watcher.go
+++ b/runtime/internal/daemon/watcher.go
@@ -13,16 +13,21 @@ import (
 // FileWatcher watches files and directories for changes using fsnotify.
 // When changes are detected, it triggers a callback.
 type FileWatcher struct {
-	watcher    *fsnotify.Watcher
-	logger     util.Logger
-	onChange   func()
-	debounce   time.Duration
-	mu         sync.Mutex
-	lastEvent  time.Time
-	stopCh     chan struct{}
-	stoppedCh  chan struct{}
-	started    bool
-	startedMu  sync.Mutex
+	watcher   *fsnotify.Watcher
+	logger    util.Logger
+	onChange  func()
+	debounce  time.Duration
+	mu        sync.Mutex
+	lastEvent time.Time
+	// trailing is the pending trailing-edge debounce timer (nil when none).
+	// stopped gates both new timers and in-flight timer callbacks after Stop.
+	// Both are guarded by mu.
+	trailing  *time.Timer
+	stopped   bool
+	stopCh    chan struct{}
+	stoppedCh chan struct{}
+	started   bool
+	startedMu sync.Mutex
 }
 
 // FileWatcherConfig configures the file watcher.
@@ -110,6 +115,10 @@ func (fw *FileWatcher) Start() {
 }
 
 // handleEvent processes a file system event with debouncing.
+// The first event of a burst fires immediately (leading edge). Events inside
+// the debounce window schedule a single trailing trigger instead of being
+// dropped — otherwise the final write of a burst would sit unsynced until the
+// slow periodic backup ticker picked it up.
 func (fw *FileWatcher) handleEvent(event fsnotify.Event) {
 	// Only trigger on write/create events (not chmod, rename, etc.)
 	if event.Op&(fsnotify.Write|fsnotify.Create) == 0 {
@@ -117,10 +126,20 @@ func (fw *FileWatcher) handleEvent(event fsnotify.Event) {
 	}
 
 	fw.mu.Lock()
+	if fw.stopped {
+		fw.mu.Unlock()
+		return
+	}
 	now := time.Now()
-	shouldTrigger := now.Sub(fw.lastEvent) >= fw.debounce
+	elapsed := now.Sub(fw.lastEvent)
+	shouldTrigger := elapsed >= fw.debounce
 	if shouldTrigger {
 		fw.lastEvent = now
+	} else if fw.trailing == nil {
+		// Inside the window with no trailing trigger pending: schedule one for
+		// the end of the window so the burst's tail is synced. Later in-window
+		// events coalesce into this same timer.
+		fw.trailing = time.AfterFunc(fw.debounce-elapsed, fw.fireTrailing)
 	}
 	fw.mu.Unlock()
 
@@ -130,11 +149,41 @@ func (fw *FileWatcher) handleEvent(event fsnotify.Event) {
 	}
 }
 
+// fireTrailing runs on the trailing debounce timer's goroutine and triggers
+// the sync callback for the tail of an event burst.
+func (fw *FileWatcher) fireTrailing() {
+	fw.mu.Lock()
+	fw.trailing = nil
+	if fw.stopped {
+		fw.mu.Unlock()
+		return
+	}
+	// Counts as an event for debouncing so a write arriving right after the
+	// trailing fire doesn't immediately fire again.
+	fw.lastEvent = time.Now()
+	fw.mu.Unlock()
+
+	if fw.onChange != nil {
+		fw.logger.Info("Trailing debounce trigger")
+		fw.onChange()
+	}
+}
+
 // Stop stops the file watcher.
 func (fw *FileWatcher) Stop() error {
 	fw.startedMu.Lock()
 	wasStarted := fw.started
 	fw.startedMu.Unlock()
+
+	// Cancel any pending trailing trigger; the stopped flag also covers a
+	// timer callback that already fired and is waiting on the mutex.
+	fw.mu.Lock()
+	fw.stopped = true
+	if fw.trailing != nil {
+		fw.trailing.Stop()
+		fw.trailing = nil
+	}
+	fw.mu.Unlock()
 
 	close(fw.stopCh)
 

--- a/runtime/internal/daemon/watcher_test.go
+++ b/runtime/internal/daemon/watcher_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -185,6 +186,77 @@ func TestFileWatcher_Debounce(t *testing.T) {
 	// Should have at most 2 calls (first write triggers, then one more after debounce)
 	count := atomic.LoadInt32(&callCount)
 	assert.LessOrEqual(t, count, int32(2), "rapid writes should be debounced")
+}
+
+func TestFileWatcher_TrailingEdgeDebounce(t *testing.T) {
+	writeEvent := fsnotify.Event{Name: "bot.log", Op: fsnotify.Write}
+
+	t.Run("burst tail triggers a trailing sync after the window", func(t *testing.T) {
+		var callCount int32
+		fw, err := NewFileWatcher(FileWatcherConfig{
+			Logger:   &util.DefaultLogger{},
+			OnChange: func() { atomic.AddInt32(&callCount, 1) },
+			Debounce: 100 * time.Millisecond,
+		})
+		require.NoError(t, err)
+		defer fw.Stop()
+
+		// Leading edge fires immediately
+		fw.handleEvent(writeEvent)
+		require.Equal(t, int32(1), atomic.LoadInt32(&callCount))
+
+		// Burst inside the debounce window: throttled, but the tail must not
+		// be dropped - a trailing trigger has to fire once the burst settles
+		fw.handleEvent(writeEvent)
+		fw.handleEvent(writeEvent)
+		require.Equal(t, int32(1), atomic.LoadInt32(&callCount),
+			"in-window events must be throttled, not fired immediately")
+
+		assert.Eventually(t, func() bool {
+			return atomic.LoadInt32(&callCount) >= 2
+		}, time.Second, 10*time.Millisecond,
+			"the final write of a burst must trigger a trailing sync within ~debounce")
+	})
+
+	t.Run("no trailing trigger fires after Stop", func(t *testing.T) {
+		var callCount int32
+		fw, err := NewFileWatcher(FileWatcherConfig{
+			Logger:   &util.DefaultLogger{},
+			OnChange: func() { atomic.AddInt32(&callCount, 1) },
+			Debounce: 100 * time.Millisecond,
+		})
+		require.NoError(t, err)
+
+		fw.handleEvent(writeEvent) // leading edge
+		fw.handleEvent(writeEvent) // schedules trailing trigger
+		require.NoError(t, fw.Stop())
+
+		time.Sleep(300 * time.Millisecond)
+		assert.Equal(t, int32(1), atomic.LoadInt32(&callCount),
+			"trailing trigger must not fire after the watcher is stopped")
+	})
+
+	t.Run("events after a trailing fire are debounced against it", func(t *testing.T) {
+		var callCount int32
+		fw, err := NewFileWatcher(FileWatcherConfig{
+			Logger:   &util.DefaultLogger{},
+			OnChange: func() { atomic.AddInt32(&callCount, 1) },
+			Debounce: 100 * time.Millisecond,
+		})
+		require.NoError(t, err)
+		defer fw.Stop()
+
+		fw.handleEvent(writeEvent) // leading edge -> 1
+		fw.handleEvent(writeEvent) // schedules trailing -> eventually 2
+		require.Eventually(t, func() bool {
+			return atomic.LoadInt32(&callCount) == 2
+		}, time.Second, 10*time.Millisecond)
+
+		// A lone event well past the window is a fresh leading edge
+		time.Sleep(150 * time.Millisecond)
+		fw.handleEvent(writeEvent)
+		assert.Equal(t, int32(3), atomic.LoadInt32(&callCount))
+	})
 }
 
 func TestFileWatcher_Stop(t *testing.T) {

--- a/runtime/internal/docker/container_builder.go
+++ b/runtime/internal/docker/container_builder.go
@@ -30,7 +30,13 @@ func NewContainerBuilder(imageName string) *ContainerBuilder {
 			StopSignal: "SIGTERM",
 			WorkingDir: "/tmp",
 			Labels:     make(map[string]string),
-			Env:        []string{"PYTHONDONTWRITEBYTECODE=1"}, // Prevent Python from creating __pycache__ directories
+			Env: []string{
+				"PYTHONDONTWRITEBYTECODE=1", // Prevent Python from creating __pycache__ directories
+				// Python block-buffers stdout (8KB) when it's a pipe, so metric()
+				// print() output would sit unflushed instead of reaching the log
+				// pipeline. Harmless for non-Python runtimes.
+				"PYTHONUNBUFFERED=1",
+			},
 		},
 		hostConfig: &container.HostConfig{
 			// Default to bridge mode; use WithNetwork to join a specific network

--- a/runtime/internal/docker/container_builder_test.go
+++ b/runtime/internal/docker/container_builder_test.go
@@ -23,6 +23,8 @@ func TestNewContainerBuilder(t *testing.T) {
 	assert.Equal(t, "/tmp", cfg.WorkingDir)
 	assert.NotNil(t, cfg.Labels)
 	assert.Contains(t, cfg.Env, "PYTHONDONTWRITEBYTECODE=1")
+	assert.Contains(t, cfg.Env, "PYTHONUNBUFFERED=1",
+		"python stdout must be unbuffered so metric() lines reach the log pipe immediately")
 	assert.Equal(t, container.NetworkMode("bridge"), hostCfg.NetworkMode)
 	assert.True(t, hostCfg.ReadonlyRootfs)
 	assert.Contains(t, hostCfg.CapDrop, "ALL")
@@ -92,8 +94,8 @@ func TestContainerBuilder_WithEnv(t *testing.T) {
 
 	cfg, _ := builder.Build()
 
-	// Should have default PYTHONDONTWRITEBYTECODE=1 + 3 new vars
-	assert.Len(t, cfg.Env, 4)
+	// Should have default PYTHONDONTWRITEBYTECODE=1 + PYTHONUNBUFFERED=1 + 3 new vars
+	assert.Len(t, cfg.Env, 5)
 	assert.Contains(t, cfg.Env, "KEY1=value1")
 	assert.Contains(t, cfg.Env, "KEY2=value2")
 	assert.Contains(t, cfg.Env, "KEY3=value3")

--- a/runtime/internal/k8s/podgen/pod_builder.go
+++ b/runtime/internal/k8s/podgen/pod_builder.go
@@ -63,6 +63,10 @@ func NewPodBuilder(name, namespace string) *PodBuilder {
 			{Name: "tmp", MountPath: "/tmp"},
 			{Name: "query", MountPath: "/query"},
 		},
+		// Python block-buffers stdout (8KB) when it's a pipe, so metric()
+		// print() output would sit unflushed instead of reaching the log
+		// pipeline. Set for all runtimes; harmless outside Python.
+		botEnv: []corev1.EnvVar{{Name: "PYTHONUNBUFFERED", Value: "1"}},
 		botResources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse(DefaultMemoryLimit),

--- a/runtime/internal/k8s/podgen/pod_generator_test.go
+++ b/runtime/internal/k8s/podgen/pod_generator_test.go
@@ -90,6 +90,8 @@ func TestPodGenerator_GeneratePod_RealtimeBot(t *testing.T) {
 	assert.Equal(t, "realtime", envMap["BOT_TYPE"])
 	assert.Empty(t, envMap["IS_SCHEDULED"], "realtime bots should not have IS_SCHEDULED set")
 	assert.Contains(t, envMap["BOT_CONFIG"], "BTC/USD")
+	assert.Equal(t, "1", envMap["PYTHONUNBUFFERED"],
+		"python stdout must be unbuffered so metric() lines reach the log pipe immediately")
 
 	// Check resources
 	assert.Equal(t, DefaultMemoryLimit, botContainer.Resources.Limits.Memory().String())


### PR DESCRIPTION
Four hygiene fixes in the bot log pipeline (bot stdout -> sync process -> NATS live SSE + MinIO history), each in its own commit. Chains off #314 (`fix/nats-url-bot-pods`).

## 1. Publish log chunks to NATS before the MinIO append (`runtime/internal/daemon/logs_syncer.go`)

`uploadChunk` ran the MinIO append first and only published to NATS after it succeeded. The append is O(day-file-size) on the multipart-copy path, so live viewers waited on durability; worse, when the append failed the drain loop broke before the publish ever ran, so the chunk never reached the live stream at all.

Now NATS publish (liveness) happens first, then the MinIO append (durability). Upload failures still return an error so `lastOffset` stays put and the chunk is re-uploaded on the next Sync - no data is ever dropped from history. The retry re-publishes to NATS, which is accepted at-least-once behavior for the live stream.

**Tests:** publish-before-upload ordering within a chunk; publish still happens when the upload fails; the same chunk is re-uploaded after a failure (offset preserved).

## 2. Trailing-edge debounce in the file watcher (`runtime/internal/daemon/watcher.go`)

Verified against the real code: the debounce was a pure leading-edge throttle - `now.Sub(fw.lastEvent) >= fw.debounce` dropped every event inside the window, so the final write of a burst sat unsynced until the 60s backup ticker fired.

In-window events now schedule a single trailing `time.AfterFunc` trigger for the end of the window (later in-window events coalesce into it), so a burst's tail syncs within ~debounce time. The timer is mutex-guarded and cancelled on `Stop`; a `stopped` flag also covers a timer callback already racing for the mutex, so no trigger can fire after shutdown. The trailing fire counts as an event for subsequent debouncing. `OnChange` (SyncRunner.DoSync) is documented thread-safe, so firing from the timer goroutine is fine.

**Tests (deterministic, driving `handleEvent` directly):** burst tail fires a trailing trigger after settling; no trigger after `Stop`; events after a trailing fire debounce against it. Suite passes under `-race`.

## 3. `PYTHONUNBUFFERED=1` for bot containers

Python block-buffers stdout (8KB) when it's a pipe, so the SDK's `print()`-based `metric()` lines sat in the interpreter's buffer instead of reaching the log file and the pipeline. Set at both container generation points - `runtime/internal/k8s/podgen/pod_builder.go` (bot container env; query sidecar inherits it too since it shares `botEnv`) and `runtime/internal/docker/container_builder.go` (local/prod parity, next to the existing `PYTHONDONTWRITEBYTECODE=1`). Applied for all runtimes; it's a no-op outside Python. No SDK or wrapper changes.

**Tests:** assertions added to the existing podgen and docker builder tests.

## 4. Real pagination + `hasMore` for `type=metrics` log queries (`api/src/logs/logs.service.ts`)

Surprise found while implementing: the date/dateRange metrics path did not actually truncate at the limit - it ignored `limit` entirely and returned the full metric history in one response, with `hasMore` hardcoded `false` (two tests pinned that behavior). So responses were unbounded for busy bots and the frontend's `loadMore` never fired.

Metrics now flow through the same desc capped-read path as raw logs (read chronologically, reverse, offset, limit); asc queries truncate at the limit. Because metric streams read whole day files, the filtered count is known before truncation, so `hasMore` is exact (entries beyond offset+limit) rather than the `>=limit` heuristic raw logs use. Latest mode (`lookbackDays`) already paginated metrics correctly and is unchanged, as is non-metrics behavior.

**Behavior change:** date/dateRange metric queries now return at most `limit` entries (newest-first by default) with an honest `hasMore`, matching Latest mode - clients page with `offset`. The two tests pinning the old ignore-limit behavior were rewritten to the new contract, plus a new `metrics pagination` describe (multi-page desc walk, asc limit, cross-day range, all-fits case).

## Out of scope (untouched)

SSE receive-time timestamps in `logs.controller.ts`, frontend, docs, JetStream replay.

## Verification

- `runtime`: `go build ./...` clean, `go test ./...` all green (daemon suite also run with `-race`)
- `api`: `yarn test --testPathPattern logs` - 89/89 passing; `yarn build` clean