### PR TITLE
fix(runtime): gc creates its buckets instead of crash-looping on a fresh stack

### DIFF
--- a/runtime/internal/gc/gc.go
+++ b/runtime/internal/gc/gc.go
@@ -24,6 +24,7 @@ type IncompleteUploadInfo struct {
 
 // MinIOClient abstracts the MinIO operations needed by the GC.
 type MinIOClient interface {
+	EnsureBucket(ctx context.Context, bucket string) error
 	ListObjectNames(ctx context.Context, bucket, prefix string) ([]string, error)
 	ListObjectsWithInfo(ctx context.Context, bucket, prefix string) ([]ObjectInfo, error)
 	RemoveObject(ctx context.Context, bucket, name string) error
@@ -90,6 +91,16 @@ const staleIncompleteUploadAge = 1 * time.Hour
 // orphaned bot IDs in MinIO and deletes their artifacts.
 func (gc *GarbageCollector) Run(ctx context.Context) (*RunResult, error) {
 	result := &RunResult{}
+
+	// On a fresh deployment these buckets don't exist until the first bot
+	// writes logs or state; every other MinIO consumer in the runtime creates
+	// its bucket lazily, and without this the GC crash-loops on a new stack
+	// because listing a nonexistent bucket is an error.
+	for _, bucket := range []string{gc.logsBucket, gc.stateBucket} {
+		if err := gc.minio.EnsureBucket(ctx, bucket); err != nil {
+			return nil, fmt.Errorf("failed to ensure bucket %s exists: %w", bucket, err)
+		}
+	}
 
 	// 0. Clean up stale temp files (leaked by the old fire-and-forget goroutine bug)
 	result.StaleTempFiles = gc.cleanupStaleTempFiles(ctx)

--- a/runtime/internal/gc/gc_test.go
+++ b/runtime/internal/gc/gc_test.go
@@ -30,6 +30,20 @@ type mockMinIOClient struct {
 	// If set, AbortIncompleteUpload returns this error for keys matching abortErrKey.
 	abortErr    error
 	abortErrKey string
+
+	// Tracks buckets passed to EnsureBucket.
+	ensured []string
+	// If set, EnsureBucket returns this error for the matching bucket.
+	ensureErr       error
+	ensureErrBucket string
+}
+
+func (m *mockMinIOClient) EnsureBucket(ctx context.Context, bucket string) error {
+	if m.ensureErr != nil && (m.ensureErrBucket == "" || m.ensureErrBucket == bucket) {
+		return m.ensureErr
+	}
+	m.ensured = append(m.ensured, bucket)
+	return nil
 }
 
 func (m *mockMinIOClient) ListObjectNames(ctx context.Context, bucket, prefix string) ([]string, error) {
@@ -159,6 +173,31 @@ func TestGC_DeletesOrphanedArtifacts(t *testing.T) {
 	for _, d := range minio.deleted {
 		assert.NotContains(t, d, "bot-active")
 	}
+}
+
+func TestGC_CreatesMissingBucketsBeforeSweep(t *testing.T) {
+	minio := &mockMinIOClient{}
+	store := &mockBotStore{existingIDs: map[string]bool{}}
+
+	gc := NewGarbageCollector(GarbageCollectorOptions{MinIO: minio, Store: store, LogsBucket: "bot-logs", StateBucket: "bot-state"})
+	_, err := gc.Run(context.Background())
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"bot-logs", "bot-state"}, minio.ensured)
+}
+
+func TestGC_EnsureBucketErrorFailsSweep(t *testing.T) {
+	minio := &mockMinIOClient{
+		ensureErr:       errors.New("access denied"),
+		ensureErrBucket: "bot-state",
+	}
+	store := &mockBotStore{existingIDs: map[string]bool{}}
+
+	gc := NewGarbageCollector(GarbageCollectorOptions{MinIO: minio, Store: store, LogsBucket: "bot-logs", StateBucket: "bot-state"})
+	_, err := gc.Run(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bot-state")
 }
 
 func TestGC_NoOrphans(t *testing.T) {

--- a/runtime/internal/gc/minio_adapter.go
+++ b/runtime/internal/gc/minio_adapter.go
@@ -16,6 +16,17 @@ func NewMinIOAdapter(client *minio.Client) MinIOClient {
 	return &minioAdapter{client: client}
 }
 
+func (m *minioAdapter) EnsureBucket(ctx context.Context, bucket string) error {
+	exists, err := m.client.BucketExists(ctx, bucket)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	return m.client.MakeBucket(ctx, bucket, minio.MakeBucketOptions{})
+}
+
 func (m *minioAdapter) ListObjectNames(ctx context.Context, bucket, prefix string) ([]string, error) {
 	var names []string
 	for obj := range m.client.ListObjects(ctx, bucket, minio.ListObjectsOptions{

--- a/runtime/internal/gc/minio_adapter.go
+++ b/runtime/internal/gc/minio_adapter.go
@@ -16,15 +16,35 @@ func NewMinIOAdapter(client *minio.Client) MinIOClient {
 	return &minioAdapter{client: client}
 }
 
-func (m *minioAdapter) EnsureBucket(ctx context.Context, bucket string) error {
-	exists, err := m.client.BucketExists(ctx, bucket)
+// bucketAPI is the subset of minio.Client that ensureBucket needs, split out
+// so the concurrent-creation race can be tested without a live server.
+type bucketAPI interface {
+	BucketExists(ctx context.Context, bucket string) (bool, error)
+	MakeBucket(ctx context.Context, bucket string, opts minio.MakeBucketOptions) error
+}
+
+func ensureBucket(ctx context.Context, api bucketAPI, bucket string) error {
+	exists, err := api.BucketExists(ctx, bucket)
 	if err != nil {
 		return err
 	}
 	if exists {
 		return nil
 	}
-	return m.client.MakeBucket(ctx, bucket, minio.MakeBucketOptions{})
+	if err := api.MakeBucket(ctx, bucket, minio.MakeBucketOptions{}); err != nil {
+		// Several services create these buckets lazily, so on a fresh stack
+		// another one can win the create between our exists check and here.
+		// The bucket existing is all we need; only fail if it still doesn't.
+		if exists, checkErr := api.BucketExists(ctx, bucket); checkErr == nil && exists {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (m *minioAdapter) EnsureBucket(ctx context.Context, bucket string) error {
+	return ensureBucket(ctx, m.client, bucket)
 }
 
 func (m *minioAdapter) ListObjectNames(ctx context.Context, bucket, prefix string) ([]string, error) {

--- a/runtime/internal/gc/minio_adapter_test.go
+++ b/runtime/internal/gc/minio_adapter_test.go
@@ -1,0 +1,72 @@
+package gc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeBucketAPI simulates a bucket that can be created by a concurrent
+// consumer between the existence check and the create call.
+type fakeBucketAPI struct {
+	exists         bool
+	makeErr        error
+	existsAfterErr bool // bucket becomes visible after MakeBucket fails
+	makeCalls      int
+}
+
+func (f *fakeBucketAPI) BucketExists(ctx context.Context, bucket string) (bool, error) {
+	return f.exists, nil
+}
+
+func (f *fakeBucketAPI) MakeBucket(ctx context.Context, bucket string, opts minio.MakeBucketOptions) error {
+	f.makeCalls++
+	if f.makeErr != nil {
+		f.exists = f.existsAfterErr
+		return f.makeErr
+	}
+	f.exists = true
+	return nil
+}
+
+func TestEnsureBucket_CreatesMissingBucket(t *testing.T) {
+	api := &fakeBucketAPI{exists: false}
+
+	require.NoError(t, ensureBucket(context.Background(), api, "bot-logs"))
+	assert.Equal(t, 1, api.makeCalls)
+	assert.True(t, api.exists)
+}
+
+func TestEnsureBucket_SkipsCreateWhenBucketExists(t *testing.T) {
+	api := &fakeBucketAPI{exists: true}
+
+	require.NoError(t, ensureBucket(context.Background(), api, "bot-logs"))
+	assert.Equal(t, 0, api.makeCalls)
+}
+
+func TestEnsureBucket_ToleratesConcurrentCreation(t *testing.T) {
+	// Another consumer creates the bucket between BucketExists and MakeBucket;
+	// the create fails but the bucket is there, which is all that matters.
+	api := &fakeBucketAPI{
+		exists:         false,
+		makeErr:        errors.New("Your previous request to create the named bucket succeeded and you already own it."),
+		existsAfterErr: true,
+	}
+
+	require.NoError(t, ensureBucket(context.Background(), api, "bot-logs"))
+}
+
+func TestEnsureBucket_ReturnsErrorWhenCreateFailsAndBucketMissing(t *testing.T) {
+	api := &fakeBucketAPI{
+		exists:  false,
+		makeErr: errors.New("access denied"),
+	}
+
+	err := ensureBucket(context.Background(), api, "bot-logs")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "access denied")
+}


### PR DESCRIPTION
## Description

On a fresh `docker compose` stack only the `custom-bots` bucket exists (the API's storage service creates it at startup). The `gc` service lists `bot-logs` and `bot-state` on its first sweep, gets a NoSuchBucket error, and exits 1; with `restart: unless-stopped` it crash-loops until the buckets are created by hand.

Every other MinIO consumer in the runtime (state store, minio-logger, query results) already creates its bucket lazily on first use. This gives gc the same behavior: ensure both buckets exist at the start of each sweep. Self-healing regardless of service start order, and it covers the k8s CronJob mode too.

Reported by @jrodriguez300 in the additional notes of #322.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `runtime/internal/gc/gc.go`: add `EnsureBucket` to the `MinIOClient` interface; `Run` ensures the logs and state buckets before sweeping
- `runtime/internal/gc/minio_adapter.go`: implement `EnsureBucket` (BucketExists then MakeBucket)
- `runtime/internal/gc/gc_test.go`: tests for bucket creation before sweep and for surfacing ensure failures

## Component(s) Affected

- [x] Runtime

## Testing

- [x] Unit tests added/updated (written first; red on dev, green with the fix)
- `go build ./...`, `go vet`, and the full `go test ./...` suite pass (17 packages)

https://claude.ai/code/session_01JN2kbt5Ui3tztGeuQJsvBz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Garbage collection now automatically creates missing logs and state storage buckets before cleanup.
  * Cleanup stops with a clear error if a required bucket cannot be checked or created.
  * Bucket creation handles concurrent creation safely without failing when another process creates the bucket first.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->