### PR TITLE
fix(examples): portfolio-tracker reported a constant value

### DIFF
--- a/example-bots/python-portfolio-tracker/README.md
+++ b/example-bots/python-portfolio-tracker/README.md
@@ -8,16 +8,22 @@ A scheduled bot example that demonstrates:
 ## What It Does
 
 On each scheduled run, this bot:
-1. Simulates portfolio value changes based on configurable volatility
-2. Randomly executes mock trades
-3. Emits metrics for the custom dashboard to visualize
+1. Walks each price on from where it closed on the previous run
+2. Marks its held quantities at the new prices
+3. Randomly executes mock trades, which move value between cash and holdings
+4. Emits metrics for the custom dashboard to visualize
+
+`main.py` (the SDK version) persists holdings, prices and cash in bot state, so
+the portfolio drifts over time and trades carry forward. `main_raw.py` has no
+state, so it re-marks the same opening allocation each run — its value varies
+with volatility but does not accumulate.
 
 ## Metrics Emitted
 
 | Metric | Description |
 |--------|-------------|
-| `portfolio_value` | Total portfolio value with change percentage |
-| `position` | Individual position details (symbol, quantity, value) |
+| `portfolio_value` | Total value, change since inception, change since last run, cash |
+| `position` | Individual position details (symbol, quantity, price, value) |
 | `trade` | Simulated trade execution details |
 
 ## Configuration
@@ -52,7 +58,7 @@ the0 custom-bot deploy
 ## Example Output
 
 ```json
-{"event": "portfolio_snapshot", "_metric": "portfolio_value", "value": 10250.50, "change_pct": 2.5}
-{"event": "position_update", "_metric": "position", "symbol": "BTC", "quantity": 0.15, "value": 6750.00}
-{"event": "trade_executed", "_metric": "trade", "symbol": "ETH", "side": "buy", "quantity": 1.5, "price": 2400.00}
+{"_metric": "portfolio_value", "value": 10243.31, "change_pct": 2.43, "change_since_last_pct": 0.7, "cash": 4.79}
+{"_metric": "position", "symbol": "BTC", "quantity": 0.073486, "price": 47137.99, "value": 3463.92}
+{"_metric": "trade", "symbol": "ETH", "side": "buy", "quantity": 0.0562, "price": 2402.1, "total": 135.0}
 ```

--- a/example-bots/python-portfolio-tracker/bot-config.yaml
+++ b/example-bots/python-portfolio-tracker/bot-config.yaml
@@ -3,7 +3,7 @@
 
 name: portfolio-tracker
 description: "Simulates portfolio tracking with value history and trade execution"
-version: 1.5.3
+version: 1.5.4
 author: "the0"
 type: scheduled
 runtime: python3.11

