### PR TITLE
fix: use forward slashes in bot bundle zip entries

### DIFF
--- a/cli/internal/zip.go
+++ b/cli/internal/zip.go
@@ -85,7 +85,12 @@ func CreateBotZipFromDir(sourceDir string) (string, error) {
 		if err != nil {
 			return err
 		}
-		header.Name = relPath
+		// The ZIP spec (APPNOTE 4.4.17.1) requires forward slashes as the path
+		// separator. filepath.Rel returns OS-native separators, so on Windows
+		// this produced entries like `vendor\the0\__init__.py`, which Linux
+		// extractors treat as one flat filename -- the bot's vendor/ directory
+		// never materialises and every dependency import fails at runtime.
+		header.Name = filepath.ToSlash(relPath)
 		header.Method = zip.Deflate
 
 		writer, err := zipWriter.CreateHeader(header)

--- a/cli/internal/zip_test.go
+++ b/cli/internal/zip_test.go
@@ -1,0 +1,82 @@
+package internal
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCreateBotZipUsesForwardSlashes guards the path separator used in archive
+// entry names.
+//
+// The ZIP spec (APPNOTE 4.4.17.1) requires forward slashes. filepath.Rel
+// returns OS-native separators, so on Windows this previously produced entries
+// named `vendor\the0\__init__.py`. Backslash is a legal filename character on
+// Linux, so the runtime extracted that as a single flat file, `vendor/` never
+// existed inside the bot container, and every dependency import failed at
+// runtime with ModuleNotFoundError - long after the CLI had reported a
+// successful deploy.
+//
+// Reading the archive back with a library is not enough to catch this on
+// Windows: Go's archive/zip preserves the raw name, but several tools and
+// libraries (Python's zipfile, for one) silently normalise os.sep to '/' when
+// reading, which hides the defect on the very platform that produces it. This
+// asserts on the stored name directly.
+func TestCreateBotZipUsesForwardSlashes(t *testing.T) {
+	sourceDir := t.TempDir()
+
+	nested := filepath.Join(sourceDir, "vendor", "the0", "inner")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatalf("failed to create nested dirs: %v", err)
+	}
+	files := []string{
+		filepath.Join(sourceDir, "main.py"),
+		filepath.Join(sourceDir, "vendor", "the0", "__init__.py"),
+		filepath.Join(nested, "deep.py"),
+	}
+	for _, path := range files {
+		if err := os.WriteFile(path, []byte("# test\n"), 0644); err != nil {
+			t.Fatalf("failed to write %s: %v", path, err)
+		}
+	}
+
+	zipPath, err := CreateBotZipFromDir(sourceDir)
+	if err != nil {
+		t.Fatalf("CreateBotZipFromDir failed: %v", err)
+	}
+	defer os.Remove(zipPath)
+
+	reader, err := zip.OpenReader(zipPath)
+	if err != nil {
+		t.Fatalf("failed to open zip: %v", err)
+	}
+	defer reader.Close()
+
+	found := map[string]bool{}
+	for _, file := range reader.File {
+		if strings.Contains(file.Name, `\`) {
+			t.Errorf("zip entry %q contains a backslash; entry names must use forward slashes", file.Name)
+		}
+		found[file.Name] = true
+	}
+
+	for _, want := range []string{
+		"main.py",
+		"vendor/the0/__init__.py",
+		"vendor/the0/inner/deep.py",
+	} {
+		if !found[want] {
+			t.Errorf("expected zip entry %q, got entries: %v", want, keys(found))
+		}
+	}
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## Description

On Windows, `CreateBotZipFromDir` writes archive entries using OS-native path
separators, so every bundle produced by `the0 custom-bot deploy` contains
entries like `vendor\the0\__init__.py`. The ZIP spec ([APPNOTE 4.4.17.1](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT))
requires forward slashes.

Backslash is a legal filename character on Linux, so the runtime's extractor
writes each nested entry as a single flat file. `/bot/vendor` never exists, the
`if os.path.exists(f"{work_dir}/vendor")` check in `wrappers/python_bot.py`
never fires, and the vendor directory is never added to `sys.path`. Every
scheduled run then fails on the bot's first import.

The symptom is confusing because nothing reports an error until runtime:

```
IMPORT_ERROR: Import failed: No module named 'the0'
  File "/bot/main.py", line 23, in <module>
    from the0 import parse, success, error, metric, state
ModuleNotFoundError: No module named 'the0'
```

`custom-bot deploy` prints "Deployment successful", `bot deploy` succeeds, and
the scheduler just reports `Container exited with code 1` once a minute.

This affects **every Windows user deploying a bot with dependencies** — the
`python-portfolio-tracker` example reproduces it as-is.

### Reproducing

Deploy any bot with a `requirements.txt` from a Windows host, then inspect the
uploaded bundle:

```
$ python -c "
import struct
d=open('bundle.zip','rb').read()
o=d.find(b'PK\x03\x04'); n=struct.unpack('<H',d[o+26:o+28])[0]
print(d[o+30:o+30+n])"
b'vendor\\structlog\\__init__.py'
```

Worth noting for anyone verifying this: **Python's `zipfile` hides the bug on
Windows.** `ZipInfo` rewrites `os.sep` to `/` when reading, so `namelist()`
reports clean forward slashes that are not in the file. Info-ZIP `unzip` on
Windows shows it differently again, as `vendor_structlog___init__.py`, because
backslash is an illegal filename character there. The raw local-file-header
bytes above are the reliable check.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

None open that I could find.

## Changes Made

- `cli/internal/zip.go`: `header.Name = filepath.ToSlash(relPath)` — no-op on
  Linux and macOS, corrects the separator on Windows.
- `cli/internal/zip_test.go`: new regression test asserting stored entry names
  contain no backslashes and that nested paths round-trip as forward-slash
  entries.

## Component(s) Affected

- [x] CLI (Command-line tool)

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Manual testing performed

### Test Commands Run

```bash
cd cli
go test ./internal/ -run TestCreateBotZipUsesForwardSlashes -v
go vet ./internal/
go test ./internal/
```

### Test Results

The new test fails on `dev` and passes with the fix. Reverting just the
one-line change, on Windows:

```
--- FAIL: TestCreateBotZipUsesForwardSlashes (0.02s)
    zip_test.go:60: zip entry "vendor\\the0\\__init__.py" contains a backslash; entry names must use forward slashes
    zip_test.go:60: zip entry "vendor\\the0\\inner\\deep.py" contains a backslash; entry names must use forward slashes
```

With the fix:

```
=== RUN   TestCreateBotZipUsesForwardSlashes
--- PASS: TestCreateBotZipUsesForwardSlashes (0.05s)
ok      the0/internal
```

`go vet ./internal/` is clean.

Full-suite note: `go test ./internal/` has 6 pre-existing failures on this
Windows machine (`TestHaskellBuilder_FindBinary`, `TestHaskellBuilder_FindAllBinaries`,
and four `*BuildSecrets*` tests). I verified these fail identically on a clean
`dev` checkout with my changes stashed, so they are unrelated to this PR.

End-to-end verification against a local `the0 local` stack: with the fix, the
`python-portfolio-tracker` example goes from failing every scheduled run with
`ModuleNotFoundError` to `exit_code: 0` and emitting metrics normally.

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (none needed)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally with my changes (see pre-existing failures above)
- [x] I have checked the build passes (`go build`)
- [ ] I have updated CHANGELOG.md — happy to add an entry if you'd like one

## AI Assistance

- [x] AI tools were used in development
- Tools used: Claude Code

## Additional Notes

Two adjacent things I ran into standing up a local stack, not fixed here since
you asked to keep PRs focused. Happy to open issues or follow-up PRs:

1. **`gc` crash-loops on a fresh `docker compose` stack.** The API creates only
   the `custom-bots` bucket at startup, but `gc` requires `bot-logs` and
   `bot-state` and exits when they are missing. Nothing in the compose files
   appears to create them, so `gc` restarts continuously until they are made by
   hand.
2. **Bot frontends can't build without a GitHub token.**
   `@alexanderwanyoike/the0-react` is published to GitHub Packages, which
   requires authentication even for public packages, so `custom-bot deploy`
   fails at the frontend build step with `npm error 401 Unauthorized` unless the
   user has a PAT in `.npmrc`. Worth a note in the example bots' README.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ZIP archives now use forward-slash paths consistently, improving compatibility when created on Windows and extracted on Linux or other platforms.

* **Tests**
  * Added coverage verifying nested archive entries are correctly formatted and preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->