### PR TITLE
chore: move SDKs to npm as the0-node and the0-react

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,7 @@ example-bots/**/main.js
 # Example bots - lock files and misc
 example-bots/*/frontend/package-lock.json
 example-bots/*/frontend/yarn.lock
-# NOTE: .npmrc tracked on purpose — points @alexanderwanyoike scope to GitHub Packages (no secrets)
-# example-bots/*/frontend/.npmrc
+example-bots/*/frontend/.npmrc
 example-bots/*/*.lock
 example-bots/*/package-lock.json
 

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Build trading bots in any of these languages with official SDK support:
 | Language | SDK | Documentation | Package Registry |
 |----------|-----|---------------|------------------|
 | **Python** | [sdk/python](sdk/python) | [Quick Start](docs/custom-bot-development/python-quick-start.md) | [PyPI](https://pypi.org/project/the0-sdk/) |
-| **TypeScript/Node.js** | [sdk/nodejs](sdk/nodejs) | [Quick Start](docs/custom-bot-development/nodejs-quick-start.md) | [npm](https://www.npmjs.com/package/@alexanderwanyoike/the0-node) |
+| **TypeScript/Node.js** | [sdk/nodejs](sdk/nodejs) | [Quick Start](docs/custom-bot-development/nodejs-quick-start.md) | [npm](https://www.npmjs.com/package/the0-node) |
 | **Rust** | [sdk/rust](sdk/rust) | [Quick Start](docs/custom-bot-development/rust-quick-start.md) | [crates.io](https://crates.io/crates/the0-sdk) |
 | **C++** | [sdk/cpp](sdk/cpp) | [Quick Start](docs/custom-bot-development/cpp-quick-start.md) | Header-only (FetchContent) |
 | **C#** | [sdk/dotnet](sdk/dotnet) | [Quick Start](docs/custom-bot-development/csharp-quick-start.md) | [NuGet](https://www.nuget.org/packages/The0.Sdk) |
@@ -346,7 +346,7 @@ Build React dashboards tailored to your trading strategies using the React SDK:
 
 | SDK | Documentation | Package |
 |-----|---------------|---------|
-| [sdk/react](sdk/react) | [Custom Frontends](docs/custom-bot-development/custom-frontends.md) | [@alexanderwanyoike/the0-react](https://www.npmjs.com/package/@alexanderwanyoike/the0-react) |
+| [sdk/react](sdk/react) | [Custom Frontends](docs/custom-bot-development/custom-frontends.md) | [the0-react](https://www.npmjs.com/package/the0-react) |
 
 ### Framework Agnostic
 

--- a/cli/internal/vendor_frontend.go
+++ b/cli/internal/vendor_frontend.go
@@ -158,7 +158,10 @@ func (v *FrontendVendor) runContainer(vm *VendorManager) (string, error) {
 		gid = "1000"
 	}
 
-	// Configure npm auth for GitHub Packages if GITHUB_TOKEN is set
+	// Configure npm auth for GitHub Packages if GITHUB_TOKEN is set. The SDKs
+	// now live on the public npm registry, but bots created before the move
+	// may still have a project .npmrc pinning the scope to GitHub Packages,
+	// and their builds only work with this auth in place.
 	npmAuthSetup := `if [ -n "$GITHUB_TOKEN" ]; then echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" >> ~/.npmrc; fi`
 
 	// Build command: setup auth, install deps, run build script

--- a/docs/custom-bot-development/bot-types.md
+++ b/docs/custom-bot-development/bot-types.md
@@ -118,7 +118,7 @@ Realtime bots don't use cron schedules—they run continuously until stopped.
 A realtime bot contains a main loop that runs indefinitely. The typescript-price-alerts example shows the pattern:
 
 ```typescript
-import { parse, metric, sleep } from "@alexanderwanyoike/the0-node";
+import { parse, metric, sleep } from "the0-node";
 import pino from "pino";
 
 const logger = pino({ level: "info" });

--- a/docs/custom-bot-development/custom-frontends.md
+++ b/docs/custom-bot-development/custom-frontends.md
@@ -47,7 +47,7 @@ Create `frontend/package.json` with the React SDK as a dev dependency:
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@alexanderwanyoike/the0-react": "^0.2.0",
+    "the0-react": "^0.2.0",
     "@types/react": "^19.0.0",
     "typescript": "^5.0.0"
   }
@@ -93,7 +93,7 @@ Here's a complete dashboard example:
 
 ```tsx
 import React from "react";
-import { useThe0Events, BotEvent } from "@alexanderwanyoike/the0-react";
+import { useThe0Events, BotEvent } from "the0-react";
 
 export default function Dashboard() {
   const { events, utils, loading, error } = useThe0Events();
@@ -356,7 +356,7 @@ For advanced users who need custom esbuild configuration, you can import the plu
 ```javascript
 // esbuild.config.mjs
 import * as esbuild from "esbuild";
-import { reactGlobalPlugin } from "@alexanderwanyoike/the0-react/esbuild";
+import { reactGlobalPlugin } from "the0-react/esbuild";
 
 await esbuild.build({
   entryPoints: ["index.tsx"],
@@ -371,7 +371,7 @@ await esbuild.build({
 Or use the programmatic build function with options:
 
 ```javascript
-import { build } from "@alexanderwanyoike/the0-react/build";
+import { build } from "the0-react/build";
 
 await build({
   entryPoint: "src/Dashboard.tsx",
@@ -384,7 +384,7 @@ await build({
 
 **Dashboard not appearing**: Ensure `frontend/package.json` exists with a `build` script that runs `the0-build`.
 
-**React not found error**: Use `@alexanderwanyoike/the0-react` version 0.2.0 or higher, which includes React as a peer dependency.
+**React not found error**: Use `the0-react` version 0.2.0 or higher, which includes React as a peer dependency.
 
 **Metrics not showing**: Verify your bot emits metrics using either the SDK `metric()` function or structured logging with the `_metric` field.
 

--- a/docs/custom-bot-development/metrics.md
+++ b/docs/custom-bot-development/metrics.md
@@ -40,7 +40,7 @@ def main():
 **TypeScript:**
 
 ```typescript
-import { parse, metric, success } from "@alexanderwanyoike/the0-node";
+import { parse, metric, success } from "the0-node";
 
 async function main(): Promise<void> {
     const { id, config } = parse();

--- a/docs/custom-bot-development/nodejs-quick-start.md
+++ b/docs/custom-bot-development/nodejs-quick-start.md
@@ -158,13 +158,9 @@ Create `tsconfig.json`:
 }
 ```
 
-Install the SDK from GitHub Packages:
+Install the dependencies:
 
 ```bash
-# Configure npm for the @alexanderwanyoike scope
-echo "@alexanderwanyoike:registry=https://npm.pkg.github.com" >> ~/.npmrc
-
-# Install dependencies
 npm install
 ```
 

--- a/docs/custom-bot-development/nodejs-quick-start.md
+++ b/docs/custom-bot-development/nodejs-quick-start.md
@@ -130,7 +130,7 @@ Create `package.json`:
     "start": "node main.js"
   },
   "dependencies": {
-    "@alexanderwanyoike/the0-node": "^0.1.0",
+    "the0-node": "^0.1.0",
     "pino": "^9.0.0"
   },
   "devDependencies": {
@@ -169,7 +169,7 @@ npm install
 Create `main.ts` with your bot implementation. The key pattern for TypeScript bots is exporting the `main` function—the runtime invokes it directly rather than your code calling it:
 
 ```typescript
-import { parse, metric, sleep, success } from "@alexanderwanyoike/the0-node";
+import { parse, metric, sleep, success } from "the0-node";
 import pino from "pino";
 
 const logger = pino({ level: "info" });
@@ -309,7 +309,7 @@ The Node.js SDK provides these core functions:
 Reads `BOT_ID` and `BOT_CONFIG` from environment variables. The generic type parameter provides TypeScript type safety for your configuration:
 
 ```typescript
-import { parse } from "@alexanderwanyoike/the0-node";
+import { parse } from "the0-node";
 
 interface MyConfig {
   symbol: string;
@@ -325,7 +325,7 @@ const { id, config } = parse<MyConfig>();
 Emits a metric to the platform dashboard:
 
 ```typescript
-import { metric } from "@alexanderwanyoike/the0-node";
+import { metric } from "the0-node";
 
 metric("price", { symbol: "BTC/USD", value: 45000, change_pct: 2.5 });
 metric("alert", { type: "price_spike", severity: "high", message: "BTC up 5%" });
@@ -337,7 +337,7 @@ metric("signal", { direction: "long", confidence: 0.85 });
 Async utility for waiting between iterations:
 
 ```typescript
-import { sleep } from "@alexanderwanyoike/the0-node";
+import { sleep } from "the0-node";
 
 await sleep(5000); // Wait 5 seconds
 ```
@@ -347,7 +347,7 @@ await sleep(5000); // Wait 5 seconds
 Reports successful execution for scheduled bots:
 
 ```typescript
-import { success } from "@alexanderwanyoike/the0-node";
+import { success } from "the0-node";
 
 success("Analysis complete", { processed: 100 });
 ```
@@ -357,7 +357,7 @@ success("Analysis complete", { processed: 100 });
 Reports failure and terminates with exit code 1:
 
 ```typescript
-import { error } from "@alexanderwanyoike/the0-node";
+import { error } from "the0-node";
 
 if (!config.api_key) {
   error("API key is required");
@@ -470,7 +470,7 @@ The platform automatically detects and parses JSON log entries with `_metric` fi
 If you prefer plain JavaScript over TypeScript, create `main.js` directly:
 
 ```javascript
-import { parse, metric, sleep } from "@alexanderwanyoike/the0-node";
+import { parse, metric, sleep } from "the0-node";
 
 async function main() {
   const { id, config } = parse();

--- a/docs/custom-bot-development/overview.md
+++ b/docs/custom-bot-development/overview.md
@@ -64,7 +64,7 @@ if __name__ == "__main__":
 **TypeScript:**
 
 ```typescript
-import { parse, metric, success } from "@alexanderwanyoike/the0-node";
+import { parse, metric, success } from "the0-node";
 
 interface BotConfig {
     symbol: string;

--- a/docs/custom-bot-development/queries.md
+++ b/docs/custom-bot-development/queries.md
@@ -74,7 +74,7 @@ if __name__ == "__main__":
 ```
 
 ```typescript [TypeScript]
-import { query, state, logger } from "@alexanderwanyoike/the0-node";
+import { query, state, logger } from "the0-node";
 
 interface BotState {
     priceHistory: { price: number; timestamp: number }[];

--- a/docs/custom-bot-development/state.md
+++ b/docs/custom-bot-development/state.md
@@ -51,7 +51,7 @@ state.clear()
 ```
 
 ```typescript [TypeScript]
-import { state } from "@alexanderwanyoike/the0-node";
+import { state } from "the0-node";
 
 // Store a value
 state.set("portfolio", { AAPL: 100, GOOGL: 50 });
@@ -258,7 +258,7 @@ state.set("prev_long_sma", long_sma)
 ```
 
 ```typescript [TypeScript]
-import { state, metric } from "@alexanderwanyoike/the0-node";
+import { state, metric } from "the0-node";
 
 interface SmaState {
     prevShortSma: number | null;
@@ -357,7 +357,7 @@ if len(price_history) >= 20:
 ```
 
 ```typescript [TypeScript]
-import { state } from "@alexanderwanyoike/the0-node";
+import { state } from "the0-node";
 
 interface PriceEntry {
     price: number;
@@ -462,7 +462,7 @@ state.set("total_trades", total_trades)
 ```
 
 ```typescript [TypeScript]
-import { state, metric } from "@alexanderwanyoike/the0-node";
+import { state, metric } from "the0-node";
 
 // Load counters
 let totalSignals = state.get<number>("total_signals", 0);

--- a/docs/welcome-to-the0.md
+++ b/docs/welcome-to-the0.md
@@ -37,7 +37,7 @@ the0 provides official SDKs for seven languages, each offering consistent APIs f
 | Language | Runtime | SDK Source |
 |----------|---------|------------|
 | Python | python3.11 | `the0-sdk` (PyPI) |
-| TypeScript/Node.js | nodejs20 | `@alexanderwanyoike/the0-node` (GitHub Packages) |
+| TypeScript/Node.js | nodejs20 | `@alexanderwanyoike/the0-node` (npm) |
 | Rust | rust-stable | `the0-sdk` (crates.io) |
 | C# | dotnet8 | `The0.Sdk` (NuGet) |
 | Scala | scala3 | `the0-sdk` (GitHub Repository) |

--- a/docs/welcome-to-the0.md
+++ b/docs/welcome-to-the0.md
@@ -37,7 +37,7 @@ the0 provides official SDKs for seven languages, each offering consistent APIs f
 | Language | Runtime | SDK Source |
 |----------|---------|------------|
 | Python | python3.11 | `the0-sdk` (PyPI) |
-| TypeScript/Node.js | nodejs20 | `@alexanderwanyoike/the0-node` (npm) |
+| TypeScript/Node.js | nodejs20 | `the0-node` (npm) |
 | Rust | rust-stable | `the0-sdk` (crates.io) |
 | C# | dotnet8 | `The0.Sdk` (NuGet) |
 | Scala | scala3 | `the0-sdk` (GitHub Repository) |

--- a/example-bots/README.md
+++ b/example-bots/README.md
@@ -136,7 +136,7 @@ The CLI automatically:
 
 ## SDK Installation
 
-The TypeScript examples use `@alexanderwanyoike/the0-node` from GitHub Packages:
+The TypeScript examples use `@alexanderwanyoike/the0-node` from npm:
 
 ```json
 {
@@ -146,17 +146,9 @@ The TypeScript examples use `@alexanderwanyoike/the0-node` from GitHub Packages:
 }
 ```
 
-Configure `.npmrc` for GitHub Packages:
-```
-@alexanderwanyoike:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
-```
-
-GitHub Packages requires authentication even for public packages, so set
-`GITHUB_TOKEN` to a personal access token with the `read:packages` scope
-before installing:
+The SDK packages are published to the public npm registry, so a plain
+install works with no registry configuration or authentication:
 
 ```bash
-export GITHUB_TOKEN=ghp_...
 yarn install
 ```

--- a/example-bots/README.md
+++ b/example-bots/README.md
@@ -1,6 +1,6 @@
 # Example Bots with Custom Frontends
 
-This directory contains example bots demonstrating how to build custom trading bots with React dashboards using the `@the0/react` SDK.
+This directory contains example bots demonstrating how to build custom trading bots with React dashboards using the `the0-react` SDK.
 
 ## Examples
 
@@ -77,10 +77,10 @@ my-bot/
         └── bundle.js     # Built ESM bundle
 ```
 
-The frontend uses the `@the0/react` SDK to access bot events:
+The frontend uses the `the0-react` SDK to access bot events:
 
 ```tsx
-import { useThe0Events } from '@the0/react';
+import { useThe0Events } from 'the0-react';
 
 export default function Dashboard() {
   const { events, utils, loading } = useThe0Events();
@@ -136,12 +136,12 @@ The CLI automatically:
 
 ## SDK Installation
 
-The TypeScript examples use `@alexanderwanyoike/the0-node` from npm:
+The TypeScript examples use `the0-node` from npm:
 
 ```json
 {
   "dependencies": {
-    "@alexanderwanyoike/the0-node": "^0.3.1"
+    "the0-node": "^0.3.1"
   }
 }
 ```

--- a/example-bots/cpp-sma-crossover/frontend/.npmrc
+++ b/example-bots/cpp-sma-crossover/frontend/.npmrc
@@ -1,1 +1,0 @@
-@alexanderwanyoike:registry=https://npm.pkg.github.com

--- a/example-bots/cpp-sma-crossover/frontend/index.tsx
+++ b/example-bots/cpp-sma-crossover/frontend/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from "react";
-import { useThe0Events, BotEvent } from "@alexanderwanyoike/the0-react";
+import { useThe0Events, BotEvent } from "the0-react";
 
 export default function Dashboard() {
   const { events, utils, loading, error } = useThe0Events();

--- a/example-bots/cpp-sma-crossover/frontend/package.json
+++ b/example-bots/cpp-sma-crossover/frontend/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@alexanderwanyoike/the0-react": "^0.2.0",
+    "the0-react": "^0.2.0",
     "@types/react": "^19.0.0",
     "esbuild": "^0.24.0",
     "typescript": "^5.0.0"

--- a/example-bots/csharp-sma-crossover/frontend/.npmrc
+++ b/example-bots/csharp-sma-crossover/frontend/.npmrc
@@ -1,1 +1,0 @@
-@alexanderwanyoike:registry=https://npm.pkg.github.com

--- a/example-bots/csharp-sma-crossover/frontend/index.tsx
+++ b/example-bots/csharp-sma-crossover/frontend/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from "react";
-import { useThe0Events, BotEvent } from "@alexanderwanyoike/the0-react";
+import { useThe0Events, BotEvent } from "the0-react";
 
 export default function Dashboard() {
   const { events, utils, loading, error } = useThe0Events();

--- a/example-bots/csharp-sma-crossover/frontend/package.json
+++ b/example-bots/csharp-sma-crossover/frontend/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@alexanderwanyoike/the0-react": "^0.2.0",
+    "the0-react": "^0.2.0",
     "@types/react": "^19.0.0",
     "esbuild": "^0.24.0",
     "typescript": "^5.0.0"

--- a/example-bots/haskell-sma-crossover/frontend/.npmrc
+++ b/example-bots/haskell-sma-crossover/frontend/.npmrc
@@ -1,1 +1,0 @@
-@alexanderwanyoike:registry=https://npm.pkg.github.com

--- a/example-bots/haskell-sma-crossover/frontend/index.tsx
+++ b/example-bots/haskell-sma-crossover/frontend/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from "react";
-import { useThe0Events, BotEvent } from "@alexanderwanyoike/the0-react";
+import { useThe0Events, BotEvent } from "the0-react";
 
 export default function Dashboard() {
   const { events, utils, loading, error } = useThe0Events();

--- a/example-bots/haskell-sma-crossover/frontend/package.json
+++ b/example-bots/haskell-sma-crossover/frontend/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@alexanderwanyoike/the0-react": "^0.2.0",
+    "the0-react": "^0.2.0",
     "@types/react": "^19.0.0",
     "esbuild": "^0.24.0",
     "typescript": "^5.0.0"

--- a/example-bots/python-portfolio-tracker/README.md
+++ b/example-bots/python-portfolio-tracker/README.md
@@ -2,7 +2,7 @@
 
 A scheduled bot example that demonstrates:
 - Structured metric emission with structlog
-- Custom React frontend with `@the0/react` SDK
+- Custom React frontend with `the0-react` SDK
 - Portfolio value tracking and trade simulation
 
 ## What It Does

--- a/example-bots/python-portfolio-tracker/frontend/.npmrc
+++ b/example-bots/python-portfolio-tracker/frontend/.npmrc
@@ -1,1 +1,0 @@
-@alexanderwanyoike:registry=https://npm.pkg.github.com

--- a/example-bots/python-portfolio-tracker/frontend/index.tsx
+++ b/example-bots/python-portfolio-tracker/frontend/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from "react";
-import { useThe0Events, BotEvent } from "@alexanderwanyoike/the0-react";
+import { useThe0Events, BotEvent } from "the0-react";
 
 export default function Dashboard() {
   const { events, utils, loading, error } = useThe0Events();

--- a/example-bots/python-portfolio-tracker/frontend/package.json
+++ b/example-bots/python-portfolio-tracker/frontend/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@alexanderwanyoike/the0-react": "^0.2.0",
+    "the0-react": "^0.2.0",
     "@types/react": "^19.0.0",
     "esbuild": "^0.24.0",
     "typescript": "^5.0.0"

--- a/example-bots/python-portfolio-tracker/main_raw.py
+++ b/example-bots/python-portfolio-tracker/main_raw.py
@@ -5,7 +5,7 @@ A scheduled bot that simulates portfolio tracking with mock data.
 
 This example demonstrates:
 - Structured metric emission using structlog with _metric field
-- How the @the0/react SDK consumes these metrics in custom frontends
+- How the the0-react SDK consumes these metrics in custom frontends
 - Scheduled bot pattern (runs once per trigger, then exits)
 
 Metrics emitted:

--- a/example-bots/rust-sma-crossover/frontend/.npmrc
+++ b/example-bots/rust-sma-crossover/frontend/.npmrc
@@ -1,1 +1,0 @@
-@alexanderwanyoike:registry=https://npm.pkg.github.com

--- a/example-bots/rust-sma-crossover/frontend/index.tsx
+++ b/example-bots/rust-sma-crossover/frontend/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from "react";
-import { useThe0Events, BotEvent } from "@alexanderwanyoike/the0-react";
+import { useThe0Events, BotEvent } from "the0-react";
 
 export default function Dashboard() {
   const { events, utils, loading, error } = useThe0Events();

--- a/example-bots/rust-sma-crossover/frontend/package.json
+++ b/example-bots/rust-sma-crossover/frontend/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@alexanderwanyoike/the0-react": "^0.2.0",
+    "the0-react": "^0.2.0",
     "@types/react": "^19.0.0",
     "esbuild": "^0.24.0",
     "typescript": "^5.0.0"

--- a/example-bots/scala-sma-crossover/frontend/.npmrc
+++ b/example-bots/scala-sma-crossover/frontend/.npmrc
@@ -1,1 +1,0 @@
-@alexanderwanyoike:registry=https://npm.pkg.github.com

--- a/example-bots/scala-sma-crossover/frontend/index.tsx
+++ b/example-bots/scala-sma-crossover/frontend/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from "react";
-import { useThe0Events, BotEvent } from "@alexanderwanyoike/the0-react";
+import { useThe0Events, BotEvent } from "the0-react";
 
 export default function Dashboard() {
   const { events, utils, loading, error } = useThe0Events();

--- a/example-bots/scala-sma-crossover/frontend/package.json
+++ b/example-bots/scala-sma-crossover/frontend/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@alexanderwanyoike/the0-react": "^0.2.0",
+    "the0-react": "^0.2.0",
     "@types/react": "^19.0.0",
     "esbuild": "^0.24.0",
     "typescript": "^5.0.0"

--- a/example-bots/typescript-price-alerts/.npmrc
+++ b/example-bots/typescript-price-alerts/.npmrc
@@ -1,2 +1,0 @@
-@alexanderwanyoike:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/example-bots/typescript-price-alerts/README.md
+++ b/example-bots/typescript-price-alerts/README.md
@@ -2,7 +2,7 @@
 
 A realtime bot example that demonstrates:
 - Structured metric emission with pino logging
-- Custom React frontend with `@the0/react` SDK
+- Custom React frontend with `the0-react` SDK
 - Continuous price monitoring with alerts
 
 ## What It Does

--- a/example-bots/typescript-price-alerts/frontend/.npmrc
+++ b/example-bots/typescript-price-alerts/frontend/.npmrc
@@ -1,1 +1,0 @@
-@alexanderwanyoike:registry=https://npm.pkg.github.com

--- a/example-bots/typescript-price-alerts/frontend/index.tsx
+++ b/example-bots/typescript-price-alerts/frontend/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from "react";
-import { useThe0Events, BotEvent } from "@alexanderwanyoike/the0-react";
+import { useThe0Events, BotEvent } from "the0-react";
 
 export default function Dashboard() {
   const { events, utils, loading, error } = useThe0Events();

--- a/example-bots/typescript-price-alerts/frontend/package.json
+++ b/example-bots/typescript-price-alerts/frontend/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@alexanderwanyoike/the0-react": "^0.2.0",
+    "the0-react": "^0.2.0",
     "@types/react": "^19.0.0",
     "esbuild": "^0.24.0",
     "typescript": "^5.0.0"

--- a/example-bots/typescript-price-alerts/main.ts
+++ b/example-bots/typescript-price-alerts/main.ts
@@ -17,7 +17,7 @@
  * - Tracks alert_count for monitoring bot activity
  */
 