--- a/example-bots/python-portfolio-tracker/config.json
+++ b/example-bots/python-portfolio-tracker/config.json
@@ -1,7 +1,7 @@
 {
   "name": "my-portfolio-tracker",
   "type": "scheduled/portfolio-tracker",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "schedule": "* * * * *",
   "symbols": ["BTC", "ETH", "SOL"],
   "initial_value": 10000,

--- a/example-bots/python-portfolio-tracker/main.py
+++ b/example-bots/python-portfolio-tracker/main.py
@@ -3,18 +3,27 @@ Portfolio Tracker Bot (SDK Version)
 ====================================
 A scheduled bot that simulates portfolio tracking with mock data.
 
-This is the SDK version - compare with main.py to see how the SDK
+This is the SDK version - compare with main_raw.py to see how the SDK
 simplifies configuration parsing and metric emission.
 
-Differences from main.py:
+Differences from main_raw.py:
 - Uses `the0.parse()` instead of function signature for config
 - Uses `the0.metric()` instead of structlog with _metric field
 - Uses Python's logging module for structured logging
 - Uses `the0.success()` for result output
 
 State Usage:
-- Persists portfolio_history between runs for trend analysis
-- Tracks total_trades count across executions
+- `holdings`   quantity held per symbol, carried between runs
+- `prices`     last price per symbol, so each run walks on from the last
+- `cash`       proceeds from simulated sells, spent by simulated buys
+- `portfolio_history` value per run, for trend analysis
+- `total_trades`      trade count across executions
+
+Holdings and prices must persist for the value to mean anything. An earlier
+version recomputed quantity from the current price on every run
+(`quantity = allocation / price`, then `value = quantity * price`), which
+cancels out to the starting allocation no matter what the price does - the
+portfolio reported exactly its initial value forever.
 """
 
 import random
@@ -29,6 +38,15 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+BASE_PRICES = {
+    "BTC": 45000,
+    "ETH": 2400,
+    "SOL": 120,
+    "AVAX": 35,
+    "LINK": 15,
+}
+DEFAULT_BASE_PRICE = 100
+
 
 def main(bot_id: str = None, config: dict = None):
     """Bot entry point using the0 SDK."""
@@ -42,117 +60,145 @@ def main(bot_id: str = None, config: dict = None):
     volatility = config.get("volatility", 0.02)
     symbols = config.get("symbols", ["BTC", "ETH", "SOL"])
 
-    # Load persistent state - portfolio history and trade count
+    # Load persistent state
+    holdings = state.get("holdings", {})
+    previous_prices = state.get("prices", {})
+    cash = float(state.get("cash", 0.0))
     portfolio_history = state.get("portfolio_history", [])
     total_trades = state.get("total_trades", 0)
 
     logger.info(f"Bot {bot_id} started with symbols: {symbols}")
     logger.info(f"Loaded {len(portfolio_history)} historical values, {total_trades} total trades")
 
-    # Simulate portfolio state
-    portfolio = simulate_portfolio(initial_value, volatility, symbols)
+    # Walk each price on from where it closed last run.
+    prices = simulate_prices(previous_prices, volatility, symbols)
+
+    if not holdings:
+        holdings = open_positions(initial_value, prices, symbols)
+        logger.info(f"Opened initial positions worth {initial_value}")
+    else:
+        # A config change can drop a symbol; liquidate it rather than lose it.
+        holdings, cash = liquidate_untracked(holdings, prices, symbols, cash)
+
+    positions = [
+        {
+            "symbol": symbol,
+            "quantity": round(holdings.get(symbol, 0.0), 6),
+            "price": prices[symbol],
+            "value": round(holdings.get(symbol, 0.0) * prices[symbol], 2),
+        }
+        for symbol in symbols
+    ]
+
+    total_value = round(cash + sum(p["value"] for p in positions), 2)
+    change_pct = round((total_value - initial_value) / initial_value * 100, 2)
+
+    previous_value = portfolio_history[-1]["value"] if portfolio_history else total_value
+    change_since_last_pct = (
+        round((total_value - previous_value) / previous_value * 100, 2)
+        if previous_value
+        else 0.0
+    )
 
     # Emit portfolio value metric
     metric("portfolio_value", {
-        "value": portfolio["total_value"],
-        "change_pct": portfolio["change_pct"],
+        "value": total_value,
+        "change_pct": change_pct,
+        "change_since_last_pct": change_since_last_pct,
+        "cash": round(cash, 2),
     })
 
     # Emit position metrics for each holding
-    for position in portfolio["positions"]:
-        metric("position", {
-            "symbol": position["symbol"],
-            "quantity": position["quantity"],
-            "value": position["value"],
-            "price": position["price"],
-        })
+    for position in positions:
+        metric("position", position)
 
-    # Randomly simulate a trade (50% chance)
+    # Randomly simulate a trade (50% chance), priced off this run's prices
+    # so a trade and the positions it moves cannot disagree.
     trade_executed = False
     if random.random() > 0.5:
-        trade = simulate_trade(symbols)
-        metric("trade", {
-            "symbol": trade["symbol"],
-            "side": trade["side"],
-            "quantity": trade["quantity"],
-            "price": trade["price"],
-            "total": trade["total"],
-        })
-        trade_executed = True
-        total_trades += 1
+        trade = simulate_trade(symbols, prices)
+        holdings, cash, filled = apply_trade(trade, holdings, cash)
+        if filled:
+            metric("trade", trade)
+            trade_executed = True
+            total_trades += 1
+        else:
+            logger.info(
+                f"Skipped {trade['side']} {trade['quantity']} {trade['symbol']}: "
+                "insufficient cash or holdings"
+            )
 
     # Update portfolio history (keep last 100 values)
     portfolio_history.append({
-        "value": portfolio["total_value"],
+        "value": total_value,
         "timestamp": datetime.now(timezone.utc).isoformat(),
     })
     if len(portfolio_history) > 100:
         portfolio_history = portfolio_history[-100:]
 
     # Save state for next run
+    state.set("holdings", holdings)
+    state.set("prices", prices)
+    state.set("cash", round(cash, 2))
     state.set("portfolio_history", portfolio_history)
     state.set("total_trades", total_trades)
 
-    logger.info(f"Bot {bot_id} completed - saved {len(portfolio_history)} history entries")
+    logger.info(
+        f"Bot {bot_id} completed - value {total_value} ({change_since_last_pct:+.2f}% "
+        f"since last run), saved {len(portfolio_history)} history entries"
+    )
 
     # Signal success with result data
-    success(f"Portfolio tracked: ${portfolio['total_value']:.2f}", {
-        "portfolio_value": portfolio["total_value"],
-        "positions_count": len(portfolio["positions"]),
+    success(f"Portfolio tracked: ${total_value:.2f}", {
+        "portfolio_value": total_value,
+        "change_pct": change_pct,
+        "cash": round(cash, 2),
+        "positions_count": len(positions),
         "history_entries": len(portfolio_history),
         "total_trades": total_trades,
         "trade_executed": trade_executed,
     })
 
 
-def simulate_portfolio(initial_value: float, volatility: float, symbols: list) -> dict:
-    """Simulate portfolio with random price movements."""
-    positions = []
-    total_value = 0
+def simulate_prices(previous_prices: dict, volatility: float, symbols: list) -> dict:
+    """Random-walk each price on from its last value.
 
-    base_prices = {
-        "BTC": 45000,
-        "ETH": 2400,
-        "SOL": 120,
-        "AVAX": 35,
-        "LINK": 15,
-    }
-
-    value_per_symbol = initial_value / len(symbols)
-
+    Starting from the previous price rather than a fixed base is what lets the
+    portfolio drift over time instead of oscillating around its opening value.
+    """
+    prices = {}
     for symbol in symbols:
-        base_price = base_prices.get(symbol, 100)
-        price_change = random.uniform(-volatility, volatility)
-        current_price = base_price * (1 + price_change)
-
-        quantity = value_per_symbol / current_price
-        position_value = quantity * current_price
-
-        positions.append({
-            "symbol": symbol,
-            "quantity": round(quantity, 6),
-            "price": round(current_price, 2),
-            "value": round(position_value, 2),
-        })
-
-        total_value += position_value
-
-    change_pct = ((total_value - initial_value) / initial_value) * 100
-
-    return {
-        "total_value": round(total_value, 2),
-        "change_pct": round(change_pct, 2),
-        "positions": positions,
-    }
+        last = previous_prices.get(symbol) or BASE_PRICES.get(symbol, DEFAULT_BASE_PRICE)
+        prices[symbol] = round(last * (1 + random.uniform(-volatility, volatility)), 2)
+    return prices
 
 
-def simulate_trade(symbols: list) -> dict:
-    """Simulate a random trade execution."""
+def open_positions(initial_value: float, prices: dict, symbols: list) -> dict:
+    """Split the opening value evenly across symbols. Quantities then persist."""
+    allocation = initial_value / len(symbols)
+    return {symbol: allocation / prices[symbol] for symbol in symbols}
+
+
+def liquidate_untracked(holdings: dict, prices: dict, symbols: list, cash: float):
+    """Sell anything no longer in the configured symbol list, into cash."""
+    kept = {}
+    for symbol, quantity in holdings.items():
+        if symbol in symbols:
+            kept[symbol] = quantity
+        else:
+            price = prices.get(symbol) or BASE_PRICES.get(symbol, DEFAULT_BASE_PRICE)
+            cash += quantity * price
+            logger.info(f"Liquidated {quantity:.6f} {symbol} - no longer tracked")
+    for symbol in symbols:
+        kept.setdefault(symbol, 0.0)
+    return kept, cash
+
+
+def simulate_trade(symbols: list, prices: dict) -> dict:
+    """Simulate a random trade execution at this run's price."""
     symbol = random.choice(symbols)
     side = random.choice(["buy", "sell"])
-
-    base_prices = {"BTC": 45000, "ETH": 2400, "SOL": 120, "AVAX": 35, "LINK": 15}
-    price = base_prices.get(symbol, 100) * random.uniform(0.99, 1.01)
+    price = prices[symbol]
 
     if symbol == "BTC":
         quantity = round(random.uniform(0.001, 0.01), 6)
@@ -165,9 +211,33 @@ def simulate_trade(symbols: list) -> dict:
         "symbol": symbol,
         "side": side,
         "quantity": quantity,
-        "price": round(price, 2),
+        "price": price,
         "total": round(quantity * price, 2),
     }
+
+
+def apply_trade(trade: dict, holdings: dict, cash: float):
+    """Move value between cash and holdings. Returns (holdings, cash, filled).
+
+    Total portfolio value is unchanged by a trade itself - only later price
+    moves change it - so an unfunded trade is skipped rather than allowed to
+    conjure value out of negative cash.
+    """
+    symbol, quantity, total = trade["symbol"], trade["quantity"], trade["total"]
+    held = holdings.get(symbol, 0.0)
+
+    if trade["side"] == "buy":
+        if cash < total:
+            return holdings, cash, False
+        holdings[symbol] = held + quantity
+        cash -= total
+    else:
+        if held < quantity:
+            return holdings, cash, False
+        holdings[symbol] = held - quantity
+        cash += total
+
+    return holdings, cash, True
 
 
 if __name__ == "__main__":

--- a/example-bots/python-portfolio-tracker/main_raw.py
+++ b/example-bots/python-portfolio-tracker/main_raw.py
@@ -126,7 +126,12 @@ def simulate_portfolio(initial_value: float, volatility: float, symbols: list) -
         price_change = random.uniform(-volatility, volatility)
         current_price = base_price * (1 + price_change)
 
-        quantity = value_per_symbol / current_price
+        # Size the position at the base price and mark it at the current one.
+        # Deriving quantity from current_price instead would cancel the price
+        # movement straight back out - quantity * current_price collapses to
+        # value_per_symbol - so the portfolio would report exactly
+        # initial_value on every run no matter what volatility was configured.
+        quantity = value_per_symbol / base_price
         position_value = quantity * current_price
 
         positions.append({


### PR DESCRIPTION
## Description

The `python-portfolio-tracker` example reports the same portfolio value forever.
`simulate_portfolio` derives quantity from the current price and then multiplies
it straight back out:

```python
quantity       = value_per_symbol / current_price
position_value = quantity * current_price       # == value_per_symbol, always
```

The randomised price cancels itself out, so `total_value` always equals
`initial_value` and `change_pct` is always `0.00`, whatever `volatility` is set
to. Running it on a `* * * * *` schedule for ten minutes:

```
{"_metric": "portfolio_value", "value": 10000.0, "change_pct": 0.0, ...}
{"_metric": "portfolio_value", "value": 10000.0, "change_pct": 0.0, ...}
{"_metric": "portfolio_value", "value": 10000.0, "change_pct": 0.0, ...}
```

Two related effects fall out of the same root cause:

- Prices are redrawn around a **static base** each run, so even with correct
  arithmetic the value would oscillate around the opening figure rather than
  drift.
- Simulated trades are emitted and counted in `total_trades`, but never change
  holdings or cash — the portfolio is unaffected by its own trading.

This makes the example misleading as a starting point: the dashboard's change
indicator and value-history chart are wired to numbers that cannot move.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

None open that I could find.

## Changes Made

- **`main.py` (SDK version)** — size positions once, then persist `holdings`,
  `prices` and `cash` in bot state. Prices random-walk from the previous run's
  close instead of a static base, so the portfolio drifts. Trades move value
  between cash and holdings via a new `apply_trade`, and an unfunded order is
  skipped rather than allowed to conjure value out of negative cash. A symbol
  removed from config is liquidated into cash instead of silently vanishing.
  This also makes the example actually demonstrate the SDK state API its
  docstring advertises.
- **`main_raw.py`** — no state access, so it gets the minimal correction: size
  the position at the base price, mark it at the current one. Its value varies
  with volatility but does not accumulate across runs. Commented so the
  difference from `main.py` is deliberate and visible.
- **`README.md`** — document the new fields and the state/stateless difference
  between the two entrypoints; refresh the example output, which showed values
  the bot could not actually produce.
- **`bot-config.yaml` / `config.json`** — 1.5.3 → 1.5.4. Bundles are stored per
  version, so behaviour changes need a bump to avoid colliding with an already
  uploaded 1.5.3 artifact. Happy to drop this if you version examples yourself.

### Backwards compatibility

`portfolio_value` keeps `value` and `change_pct`, and `position` / `trade` keep
every field they had, so `frontend/index.tsx` needs no change. The additions are
`change_since_last_pct` and `cash`. `query.py`'s state keys (`portfolio_history`,
`total_trades`) keep their names and shapes.

## Component(s) Affected

- [x] Documentation
- [x] Other: example bots

## Testing

### Test Coverage

- [x] Manual testing performed

### Test Commands Run

```bash
# 12 consecutive runs against a persistent fake state store, seeded
docker run --rm -v "$PWD:/bot:ro" -v "$VENDOR:/vendor:ro" -w /bot \
  -e PYTHONPATH=/vendor -e 'BOT_CONFIG={"initial_value":10000,"volatility":0.02,"symbols":["BTC","ETH","SOL"]}' \
  python:3.11-slim python /scratch/simruns.py

# main_raw.py, 10 calls to simulate_portfolio
python /scratch/test_raw.py
```

### Test Results

`main.py` — 12 runs, 12 distinct values, trades moving cash and holdings:

```
 run      value   vs last      cash  trade
   1    9999.99     0.00%      0.00
   2    9970.64    -0.29%      0.00
   3    9930.34    -0.40%      0.00  sell 0.009683 BTC @ 44575.06
   4    9917.65    -0.13%    431.62
   6    9755.21    -0.68%    431.62  buy 0.68 SOL @ 118.55
   7    9770.65     0.16%    351.01
   8    9937.03     1.70%    351.01  buy 0.0562 ETH @ 2402.1
  12    9639.81    -0.11%    216.01

distinct values across runs: 12 of 12
total_trades: 3
holdings: {'BTC': 0.064532, 'ETH': 1.441775, 'SOL': 27.993449}
drift from first to last run: -3.60%
```

One run in that sequence logged `Skipped buy 0.009343 BTC: insufficient cash or
holdings`, which is the intended guard rather than a failure.

`main_raw.py` — 10 calls, all distinct:

```
values : [10087.98, 10147.29, 9991.73, 10021.74, 9967.92, 9907.17, 10061.54, 9946.07, 9899.46, 9972.85]
distinct: 10 of 10
min/max : 9899.46 10147.29
```

Also deployed to a local `the0 local` stack on a one-minute schedule and watched
it over ~20 runs — values move, cash tracks through trades, and state survives
between executions:

```
03:01  10120.61  +0.82%   cash 259.54   sell 0.72 SOL @ 118.80
03:02  10054.28  -0.66%   cash 345.08
03:03  10195.72  +1.41%   cash 345.08   sell 0.97 SOL @ 118.67
03:04  10171.61  -0.24%   cash 460.19   buy 0.009661 BTC @ 47137.99
03:05  10243.31  +0.70%   cash   4.79
```

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests — the example bots have no test suite; verified by the
      repeated-run harness above
- [x] Any dependent changes have been merged and published
- [ ] I have updated CHANGELOG.md (if applicable)

## AI Assistance

- [x] AI tools were used in development
- Tools used: Claude Code

## Additional Notes

The `main.py` diff is larger than the one-line arithmetic bug strictly requires,
because a value that merely stops being constant still would not accumulate —
without persisted holdings and prices it just oscillates around the opening
figure. If you would rather keep the example minimal, the two-line version
applied to `main_raw.py` works identically in `main.py` and I am happy to
reduce the PR to that.

Separately: this stacks cleanly with #322, which fixes a Windows-only CLI bug
that prevented deploying this example (or any bot with dependencies) at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portfolio tracking now carries holdings, prices, cash, and trades across runs.
  * Reports include cash, current position prices, and changes since the previous run.
  * Positions are opened for new portfolios and removed when symbols are no longer tracked.
* **Bug Fixes**
  * Portfolio values now reflect simulated price movement instead of resetting to the initial allocation each run.
* **Documentation**
  * Updated usage guidance and example output to reflect stateful tracking and expanded metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->