-import { parse, metric, sleep, success, state } from "@alexanderwanyoike/the0-node";
+import { parse, metric, sleep, success, state } from "the0-node";
 import pino from "pino";
 
 // Configure pino logger for structured JSON output

--- a/example-bots/typescript-price-alerts/package.json
+++ b/example-bots/typescript-price-alerts/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "pino": "^9.0.0",
-    "@alexanderwanyoike/the0-node": "^0.3.1"
+    "the0-node": "^0.3.1"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/example-bots/typescript-price-alerts/query.ts
+++ b/example-bots/typescript-price-alerts/query.ts
@@ -14,7 +14,7 @@
  *   /statistics    - Get overall bot statistics
  */
 
-import { query, state } from "@alexanderwanyoike/the0-node";
+import { query, state } from "the0-node";
 
 // Persistent state structure (matches main.ts)
 interface PersistedState {

--- a/frontend/src/contexts/bot-events-context.tsx
+++ b/frontend/src/contexts/bot-events-context.tsx
@@ -29,7 +29,7 @@ interface BotEventsContextValue {
   botId: string;
 }
 
-// Shared context - also accessible via @the0/react SDK
+// Shared context - also accessible via the0-react SDK
 declare global {
   interface Window {
     __THE0_EVENTS_CONTEXT__?: React.Context<BotEventsContextValue | null>;

--- a/sdk/nodejs/README.md
+++ b/sdk/nodejs/README.md
@@ -1,23 +1,23 @@
-# @alexanderwanyoike/the0-node
+# the0-node
 
 Official SDK for building trading bots on the0 platform with Node.js and TypeScript.
 
 ## Installation
 
 ```bash
-npm install @alexanderwanyoike/the0-node
+npm install the0-node
 # or
-yarn add @alexanderwanyoike/the0-node
+yarn add the0-node
 ```
 
-> Migrating from GitHub Packages? This package now lives on the public npm
-> registry. Remove the `@alexanderwanyoike:registry` line from your `.npmrc`
-> (project or `~/.npmrc`) to pick up new versions.
+> Migrating from GitHub Packages? This package was previously published there
+> as `@alexanderwanyoike/the0-node`. Update your dependency to `the0-node` and remove the
+> `@alexanderwanyoike:registry` line from your `.npmrc` (project or `~/.npmrc`).
 
 ## Quick Start
 
 ```typescript
-import { parse, success, error, metric } from '@alexanderwanyoike/the0-node';
+import { parse, success, error, metric } from 'the0-node';
 
 // Parse bot configuration from environment
 const { id, config } = parse<{
@@ -123,7 +123,7 @@ await sleep(5000); // Wait 5 seconds
 Run on a cron schedule, execute once, and exit:
 
 ```typescript
-import { parse, success, error } from '@alexanderwanyoike/the0-node';
+import { parse, success, error } from 'the0-node';
 
 const { id, config } = parse();
 
@@ -141,7 +141,7 @@ try {
 Run continuously until stopped:
 
 ```typescript
-import { parse, metric, sleep } from '@alexanderwanyoike/the0-node';
+import { parse, metric, sleep } from 'the0-node';
 
 const { id, config } = parse();
 
@@ -164,8 +164,7 @@ This package is published to the public npm registry.
 
 ### Prerequisites
 
-Authenticate with npm as a user with publish rights to the
-`@alexanderwanyoike` scope:
+Authenticate with npm as a maintainer of the package:
 
 ```bash
 npm login

--- a/sdk/nodejs/README.md
+++ b/sdk/nodejs/README.md
@@ -4,20 +4,15 @@ Official SDK for building trading bots on the0 platform with Node.js and TypeScr
 
 ## Installation
 
-This package is published to GitHub Packages. First, configure npm to use GitHub Packages for the `@alexanderwanyoike` scope:
-
-```bash
-# Create or edit ~/.npmrc
-echo "@alexanderwanyoike:registry=https://npm.pkg.github.com" >> ~/.npmrc
-```
-
-Then install:
-
 ```bash
 npm install @alexanderwanyoike/the0-node
 # or
 yarn add @alexanderwanyoike/the0-node
 ```
+
+> Migrating from GitHub Packages? This package now lives on the public npm
+> registry. Remove the `@alexanderwanyoike:registry` line from your `.npmrc`
+> (project or `~/.npmrc`) to pick up new versions.
 
 ## Quick Start
 
@@ -165,19 +160,16 @@ while (true) {
 
 ## Publishing (Maintainers)
 
-This package is published to GitHub Packages.
+This package is published to the public npm registry.
 
 ### Prerequisites
 
-1. Create a GitHub Personal Access Token with `write:packages` scope:
-   https://github.com/settings/tokens/new?scopes=write:packages,read:packages
+Authenticate with npm as a user with publish rights to the
+`@alexanderwanyoike` scope:
 
-2. Authenticate with GitHub Packages:
-   ```bash
-   npm login --registry=https://npm.pkg.github.com
-   # Username: your-github-username
-   # Password: your-personal-access-token
-   ```
+```bash
+npm login
+```
 
 ### Publish
 
@@ -185,7 +177,7 @@ This package is published to GitHub Packages.
 # Build the package
 yarn build
 
-# Publish to GitHub Packages
+# Publish to npm
 npm publish
 ```
 

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -8,7 +8,7 @@
     "directory": "sdk/nodejs"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com",
+    "registry": "https://registry.npmjs.org",
     "access": "public"
   },
   "main": "dist/index.js",

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@alexanderwanyoike/the0-node",
+  "name": "the0-node",
   "version": "0.3.1",
   "description": "the0 SDK for Node.js/TypeScript trading bots",
   "repository": {

--- a/sdk/nodejs/src/index.ts
+++ b/sdk/nodejs/src/index.ts
@@ -6,7 +6,7 @@
  *
  * @example
  * ```typescript
- * import { parse, success, error, result, metric } from '@the0/sdk';
+ * import { parse, success, error, result, metric } from 'the0-node';
  *
  * // Parse bot configuration
  * const { id, config } = parse();

--- a/sdk/nodejs/src/query.ts
+++ b/sdk/nodejs/src/query.ts
@@ -5,10 +5,10 @@
  * custom read-only query handlers that can be executed on demand.
  *
  * Separate namespace from state and main SDK exports.
- * Users import: import { query } from '@the0/sdk';
+ * Users import: import { query } from 'the0-node';
  *
  * @example
- * import { query, state } from '@the0/sdk';
+ * import { query, state } from 'the0-node';
  *
  * query.handler('/portfolio', async (req) => {
  *   const positions = await state.get('positions', []);
@@ -142,7 +142,7 @@ export function getConfig(): Record<string, unknown> {
  *
  * @example
  * // In query.ts
- * import { query, state } from '@the0/sdk';
+ * import { query, state } from 'the0-node';
  *
  * query.handler('/portfolio', async (req) => {
  *   return { positions: await state.get('positions', []) };

--- a/sdk/nodejs/src/state.ts
+++ b/sdk/nodejs/src/state.ts
@@ -7,7 +7,7 @@
  *
  * @example
  * ```typescript
- * import { state } from '@the0/sdk';
+ * import { state } from 'the0-node';
  *
  * // Store state
  * state.set('portfolio', { AAPL: 100, GOOGL: 50 });

--- a/sdk/react/README.md
+++ b/sdk/react/README.md
@@ -1,23 +1,23 @@
-# @alexanderwanyoike/the0-react
+# the0-react
 
 React SDK for building custom bot dashboards on the0 platform.
 
 ## Installation
 
 ```bash
-npm install @alexanderwanyoike/the0-react
+npm install the0-react
 # or
-yarn add @alexanderwanyoike/the0-react
+yarn add the0-react
 ```
 
-> Migrating from GitHub Packages? This package now lives on the public npm
-> registry. Remove the `@alexanderwanyoike:registry` line from your `.npmrc`
-> (project or `~/.npmrc`) to pick up new versions.
+> Migrating from GitHub Packages? This package was previously published there
+> as `@alexanderwanyoike/the0-react`. Update your dependency to `the0-react` and remove the
+> `@alexanderwanyoike:registry` line from your `.npmrc` (project or `~/.npmrc`).
 
 ## Usage
 
 ```tsx
-import { useThe0Events } from '@alexanderwanyoike/the0-react';
+import { useThe0Events } from 'the0-react';
 
 export default function Dashboard() {
   const { events, utils, loading, error } = useThe0Events();
@@ -119,8 +119,7 @@ This package is published to the public npm registry.
 
 ### Prerequisites
 
-Authenticate with npm as a user with publish rights to the
-`@alexanderwanyoike` scope:
+Authenticate with npm as a maintainer of the package:
 
 ```bash
 npm login

--- a/sdk/react/README.md
+++ b/sdk/react/README.md
@@ -4,20 +4,15 @@ React SDK for building custom bot dashboards on the0 platform.
 
 ## Installation
 
-This package is published to GitHub Packages. First, configure npm to use GitHub Packages for the `@alexanderwanyoike` scope:
-
-```bash
-# Create or edit ~/.npmrc
-echo "@alexanderwanyoike:registry=https://npm.pkg.github.com" >> ~/.npmrc
-```
-
-Then install:
-
 ```bash
 npm install @alexanderwanyoike/the0-react
 # or
 yarn add @alexanderwanyoike/the0-react
 ```
+
+> Migrating from GitHub Packages? This package now lives on the public npm
+> registry. Remove the `@alexanderwanyoike:registry` line from your `.npmrc`
+> (project or `~/.npmrc`) to pick up new versions.
 
 ## Usage
 
@@ -120,19 +115,16 @@ esbuild frontend/index.tsx \
 
 ## Publishing (Maintainers)
 
-This package is published to GitHub Packages.
+This package is published to the public npm registry.
 
 ### Prerequisites
 
-1. Create a GitHub Personal Access Token with `write:packages` scope:
-   https://github.com/settings/tokens/new?scopes=write:packages,read:packages
+Authenticate with npm as a user with publish rights to the
+`@alexanderwanyoike` scope:
 
-2. Authenticate with GitHub Packages:
-   ```bash
-   npm login --registry=https://npm.pkg.github.com
-   # Username: your-github-username
-   # Password: your-personal-access-token
-   ```
+```bash
+npm login
+```
 
 ### Publish
 
@@ -140,7 +132,7 @@ This package is published to GitHub Packages.
 # Build the package
 yarn build
 
-# Publish to GitHub Packages
+# Publish to npm
 npm publish
 ```
 

--- a/sdk/react/package.json
+++ b/sdk/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@alexanderwanyoike/the0-react",
+  "name": "the0-react",
   "version": "0.2.0",
   "description": "React SDK for the0 bot custom frontends",
   "repository": {

--- a/sdk/react/package.json
+++ b/sdk/react/package.json
@@ -8,7 +8,7 @@
     "directory": "sdk/react"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com",
+    "registry": "https://registry.npmjs.org",
     "access": "public"
   },
   "main": "dist/index.js",

--- a/sdk/react/src/__tests__/index.test.tsx
+++ b/sdk/react/src/__tests__/index.test.tsx
@@ -10,7 +10,7 @@ import {
   The0EventsContextValue,
 } from "../index";
 
-describe("@the0/react SDK", () => {
+describe("the0-react SDK", () => {
   // Create mock utils
   const createMockUtils = (events: BotEvent[]): BotEventUtils => ({
     since: jest.fn(() => events),

--- a/sdk/react/src/__tests__/setup.ts
+++ b/sdk/react/src/__tests__/setup.ts
@@ -1,4 +1,4 @@
-// Jest setup for @the0/react SDK
+// Jest setup for the0-react SDK
 import "@testing-library/react";
 
 // Suppress console errors during tests unless debugging

--- a/sdk/react/src/build.ts
+++ b/sdk/react/src/build.ts
@@ -23,7 +23,7 @@ export interface BuildOptions {
  *
  * @example
  * ```js
- * import { build } from "@alexanderwanyoike/the0-react/build";
+ * import { build } from "the0-react/build";
  *
  * // Simple usage with defaults
  * await build();

--- a/sdk/react/src/esbuild.ts
+++ b/sdk/react/src/esbuild.ts
@@ -14,7 +14,7 @@ import type { Plugin } from "esbuild";
  * @example
  * ```js
  * import * as esbuild from "esbuild";
- * import { reactGlobalPlugin } from "@alexanderwanyoike/the0-react/esbuild";
+ * import { reactGlobalPlugin } from "the0-react/esbuild";
  *
  * await esbuild.build({
  *   entryPoints: ["index.tsx"],

--- a/sdk/react/src/index.ts
+++ b/sdk/react/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @the0/react - React SDK for bot custom frontends
+ * the0-react - React SDK for bot custom frontends
  *
  * This SDK provides hooks and utilities for building custom dashboards
  * that visualize bot metrics and events.
@@ -104,7 +104,7 @@ export const The0EventsContext = getSharedContext();
  *
  * @example
  * ```tsx
- * import { useThe0Events } from '@the0/react';
+ * import { useThe0Events } from 'the0-react';
  *
  * export default function Dashboard() {
  *   const { events, utils, loading } = useThe0Events();


### PR DESCRIPTION
## Description

GitHub Packages requires authentication for every npm operation, including installing public packages, so anyone deploying a bot with a frontend (or a TypeScript bot) hit `npm error 401 Unauthorized` unless they had a PAT with `read:packages` in their `.npmrc`. Reported by @jrodriguez300 in the additional notes of #322.

This moves both SDKs to the public npm registry and renames them while the consumer base is effectively zero (the auth wall locked most people out):

- `@alexanderwanyoike/the0-node` becomes **`the0-node`**
- `@alexanderwanyoike/the0-react` becomes **`the0-react`**

Unscoped names match the sibling registries (`the0-sdk` on PyPI and crates.io, `The0.Sdk` on NuGet). The `the0` org name is taken on npm, so scoping under `@the0/` was not an option. The docs already referenced `@the0/react` and `@the0/sdk` in places; this settles the inconsistency.

## Type of Change

- [x] Other: registry move + package rename

## Changes Made

- `sdk/nodejs` and `sdk/react` package.jsons: new names, `publishConfig.registry` now `registry.npmjs.org`
- All imports and dependency declarations updated across example bots and docs
- Removed the scope-to-GitHub-Packages `.npmrc` pins from the example bots (8 files) and added `frontend/.npmrc` to .gitignore
- Updated install/publishing docs with a migration note (old name, new name, remove the registry pin)
- The CLI's `GITHUB_TOKEN` npmrc shim is deliberately kept so bots created before the move keep building

## Migration impact

- Old scoped versions stay on GitHub Packages; existing PAT-based setups keep working and simply stop receiving updates until they switch to the new package name (documented in both SDK READMEs)
- Nothing breaks on merge; runtime contracts don't reference the package name (react/react-dom are externalized via `window.__THE0_REACT__` globals, and the SDK itself is bundled into `bundle.js`)

## Before merging to main

- [ ] Publish `the0-node` and `the0-react` to npmjs.org (manual first publish: `yarn build && npm publish` in each SDK dir)
- [ ] Optionally claim `the0-sdk` as a placeholder pointing at the real packages, since it's unclaimed and is the name users of the other-language SDKs will guess
- [ ] Configure npm trusted publishing per package afterwards; CI publish workflow to follow as a separate PR

## Component(s) Affected

- [x] Documentation
- [x] Other: sdk/nodejs, sdk/react, example bots

## Testing

- Both SDKs: `yarn install --frozen-lockfile`, `yarn build`, `yarn test` all pass after the rename
- CLI: `go build ./...` and full `go test ./...` pass (only change is a comment)
- `git grep` confirms zero remaining references to the old scoped names or the stale `@the0/*` variants in tracked files

https://claude.ai/code/session_01JN2kbt5Ui3tztGeuQJsvBz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Node.js and React SDK packages are now available through the public npm registry.
  * Example projects can install SDKs without GitHub Packages configuration or authentication.

* **Documentation**
  * Updated installation, imports, package links, and publishing instructions for standard npm workflows.
  * Simplified quick-start guides and added migration guidance for existing projects.
  * Updated SDK references across documentation and example applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->