### PR TITLE
Release v1.14.6

### DIFF
--- a/.github/workflows/sdk-npm-publish.yml
+++ b/.github/workflows/sdk-npm-publish.yml
@@ -1,0 +1,81 @@
+name: Publish SDKs to npm
+
+# Publishes the0-node and the0-react via npm trusted publishing (OIDC).
+# Both packages' npm settings trust this exact workflow filename; renaming
+# this file breaks publishing until the npm config is updated to match.
+#
+# Idempotent: a package whose version already exists on npm is skipped, so
+# running the workflow publishes only what has been bumped.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: the0-node
+            dir: sdk/nodejs
+          - package: the0-react
+            dir: sdk/react
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'yarn'
+          cache-dependency-path: ${{ matrix.dir }}/yarn.lock
+
+      # Trusted publishing (OIDC) requires npm 11.5.1+
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Check whether this version is already published
+        id: version
+        working-directory: ${{ matrix.dir }}
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          if [ "$NAME" != "${{ matrix.package }}" ]; then
+            echo "package.json name '$NAME' does not match expected '${{ matrix.package }}'" >&2
+            exit 1
+          fi
+          if npm view "$NAME@$VERSION" version > /dev/null 2>&1; then
+            echo "$NAME@$VERSION already on npm, skipping publish"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "$NAME@$VERSION not yet published"
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies
+        if: steps.version.outputs.publish == 'true'
+        working-directory: ${{ matrix.dir }}
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        if: steps.version.outputs.publish == 'true'
+        working-directory: ${{ matrix.dir }}
+        run: yarn build
+
+      - name: Test
+        if: steps.version.outputs.publish == 'true'
+        working-directory: ${{ matrix.dir }}
+        run: yarn test
+
+      - name: Publish
+        if: steps.version.outputs.publish == 'true'
+        working-directory: ${{ matrix.dir }}
+        run: npm publish

--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,7 @@ example-bots/**/main.js
 # Example bots - lock files and misc
 example-bots/*/frontend/package-lock.json
 example-bots/*/frontend/yarn.lock
-# NOTE: .npmrc tracked on purpose — points @alexanderwanyoike scope to GitHub Packages (no secrets)
-# example-bots/*/frontend/.npmrc
+example-bots/*/frontend/.npmrc
 example-bots/*/*.lock
 example-bots/*/package-lock.json
 

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Build trading bots in any of these languages with official SDK support:
 | Language | SDK | Documentation | Package Registry |
 |----------|-----|---------------|------------------|
 | **Python** | [sdk/python](sdk/python) | [Quick Start](docs/custom-bot-development/python-quick-start.md) | [PyPI](https://pypi.org/project/the0-sdk/) |
-| **TypeScript/Node.js** | [sdk/nodejs](sdk/nodejs) | [Quick Start](docs/custom-bot-development/nodejs-quick-start.md) | [npm](https://www.npmjs.com/package/@alexanderwanyoike/the0-node) |
+| **TypeScript/Node.js** | [sdk/nodejs](sdk/nodejs) | [Quick Start](docs/custom-bot-development/nodejs-quick-start.md) | [npm](https://www.npmjs.com/package/the0-node) |
 | **Rust** | [sdk/rust](sdk/rust) | [Quick Start](docs/custom-bot-development/rust-quick-start.md) | [crates.io](https://crates.io/crates/the0-sdk) |
 | **C++** | [sdk/cpp](sdk/cpp) | [Quick Start](docs/custom-bot-development/cpp-quick-start.md) | Header-only (FetchContent) |
 | **C#** | [sdk/dotnet](sdk/dotnet) | [Quick Start](docs/custom-bot-development/csharp-quick-start.md) | [NuGet](https://www.nuget.org/packages/The0.Sdk) |
@@ -346,7 +346,7 @@ Build React dashboards tailored to your trading strategies using the React SDK:
 
 | SDK | Documentation | Package |
 |-----|---------------|---------|
-| [sdk/react](sdk/react) | [Custom Frontends](docs/custom-bot-development/custom-frontends.md) | [@alexanderwanyoike/the0-react](https://www.npmjs.com/package/@alexanderwanyoike/the0-react) |
+| [sdk/react](sdk/react) | [Custom Frontends](docs/custom-bot-development/custom-frontends.md) | [the0-react](https://www.npmjs.com/package/the0-react) |
 
 ### Framework Agnostic
 

--- a/cli/internal/vendor_frontend.go
+++ b/cli/internal/vendor_frontend.go
@@ -158,7 +158,10 @@ func (v *FrontendVendor) runContainer(vm *VendorManager) (string, error) {
 		gid = "1000"
 	}
 
-	// Configure npm auth for GitHub Packages if GITHUB_TOKEN is set
+	// Configure npm auth for GitHub Packages if GITHUB_TOKEN is set. The SDKs
+	// now live on the public npm registry, but bots created before the move
+	// may still have a project .npmrc pinning the scope to GitHub Packages,
+	// and their builds only work with this auth in place.
 	npmAuthSetup := `if [ -n "$GITHUB_TOKEN" ]; then echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" >> ~/.npmrc; fi`
 
 	// Build command: setup auth, install deps, run build script

--- a/cli/internal/zip.go
+++ b/cli/internal/zip.go
@@ -85,7 +85,12 @@ func CreateBotZipFromDir(sourceDir string) (string, error) {
 		if err != nil {
 			return err
 		}
-		header.Name = relPath
+		// The ZIP spec (APPNOTE 4.4.17.1) requires forward slashes as the path
+		// separator. filepath.Rel returns OS-native separators, so on Windows
+		// this produced entries like `vendor\the0\__init__.py`, which Linux
+		// extractors treat as one flat filename -- the bot's vendor/ directory
+		// never materialises and every dependency import fails at runtime.
+		header.Name = filepath.ToSlash(relPath)
 		header.Method = zip.Deflate
 
 		writer, err := zipWriter.CreateHeader(header)

--- a/cli/internal/zip_test.go
+++ b/cli/internal/zip_test.go
@@ -1,0 +1,82 @@
+package internal
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCreateBotZipUsesForwardSlashes guards the path separator used in archive
+// entry names.
+//
+// The ZIP spec (APPNOTE 4.4.17.1) requires forward slashes. filepath.Rel
+// returns OS-native separators, so on Windows this previously produced entries
+// named `vendor\the0\__init__.py`. Backslash is a legal filename character on
+// Linux, so the runtime extracted that as a single flat file, `vendor/` never
+// existed inside the bot container, and every dependency import failed at
+// runtime with ModuleNotFoundError - long after the CLI had reported a
+// successful deploy.
+//
+// Reading the archive back with a library is not enough to catch this on
+// Windows: Go's archive/zip preserves the raw name, but several tools and
+// libraries (Python's zipfile, for one) silently normalise os.sep to '/' when
+// reading, which hides the defect on the very platform that produces it. This
+// asserts on the stored name directly.
+func TestCreateBotZipUsesForwardSlashes(t *testing.T) {
+	sourceDir := t.TempDir()
+
+	nested := filepath.Join(sourceDir, "vendor", "the0", "inner")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatalf("failed to create nested dirs: %v", err)
+	}
+	files := []string{
+		filepath.Join(sourceDir, "main.py"),
+		filepath.Join(sourceDir, "vendor", "the0", "__init__.py"),
+		filepath.Join(nested, "deep.py"),
+	}
+	for _, path := range files {
+		if err := os.WriteFile(path, []byte("# test\n"), 0644); err != nil {
+			t.Fatalf("failed to write %s: %v", path, err)
+		}
+	}
+
+	zipPath, err := CreateBotZipFromDir(sourceDir)
+	if err != nil {
+		t.Fatalf("CreateBotZipFromDir failed: %v", err)
+	}
+	defer os.Remove(zipPath)
+
+	reader, err := zip.OpenReader(zipPath)
+	if err != nil {
+		t.Fatalf("failed to open zip: %v", err)
+	}
+	defer reader.Close()
+
+	found := map[string]bool{}
+	for _, file := range reader.File {
+		if strings.Contains(file.Name, `\`) {
+			t.Errorf("zip entry %q contains a backslash; entry names must use forward slashes", file.Name)
+		}
+		found[file.Name] = true
+	}
+
+	for _, want := range []string{
+		"main.py",
+		"vendor/the0/__init__.py",
+		"vendor/the0/inner/deep.py",
+	} {
+		if !found[want] {
+			t.Errorf("expected zip entry %q, got entries: %v", want, keys(found))
+		}
+	}
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/docs/custom-bot-development/bot-types.md
+++ b/docs/custom-bot-development/bot-types.md
@@ -118,7 +118,7 @@ Realtime bots don't use cron schedules—they run continuously until stopped.
 A realtime bot contains a main loop that runs indefinitely. The typescript-price-alerts example shows the pattern:
 
 ```typescript
-import { parse, metric, sleep } from "@alexanderwanyoike/the0-node";
+import { parse, metric, sleep } from "the0-node";
 import pino from "pino";
 
 const logger = pino({ level: "info" });

--- a/docs/custom-bot-development/custom-frontends.md
+++ b/docs/custom-bot-development/custom-frontends.md
@@ -47,7 +47,7 @@ Create `frontend/package.json` with the React SDK as a dev dependency:
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@alexanderwanyoike/the0-react": "^0.2.0",
+    "the0-react": "^0.2.0",
     "@types/react": "^19.0.0",
     "typescript": "^5.0.0"
   }
@@ -93,7 +93,7 @@ Here's a complete dashboard example:
 
 ```tsx
 import React from "react";
-import { useThe0Events, BotEvent } from "@alexanderwanyoike/the0-react";
+import { useThe0Events, BotEvent } from "the0-react";
 
 export default function Dashboard() {
   const { events, utils, loading, error } = useThe0Events();
@@ -356,7 +356,7 @@ For advanced users who need custom esbuild configuration, you can import the plu
 ```javascript
 // esbuild.config.mjs
 import * as esbuild from "esbuild";
-import { reactGlobalPlugin } from "@alexanderwanyoike/the0-react/esbuild";
+import { reactGlobalPlugin } from "the0-react/esbuild";
 
 await esbuild.build({
   entryPoints: ["index.tsx"],
@@ -371,7 +371,7 @@ await esbuild.build({
 Or use the programmatic build function with options:
 
 ```javascript
-import { build } from "@alexanderwanyoike/the0-react/build";
+import { build } from "the0-react/build";
 
 await build({
   entryPoint: "src/Dashboard.tsx",
@@ -384,7 +384,7 @@ await build({
 
 **Dashboard not appearing**: Ensure `frontend/package.json` exists with a `build` script that runs `the0-build`.
 
-**React not found error**: Use `@alexanderwanyoike/the0-react` version 0.2.0 or higher, which includes React as a peer dependency.
+**React not found error**: Use `the0-react` version 0.2.0 or higher, which includes React as a peer dependency.
 
 **Metrics not showing**: Verify your bot emits metrics using either the SDK `metric()` function or structured logging with the `_metric` field.
 

--- a/docs/custom-bot-development/metrics.md
+++ b/docs/custom-bot-development/metrics.md
@@ -40,7 +40,7 @@ def main():
 **TypeScript:**
 
 ```typescript
-import { parse, metric, success } from "@alexanderwanyoike/the0-node";
+import { parse, metric, success } from "the0-node";
 
 async function main(): Promise<void> {
     const { id, config } = parse();

--- a/docs/custom-bot-development/nodejs-quick-start.md
+++ b/docs/custom-bot-development/nodejs-quick-start.md
@@ -158,13 +158,9 @@ Create `tsconfig.json`:
 }
 ```
 
-Install the SDK from GitHub Packages:
+Install the dependencies:
 
 ```bash
-# Configure npm for the @alexanderwanyoike scope
-echo "@alexanderwanyoike:registry=https://npm.pkg.github.com" >> ~/.npmrc
-
-# Install dependencies
 npm install
 ```
 

--- a/docs/custom-bot-development/nodejs-quick-start.md
+++ b/docs/custom-bot-development/nodejs-quick-start.md
@@ -130,7 +130,7 @@ Create `package.json`:
     "start": "node main.js"
   },
   "dependencies": {
-    "@alexanderwanyoike/the0-node": "^0.1.0",
+    "the0-node": "^0.1.0",
     "pino": "^9.0.0"
   },
   "devDependencies": {
@@ -169,7 +169,7 @@ npm install
 Create `main.ts` with your bot implementation. The key pattern for TypeScript bots is exporting the `main` function—the runtime invokes it directly rather than your code calling it:
 
 ```typescript
-import { parse, metric, sleep, success } from "@alexanderwanyoike/the0-node";
+import { parse, metric, sleep, success } from "the0-node";
 import pino from "pino";
 
 const logger = pino({ level: "info" });
@@ -309,7 +309,7 @@ The Node.js SDK provides these core functions:
 Reads `BOT_ID` and `BOT_CONFIG` from environment variables. The generic type parameter provides TypeScript type safety for your configuration:
 
 ```typescript
-import { parse } from "@alexanderwanyoike/the0-node";
+import { parse } from "the0-node";
 
 interface MyConfig {
   symbol: string;
@@ -325,7 +325,7 @@ const { id, config } = parse<MyConfig>();
 Emits a metric to the platform dashboard:
 
 ```typescript
-import { metric } from "@alexanderwanyoike/the0-node";
+import { metric } from "the0-node";
 
 metric("price", { symbol: "BTC/USD", value: 45000, change_pct: 2.5 });
 metric("alert", { type: "price_spike", severity: "high", message: "BTC up 5%" });
@@ -337,7 +337,7 @@ metric("signal", { direction: "long", confidence: 0.85 });
 Async utility for waiting between iterations:
 
 ```typescript
-import { sleep } from "@alexanderwanyoike/the0-node";
+import { sleep } from "the0-node";
 
 await sleep(5000); // Wait 5 seconds
 ```
@@ -347,7 +347,7 @@ await sleep(5000); // Wait 5 seconds
 Reports successful execution for scheduled bots:
 
 ```typescript
-import { success } from "@alexanderwanyoike/the0-node";
+import { success } from "the0-node";
 
 success("Analysis complete", { processed: 100 });
 ```
@@ -357,7 +357,7 @@ success("Analysis complete", { processed: 100 });
 Reports failure and terminates with exit code 1:
 
 ```typescript
-import { error } from "@alexanderwanyoike/the0-node";
+import { error } from "the0-node";
 
 if (!config.api_key) {
   error("API key is required");
@@ -470,7 +470,7 @@ The platform automatically detects and parses JSON log entries with `_metric` fi
 If you prefer plain JavaScript over TypeScript, create `main.js` directly:
 
 ```javascript
-import { parse, metric, sleep } from "@alexanderwanyoike/the0-node";
+import { parse, metric, sleep } from "the0-node";
 
 async function main() {
   const { id, config } = parse();

--- a/docs/custom-bot-development/overview.md
+++ b/docs/custom-bot-development/overview.md
@@ -64,7 +64,7 @@ if __name__ == "__main__":
 **TypeScript:**
 
 ```typescript
-import { parse, metric, success } from "@alexanderwanyoike/the0-node";
+import { parse, metric, success } from "the0-node";
 
 interface BotConfig {
     symbol: string;

--- a/docs/custom-bot-development/queries.md
+++ b/docs/custom-bot-development/queries.md
@@ -74,7 +74,7 @@ if __name__ == "__main__":
 ```
 
 ```typescript [TypeScript]
-import { query, state, logger } from "@alexanderwanyoike/the0-node";
+import { query, state, logger } from "the0-node";
 
 interface BotState {
     priceHistory: { price: number; timestamp: number }[];

--- a/docs/custom-bot-development/state.md
+++ b/docs/custom-bot-development/state.md
@@ -51,7 +51,7 @@ state.clear()
 ```
 
 ```typescript [TypeScript]
-import { state } from "@alexanderwanyoike/the0-node";
+import { state } from "the0-node";
 
 // Store a value
 state.set("portfolio", { AAPL: 100, GOOGL: 50 });
@@ -258,7 +258,7 @@ state.set("prev_long_sma", long_sma)
 ```
 
 ```typescript [TypeScript]
-import { state, metric } from "@alexanderwanyoike/the0-node";
+import { state, metric } from "the0-node";
 
 interface SmaState {
     prevShortSma: number | null;
@@ -357,7 +357,7 @@ if len(price_history) >= 20:
 ```
 
 ```typescript [TypeScript]
-import { state } from "@alexanderwanyoike/the0-node";
+import { state } from "the0-node";
 
 interface PriceEntry {
     price: number;
@@ -462,7 +462,7 @@ state.set("total_trades", total_trades)
 ```
 
 ```typescript [TypeScript]
-import { state, metric } from "@alexanderwanyoike/the0-node";
+import { state, metric } from "the0-node";
 
 // Load counters
 let totalSignals = state.get<number>("total_signals", 0);

--- a/docs/welcome-to-the0.md
+++ b/docs/welcome-to-the0.md
@@ -37,7 +37,7 @@ the0 provides official SDKs for seven languages, each offering consistent APIs f
 | Language | Runtime | SDK Source |
 |----------|---------|------------|
 | Python | python3.11 | `the0-sdk` (PyPI) |
-| TypeScript/Node.js | nodejs20 | `@alexanderwanyoike/the0-node` (GitHub Packages) |
+| TypeScript/Node.js | nodejs20 | `@alexanderwanyoike/the0-node` (npm) |
 | Rust | rust-stable | `the0-sdk` (crates.io) |
 | C# | dotnet8 | `The0.Sdk` (NuGet) |
 | Scala | scala3 | `the0-sdk` (GitHub Repository) |

--- a/docs/welcome-to-the0.md
+++ b/docs/welcome-to-the0.md
@@ -37,7 +37,7 @@ the0 provides official SDKs for seven languages, each offering consistent APIs f
 | Language | Runtime | SDK Source |
 |----------|---------|------------|
 | Python | python3.11 | `the0-sdk` (PyPI) |
-| TypeScript/Node.js | nodejs20 | `@alexanderwanyoike/the0-node` (npm) |
+| TypeScript/Node.js | nodejs20 | `the0-node` (npm) |
 | Rust | rust-stable | `the0-sdk` (crates.io) |
 | C# | dotnet8 | `The0.Sdk` (NuGet) |
 | Scala | scala3 | `the0-sdk` (GitHub Repository) |

--- a/example-bots/README.md
+++ b/example-bots/README.md
@@ -136,7 +136,7 @@ The CLI automatically:
 
 ## SDK Installation
 
-The TypeScript examples use `@alexanderwanyoike/the0-node` from GitHub Packages:
+The TypeScript examples use `@alexanderwanyoike/the0-node` from npm:
 
 ```json
 {
@@ -146,17 +146,9 @@ The TypeScript examples use `@alexanderwanyoike/the0-node` from GitHub Packages:
 }
 ```
 
-Configure `.npmrc` for GitHub Packages:
-```
-@alexanderwanyoike:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
-```
-
-GitHub Packages requires authentication even for public packages, so set
-`GITHUB_TOKEN` to a personal access token with the `read:packages` scope
-before installing:
+The SDK packages are published to the public npm registry, so a plain
+install works with no registry configuration or authentication:
 
 ```bash
-export GITHUB_TOKEN=ghp_...
 yarn install
 ```

--- a/example-bots/README.md
+++ b/example-bots/README.md
@@ -1,6 +1,6 @@
 # Example Bots with Custom Frontends
 
-This directory contains example bots demonstrating how to build custom trading bots with React dashboards using the `@the0/react` SDK.
+This directory contains example bots demonstrating how to build custom trading bots with React dashboards using the `the0-react` SDK.
 
 ## Examples
 
@@ -77,10 +77,10 @@ my-bot/
         └── bundle.js     # Built ESM bundle
 ```
 
-The frontend uses the `@the0/react` SDK to access bot events:
+The frontend uses the `the0-react` SDK to access bot events:
 
 ```tsx
-import { useThe0Events } from '@the0/react';
+import { useThe0Events } from 'the0-react';
 
 export default function Dashboard() {
   const { events, utils, loading } = useThe0Events();
@@ -136,12 +136,12 @@ The CLI automatically:
 
 ## SDK Installation
 
-The TypeScript examples use `@alexanderwanyoike/the0-node` from npm:
+The TypeScript examples use `the0-node` from npm:
 
 ```json
 {
   "dependencies": {
-    "@alexanderwanyoike/the0-node": "^0.3.1"
+    "the0-node": "^0.3.1"
   }
 }
 ```

--- a/example-bots/cpp-sma-crossover/frontend/.npmrc
+++ b/example-bots/cpp-sma-crossover/frontend/.npmrc
@@ -1,1 +1,0 @@
-@alexanderwanyoike:registry=https://npm.pkg.github.com

--- a/example-bots/cpp-sma-crossover/frontend/index.tsx
+++ b/example-bots/cpp-sma-crossover/frontend/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from "react";
-import { useThe0Events, BotEvent } from "@alexanderwanyoike/the0-react";
+import { useThe0Events, BotEvent } from "the0-react";
 
 export default function Dashboard() {
   const { events, utils, loading, error } = useThe0Events();

--- a/example-bots/cpp-sma-crossover/frontend/package.json
+++ b/example-bots/cpp-sma-crossover/frontend/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@alexanderwanyoike/the0-react": "^0.2.0",
+    "the0-react": "^0.2.0",
     "@types/react": "^19.0.0",
     "esbuild": "^0.24.0",
     "typescript": "^5.0.0"

--- a/example-bots/csharp-sma-crossover/frontend/.npmrc
+++ b/example-bots/csharp-sma-crossover/frontend/.npmrc
@@ -1,1 +1,0 @@
-@alexanderwanyoike:registry=https://npm.pkg.github.com

--- a/example-bots/csharp-sma-crossover/frontend/index.tsx
+++ b/example-bots/csharp-sma-crossover/frontend/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from "react";
-import { useThe0Events, BotEvent } from "@alexanderwanyoike/the0-react";
+import { useThe0Events, BotEvent } from "the0-react";
 
 export default function Dashboard() {
   const { events, utils, loading, error } = useThe0Events();

--- a/example-bots/csharp-sma-crossover/frontend/package.json
+++ b/example-bots/csharp-sma-crossover/frontend/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@alexanderwanyoike/the0-react": "^0.2.0",
+    "the0-react": "^0.2.0",
     "@types/react": "^19.0.0",
     "esbuild": "^0.24.0",
     "typescript": "^5.0.0"

--- a/example-bots/haskell-sma-crossover/frontend/.npmrc
+++ b/example-bots/haskell-sma-crossover/frontend/.npmrc
@@ -1,1 +1,0 @@
-@alexanderwanyoike:registry=https://npm.pkg.github.com

--- a/example-bots/haskell-sma-crossover/frontend/index.tsx
+++ b/example-bots/haskell-sma-crossover/frontend/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from "react";
-import { useThe0Events, BotEvent } from "@alexanderwanyoike/the0-react";
+import { useThe0Events, BotEvent } from "the0-react";
 
 export default function Dashboard() {
   const { events, utils, loading, error } = useThe0Events();

--- a/example-bots/haskell-sma-crossover/frontend/package.json
+++ b/example-bots/haskell-sma-crossover/frontend/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@alexanderwanyoike/the0-react": "^0.2.0",
+    "the0-react": "^0.2.0",
     "@types/react": "^19.0.0",
     "esbuild": "^0.24.0",
     "typescript": "^5.0.0"

--- a/example-bots/python-portfolio-tracker/README.md
+++ b/example-bots/python-portfolio-tracker/README.md
@@ -2,7 +2,7 @@
 
 A scheduled bot example that demonstrates:
 - Structured metric emission with structlog
-- Custom React frontend with `@the0/react` SDK
+- Custom React frontend with `the0-react` SDK
 - Portfolio value tracking and trade simulation
 
 ## What It Does

--- a/example-bots/python-portfolio-tracker/frontend/.npmrc
+++ b/example-bots/python-portfolio-tracker/frontend/.npmrc
@@ -1,1 +1,0 @@
-@alexanderwanyoike:registry=https://npm.pkg.github.com

--- a/example-bots/python-portfolio-tracker/frontend/index.tsx
+++ b/example-bots/python-portfolio-tracker/frontend/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from "react";
-import { useThe0Events, BotEvent } from "@alexanderwanyoike/the0-react";
+import { useThe0Events, BotEvent } from "the0-react";
 
 export default function Dashboard() {
   const { events, utils, loading, error } = useThe0Events();

--- a/example-bots/python-portfolio-tracker/frontend/package.json
+++ b/example-bots/python-portfolio-tracker/frontend/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@alexanderwanyoike/the0-react": "^0.2.0",
+    "the0-react": "^0.2.0",
     "@types/react": "^19.0.0",
     "esbuild": "^0.24.0",
     "typescript": "^5.0.0"

--- a/example-bots/python-portfolio-tracker/main_raw.py
+++ b/example-bots/python-portfolio-tracker/main_raw.py
@@ -5,7 +5,7 @@ A scheduled bot that simulates portfolio tracking with mock data.
 
 This example demonstrates:
 - Structured metric emission using structlog with _metric field
-- How the @the0/react SDK consumes these metrics in custom frontends
+- How the the0-react SDK consumes these metrics in custom frontends
 - Scheduled bot pattern (runs once per trigger, then exits)
 
 Metrics emitted:

--- a/example-bots/rust-sma-crossover/frontend/.npmrc
+++ b/example-bots/rust-sma-crossover/frontend/.npmrc
@@ -1,1 +1,0 @@
-@alexanderwanyoike:registry=https://npm.pkg.github.com

--- a/example-bots/rust-sma-crossover/frontend/index.tsx
+++ b/example-bots/rust-sma-crossover/frontend/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from "react";
-import { useThe0Events, BotEvent } from "@alexanderwanyoike/the0-react";
+import { useThe0Events, BotEvent } from "the0-react";
 
 export default function Dashboard() {
   const { events, utils, loading, error } = useThe0Events();

--- a/example-bots/rust-sma-crossover/frontend/package.json
+++ b/example-bots/rust-sma-crossover/frontend/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@alexanderwanyoike/the0-react": "^0.2.0",
+    "the0-react": "^0.2.0",
     "@types/react": "^19.0.0",
     "esbuild": "^0.24.0",
     "typescript": "^5.0.0"

--- a/example-bots/scala-sma-crossover/frontend/.npmrc
+++ b/example-bots/scala-sma-crossover/frontend/.npmrc
@@ -1,1 +1,0 @@
-@alexanderwanyoike:registry=https://npm.pkg.github.com

--- a/example-bots/scala-sma-crossover/frontend/index.tsx
+++ b/example-bots/scala-sma-crossover/frontend/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from "react";
-import { useThe0Events, BotEvent } from "@alexanderwanyoike/the0-react";
+import { useThe0Events, BotEvent } from "the0-react";
 
 export default function Dashboard() {
   const { events, utils, loading, error } = useThe0Events();

--- a/example-bots/scala-sma-crossover/frontend/package.json
+++ b/example-bots/scala-sma-crossover/frontend/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@alexanderwanyoike/the0-react": "^0.2.0",
+    "the0-react": "^0.2.0",
     "@types/react": "^19.0.0",
     "esbuild": "^0.24.0",
     "typescript": "^5.0.0"

--- a/example-bots/typescript-price-alerts/.npmrc
+++ b/example-bots/typescript-price-alerts/.npmrc
@@ -1,2 +1,0 @@
-@alexanderwanyoike:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/example-bots/typescript-price-alerts/README.md
+++ b/example-bots/typescript-price-alerts/README.md
@@ -2,7 +2,7 @@
 
 A realtime bot example that demonstrates:
 - Structured metric emission with pino logging
-- Custom React frontend with `@the0/react` SDK
+- Custom React frontend with `the0-react` SDK
 - Continuous price monitoring with alerts
 
 ## What It Does

--- a/example-bots/typescript-price-alerts/frontend/.npmrc
+++ b/example-bots/typescript-price-alerts/frontend/.npmrc
@@ -1,1 +1,0 @@
-@alexanderwanyoike:registry=https://npm.pkg.github.com

--- a/example-bots/typescript-price-alerts/frontend/index.tsx
+++ b/example-bots/typescript-price-alerts/frontend/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from "react";
-import { useThe0Events, BotEvent } from "@alexanderwanyoike/the0-react";
+import { useThe0Events, BotEvent } from "the0-react";
 
 export default function Dashboard() {
   const { events, utils, loading, error } = useThe0Events();

--- a/example-bots/typescript-price-alerts/frontend/package.json
+++ b/example-bots/typescript-price-alerts/frontend/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@alexanderwanyoike/the0-react": "^0.2.0",
+    "the0-react": "^0.2.0",
     "@types/react": "^19.0.0",
     "esbuild": "^0.24.0",
     "typescript": "^5.0.0"

--- a/example-bots/typescript-price-alerts/main.ts
+++ b/example-bots/typescript-price-alerts/main.ts
@@ -17,7 +17,7 @@
  * - Tracks alert_count for monitoring bot activity
  */
 
-import { parse, metric, sleep, success, state } from "@alexanderwanyoike/the0-node";
+import { parse, metric, sleep, success, state } from "the0-node";
 import pino from "pino";
 
 // Configure pino logger for structured JSON output

--- a/example-bots/typescript-price-alerts/package.json
+++ b/example-bots/typescript-price-alerts/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "pino": "^9.0.0",
-    "@alexanderwanyoike/the0-node": "^0.3.1"
+    "the0-node": "^0.3.1"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/example-bots/typescript-price-alerts/query.ts
+++ b/example-bots/typescript-price-alerts/query.ts
@@ -14,7 +14,7 @@
  *   /statistics    - Get overall bot statistics
  */
 
-import { query, state } from "@alexanderwanyoike/the0-node";
+import { query, state } from "the0-node";
 
 // Persistent state structure (matches main.ts)
 interface PersistedState {

--- a/frontend/src/contexts/bot-events-context.tsx
+++ b/frontend/src/contexts/bot-events-context.tsx
@@ -29,7 +29,7 @@ interface BotEventsContextValue {
   botId: string;
 }
 
-// Shared context - also accessible via @the0/react SDK
+// Shared context - also accessible via the0-react SDK
 declare global {
   interface Window {
     __THE0_EVENTS_CONTEXT__?: React.Context<BotEventsContextValue | null>;

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: the0
 description: An open-source algorithmic trading platform for creating, deploying, and managing trading bots
 type: application
-version: 0.9.6
-appVersion: "1.14.5"
+version: 0.9.7
+appVersion: "1.14.6"
 kubeVersion: ">=1.21.0-0"
 keywords:
   - trading
@@ -31,21 +31,13 @@ annotations:
       url: https://discord.gg/g5mp57nK
   artifacthub.io/changes: |
     - kind: fixed
-      description: Propagate NATS_URL into bot pods so live log streaming works in Kubernetes (sync sidecar and inline sync); changing it now reconciles existing pods and CronJobs
+      description: CLI bot bundles use forward slashes in zip entries so bundles built on Windows extract correctly; previously every Windows-deployed bot with dependencies failed at import time
     - kind: fixed
-      description: Publish log chunks to NATS before the MinIO append so live streaming latency is not gated on object storage writes
-    - kind: fixed
-      description: File watcher debounce gained a trailing-edge trigger so the final write of a burst syncs immediately instead of waiting for the backup ticker
-    - kind: fixed
-      description: Set PYTHONUNBUFFERED=1 on bot containers so Python metric output streams instead of sitting in the stdout buffer
-    - kind: fixed
-      description: Dashboards no longer unmount into loading screens on background refreshes; loading and error only surface when there is nothing to render
+      description: The gc service creates its MinIO buckets on startup instead of crash-looping on a fresh stack, and tolerates another service winning the bucket-creation race
     - kind: changed
-      description: All bot types stream over SSE by default, including scheduled bots; the refresh interval selector is replaced by a live connection status indicator
-    - kind: changed
-      description: Metrics log queries respect limit/offset and report hasMore honestly; dashboard metric history fetch raised to 1000 entries
+      description: The Node.js and React SDKs moved from GitHub Packages to the public npm registry as the0-node and the0-react; installs need no registry configuration or authentication
     - kind: added
-      description: React SDK context exposes optional isFetching, connected and lastUpdate fields so custom dashboards can render live indicators
+      description: SDK npm releases publish via GitHub Actions with npm trusted publishing (OIDC) and provenance attestations
   artifacthub.io/images: |
     - name: api
       image: ghcr.io/alexanderwanyoike/the0/api

--- a/runtime/internal/gc/gc.go
+++ b/runtime/internal/gc/gc.go
@@ -24,6 +24,7 @@ type IncompleteUploadInfo struct {
 
 // MinIOClient abstracts the MinIO operations needed by the GC.
 type MinIOClient interface {
+	EnsureBucket(ctx context.Context, bucket string) error
 	ListObjectNames(ctx context.Context, bucket, prefix string) ([]string, error)
 	ListObjectsWithInfo(ctx context.Context, bucket, prefix string) ([]ObjectInfo, error)
 	RemoveObject(ctx context.Context, bucket, name string) error
@@ -90,6 +91,16 @@ const staleIncompleteUploadAge = 1 * time.Hour
 // orphaned bot IDs in MinIO and deletes their artifacts.
 func (gc *GarbageCollector) Run(ctx context.Context) (*RunResult, error) {
 	result := &RunResult{}
+
+	// On a fresh deployment these buckets don't exist until the first bot
+	// writes logs or state; every other MinIO consumer in the runtime creates
+	// its bucket lazily, and without this the GC crash-loops on a new stack
+	// because listing a nonexistent bucket is an error.
+	for _, bucket := range []string{gc.logsBucket, gc.stateBucket} {
+		if err := gc.minio.EnsureBucket(ctx, bucket); err != nil {
+			return nil, fmt.Errorf("failed to ensure bucket %s exists: %w", bucket, err)
+		}
+	}
 
 	// 0. Clean up stale temp files (leaked by the old fire-and-forget goroutine bug)
 	result.StaleTempFiles = gc.cleanupStaleTempFiles(ctx)

--- a/runtime/internal/gc/gc_test.go
+++ b/runtime/internal/gc/gc_test.go
@@ -30,6 +30,20 @@ type mockMinIOClient struct {
 	// If set, AbortIncompleteUpload returns this error for keys matching abortErrKey.
 	abortErr    error
 	abortErrKey string
+
+	// Tracks buckets passed to EnsureBucket.
+	ensured []string
+	// If set, EnsureBucket returns this error for the matching bucket.
+	ensureErr       error
+	ensureErrBucket string
+}
+
+func (m *mockMinIOClient) EnsureBucket(ctx context.Context, bucket string) error {
+	if m.ensureErr != nil && (m.ensureErrBucket == "" || m.ensureErrBucket == bucket) {
+		return m.ensureErr
+	}
+	m.ensured = append(m.ensured, bucket)
+	return nil
 }
 
 func (m *mockMinIOClient) ListObjectNames(ctx context.Context, bucket, prefix string) ([]string, error) {
@@ -159,6 +173,31 @@ func TestGC_DeletesOrphanedArtifacts(t *testing.T) {
 	for _, d := range minio.deleted {
 		assert.NotContains(t, d, "bot-active")
 	}
+}
+
+func TestGC_CreatesMissingBucketsBeforeSweep(t *testing.T) {
+	minio := &mockMinIOClient{}
+	store := &mockBotStore{existingIDs: map[string]bool{}}
+
+	gc := NewGarbageCollector(GarbageCollectorOptions{MinIO: minio, Store: store, LogsBucket: "bot-logs", StateBucket: "bot-state"})
+	_, err := gc.Run(context.Background())
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"bot-logs", "bot-state"}, minio.ensured)
+}
+
+func TestGC_EnsureBucketErrorFailsSweep(t *testing.T) {
+	minio := &mockMinIOClient{
+		ensureErr:       errors.New("access denied"),
+		ensureErrBucket: "bot-state",
+	}
+	store := &mockBotStore{existingIDs: map[string]bool{}}
+
+	gc := NewGarbageCollector(GarbageCollectorOptions{MinIO: minio, Store: store, LogsBucket: "bot-logs", StateBucket: "bot-state"})
+	_, err := gc.Run(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bot-state")
 }
 
 func TestGC_NoOrphans(t *testing.T) {

--- a/runtime/internal/gc/minio_adapter.go
+++ b/runtime/internal/gc/minio_adapter.go
@@ -16,6 +16,17 @@ func NewMinIOAdapter(client *minio.Client) MinIOClient {
 	return &minioAdapter{client: client}
 }
 
+func (m *minioAdapter) EnsureBucket(ctx context.Context, bucket string) error {
+	exists, err := m.client.BucketExists(ctx, bucket)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	return m.client.MakeBucket(ctx, bucket, minio.MakeBucketOptions{})
+}
+
 func (m *minioAdapter) ListObjectNames(ctx context.Context, bucket, prefix string) ([]string, error) {
 	var names []string
 	for obj := range m.client.ListObjects(ctx, bucket, minio.ListObjectsOptions{

--- a/runtime/internal/gc/minio_adapter.go
+++ b/runtime/internal/gc/minio_adapter.go
@@ -16,15 +16,35 @@ func NewMinIOAdapter(client *minio.Client) MinIOClient {
 	return &minioAdapter{client: client}
 }
 
-func (m *minioAdapter) EnsureBucket(ctx context.Context, bucket string) error {
-	exists, err := m.client.BucketExists(ctx, bucket)
+// bucketAPI is the subset of minio.Client that ensureBucket needs, split out
+// so the concurrent-creation race can be tested without a live server.
+type bucketAPI interface {
+	BucketExists(ctx context.Context, bucket string) (bool, error)
+	MakeBucket(ctx context.Context, bucket string, opts minio.MakeBucketOptions) error
+}
+
+func ensureBucket(ctx context.Context, api bucketAPI, bucket string) error {
+	exists, err := api.BucketExists(ctx, bucket)
 	if err != nil {
 		return err
 	}
 	if exists {
 		return nil
 	}
-	return m.client.MakeBucket(ctx, bucket, minio.MakeBucketOptions{})
+	if err := api.MakeBucket(ctx, bucket, minio.MakeBucketOptions{}); err != nil {
+		// Several services create these buckets lazily, so on a fresh stack
+		// another one can win the create between our exists check and here.
+		// The bucket existing is all we need; only fail if it still doesn't.
+		if exists, checkErr := api.BucketExists(ctx, bucket); checkErr == nil && exists {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (m *minioAdapter) EnsureBucket(ctx context.Context, bucket string) error {
+	return ensureBucket(ctx, m.client, bucket)
 }
 
 func (m *minioAdapter) ListObjectNames(ctx context.Context, bucket, prefix string) ([]string, error) {

--- a/runtime/internal/gc/minio_adapter_test.go
+++ b/runtime/internal/gc/minio_adapter_test.go
@@ -1,0 +1,72 @@
+package gc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeBucketAPI simulates a bucket that can be created by a concurrent
+// consumer between the existence check and the create call.
+type fakeBucketAPI struct {
+	exists         bool
+	makeErr        error
+	existsAfterErr bool // bucket becomes visible after MakeBucket fails
+	makeCalls      int
+}
+
+func (f *fakeBucketAPI) BucketExists(ctx context.Context, bucket string) (bool, error) {
+	return f.exists, nil
+}
+
+func (f *fakeBucketAPI) MakeBucket(ctx context.Context, bucket string, opts minio.MakeBucketOptions) error {
+	f.makeCalls++
+	if f.makeErr != nil {
+		f.exists = f.existsAfterErr
+		return f.makeErr
+	}
+	f.exists = true
+	return nil
+}
+
+func TestEnsureBucket_CreatesMissingBucket(t *testing.T) {
+	api := &fakeBucketAPI{exists: false}
+
+	require.NoError(t, ensureBucket(context.Background(), api, "bot-logs"))
+	assert.Equal(t, 1, api.makeCalls)
+	assert.True(t, api.exists)
+}
+
+func TestEnsureBucket_SkipsCreateWhenBucketExists(t *testing.T) {
+	api := &fakeBucketAPI{exists: true}
+
+	require.NoError(t, ensureBucket(context.Background(), api, "bot-logs"))
+	assert.Equal(t, 0, api.makeCalls)
+}
+
+func TestEnsureBucket_ToleratesConcurrentCreation(t *testing.T) {
+	// Another consumer creates the bucket between BucketExists and MakeBucket;
+	// the create fails but the bucket is there, which is all that matters.
+	api := &fakeBucketAPI{
+		exists:         false,
+		makeErr:        errors.New("Your previous request to create the named bucket succeeded and you already own it."),
+		existsAfterErr: true,
+	}
+
+	require.NoError(t, ensureBucket(context.Background(), api, "bot-logs"))
+}
+
+func TestEnsureBucket_ReturnsErrorWhenCreateFailsAndBucketMissing(t *testing.T) {
+	api := &fakeBucketAPI{
+		exists:  false,
+		makeErr: errors.New("access denied"),
+	}
+
+	err := ensureBucket(context.Background(), api, "bot-logs")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "access denied")
+}

--- a/sdk/nodejs/README.md
+++ b/sdk/nodejs/README.md
@@ -1,23 +1,23 @@
-# @alexanderwanyoike/the0-node
+# the0-node
 
 Official SDK for building trading bots on the0 platform with Node.js and TypeScript.
 
 ## Installation
 
 ```bash
-npm install @alexanderwanyoike/the0-node
+npm install the0-node
 # or
-yarn add @alexanderwanyoike/the0-node
+yarn add the0-node
 ```
 
-> Migrating from GitHub Packages? This package now lives on the public npm
-> registry. Remove the `@alexanderwanyoike:registry` line from your `.npmrc`
-> (project or `~/.npmrc`) to pick up new versions.
+> Migrating from GitHub Packages? This package was previously published there
+> as `@alexanderwanyoike/the0-node`. Update your dependency to `the0-node` and remove the
+> `@alexanderwanyoike:registry` line from your `.npmrc` (project or `~/.npmrc`).
 
 ## Quick Start
 
 ```typescript
-import { parse, success, error, metric } from '@alexanderwanyoike/the0-node';
+import { parse, success, error, metric } from 'the0-node';
 
 // Parse bot configuration from environment
 const { id, config } = parse<{
@@ -123,7 +123,7 @@ await sleep(5000); // Wait 5 seconds
 Run on a cron schedule, execute once, and exit:
 
 ```typescript
-import { parse, success, error } from '@alexanderwanyoike/the0-node';
+import { parse, success, error } from 'the0-node';
 
 const { id, config } = parse();
 
@@ -141,7 +141,7 @@ try {
 Run continuously until stopped:
 
 ```typescript
-import { parse, metric, sleep } from '@alexanderwanyoike/the0-node';
+import { parse, metric, sleep } from 'the0-node';
 
 const { id, config } = parse();
 
@@ -164,8 +164,7 @@ This package is published to the public npm registry.
 
 ### Prerequisites
 
-Authenticate with npm as a user with publish rights to the
-`@alexanderwanyoike` scope:
+Authenticate with npm as a maintainer of the package:
 
 ```bash
 npm login

--- a/sdk/nodejs/README.md
+++ b/sdk/nodejs/README.md
@@ -4,20 +4,15 @@ Official SDK for building trading bots on the0 platform with Node.js and TypeScr
 
 ## Installation
 
-This package is published to GitHub Packages. First, configure npm to use GitHub Packages for the `@alexanderwanyoike` scope:
-
-```bash
-# Create or edit ~/.npmrc
-echo "@alexanderwanyoike:registry=https://npm.pkg.github.com" >> ~/.npmrc
-```
-
-Then install:
-
 ```bash
 npm install @alexanderwanyoike/the0-node
 # or
 yarn add @alexanderwanyoike/the0-node
 ```
+
+> Migrating from GitHub Packages? This package now lives on the public npm
+> registry. Remove the `@alexanderwanyoike:registry` line from your `.npmrc`
+> (project or `~/.npmrc`) to pick up new versions.
 
 ## Quick Start
 
@@ -165,19 +160,16 @@ while (true) {
 
 ## Publishing (Maintainers)
 
-This package is published to GitHub Packages.
+This package is published to the public npm registry.
 
 ### Prerequisites
 
-1. Create a GitHub Personal Access Token with `write:packages` scope:
-   https://github.com/settings/tokens/new?scopes=write:packages,read:packages
+Authenticate with npm as a user with publish rights to the
+`@alexanderwanyoike` scope:
 
-2. Authenticate with GitHub Packages:
-   ```bash
-   npm login --registry=https://npm.pkg.github.com
-   # Username: your-github-username
-   # Password: your-personal-access-token
-   ```
+```bash
+npm login
+```
 
 ### Publish
 
@@ -185,7 +177,7 @@ This package is published to GitHub Packages.
 # Build the package
 yarn build
 
-# Publish to GitHub Packages
+# Publish to npm
 npm publish
 ```
 

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -46,11 +46,14 @@
     "@types/node": "^20.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.3.0",
-    "vitest": "^1.0.0"
+    "vitest": "^3.2.6"
   },
   "resolutions": {
     "picomatch": "^4.0.4",
-    "rollup": "^4.59.0"
+    "rollup": "^4.59.0",
+    "vite": "^6.4.3",
+    "postcss": "^8.5.18",
+    "nanoid": "^3.3.18"
   },
   "engines": {
     "node": ">=18"

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -8,7 +8,7 @@
     "directory": "sdk/nodejs"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com",
+    "registry": "https://registry.npmjs.org",
     "access": "public"
   },
   "main": "dist/index.js",

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@alexanderwanyoike/the0-node",
+  "name": "the0-node",
   "version": "0.3.1",
   "description": "the0 SDK for Node.js/TypeScript trading bots",
   "repository": {

--- a/sdk/nodejs/src/index.ts
+++ b/sdk/nodejs/src/index.ts
@@ -6,7 +6,7 @@
  *
  * @example
  * ```typescript
- * import { parse, success, error, result, metric } from '@the0/sdk';
+ * import { parse, success, error, result, metric } from 'the0-node';
  *
  * // Parse bot configuration
  * const { id, config } = parse();

--- a/sdk/nodejs/src/query.ts
+++ b/sdk/nodejs/src/query.ts
@@ -5,10 +5,10 @@
  * custom read-only query handlers that can be executed on demand.
  *
  * Separate namespace from state and main SDK exports.
- * Users import: import { query } from '@the0/sdk';
+ * Users import: import { query } from 'the0-node';
  *
  * @example
- * import { query, state } from '@the0/sdk';
+ * import { query, state } from 'the0-node';
  *
  * query.handler('/portfolio', async (req) => {
  *   const positions = await state.get('positions', []);
@@ -142,7 +142,7 @@ export function getConfig(): Record<string, unknown> {
  *
  * @example
  * // In query.ts
- * import { query, state } from '@the0/sdk';
+ * import { query, state } from 'the0-node';
  *
  * query.handler('/portfolio', async (req) => {
  *   return { positions: await state.get('positions', []) };

--- a/sdk/nodejs/src/state.ts
+++ b/sdk/nodejs/src/state.ts
@@ -7,7 +7,7 @@
  *
  * @example
  * ```typescript
- * import { state } from '@the0/sdk';
+ * import { state } from 'the0-node';
  *
  * // Store state
  * state.set('portfolio', { AAPL: 100, GOOGL: 50 });

--- a/sdk/nodejs/yarn.lock
+++ b/sdk/nodejs/yarn.lock
@@ -2,257 +2,265 @@
 # yarn lockfile v1
 
 
-"@esbuild/aix-ppc64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz#c7184a326533fcdf1b8ee0733e21c713b975575f"
-  integrity sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==
+"@esbuild/aix-ppc64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz#80fcbe36130e58b7670511e888b8e88a259ed76c"
+  integrity sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==
 
 "@esbuild/aix-ppc64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz#521cbd968dcf362094034947f76fa1b18d2d403c"
   integrity sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==
 
-"@esbuild/android-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz#09d9b4357780da9ea3a7dfb833a1f1ff439b4052"
-  integrity sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==
+"@esbuild/android-arm64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz#8aa4965f8d0a7982dc21734bf6601323a66da752"
+  integrity sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==
 
 "@esbuild/android-arm64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz#61ea550962d8aa12a9b33194394e007657a6df57"
   integrity sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==
 
-"@esbuild/android-arm@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.21.5.tgz#9b04384fb771926dfa6d7ad04324ecb2ab9b2e28"
-  integrity sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==
+"@esbuild/android-arm@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.12.tgz#300712101f7f50f1d2627a162e6e09b109b6767a"
+  integrity sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==
 
 "@esbuild/android-arm@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.27.2.tgz#554887821e009dd6d853f972fde6c5143f1de142"
   integrity sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==
 
-"@esbuild/android-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.21.5.tgz#29918ec2db754cedcb6c1b04de8cd6547af6461e"
-  integrity sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==
+"@esbuild/android-x64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.12.tgz#87dfb27161202bdc958ef48bb61b09c758faee16"
+  integrity sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==
 
 "@esbuild/android-x64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.27.2.tgz#a7ce9d0721825fc578f9292a76d9e53334480ba2"
   integrity sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==
 
-"@esbuild/darwin-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz#e495b539660e51690f3928af50a76fb0a6ccff2a"
-  integrity sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==
+"@esbuild/darwin-arm64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz#79197898ec1ff745d21c071e1c7cc3c802f0c1fd"
+  integrity sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==
 
 "@esbuild/darwin-arm64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz#2cb7659bd5d109803c593cfc414450d5430c8256"
   integrity sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==
 
-"@esbuild/darwin-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz#c13838fa57372839abdddc91d71542ceea2e1e22"
-  integrity sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==
+"@esbuild/darwin-x64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz#146400a8562133f45c4d2eadcf37ddd09718079e"
+  integrity sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==
 
 "@esbuild/darwin-x64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz#e741fa6b1abb0cd0364126ba34ca17fd5e7bf509"
   integrity sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==
 
-"@esbuild/freebsd-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz#646b989aa20bf89fd071dd5dbfad69a3542e550e"
-  integrity sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==
+"@esbuild/freebsd-arm64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz#1c5f9ba7206e158fd2b24c59fa2d2c8bb47ca0fe"
+  integrity sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==
 
 "@esbuild/freebsd-arm64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz#2b64e7116865ca172d4ce034114c21f3c93e397c"
   integrity sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==
 
-"@esbuild/freebsd-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz#aa615cfc80af954d3458906e38ca22c18cf5c261"
-  integrity sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==
+"@esbuild/freebsd-x64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz#ea631f4a36beaac4b9279fa0fcc6ca29eaeeb2b3"
+  integrity sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==
 
 "@esbuild/freebsd-x64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz#e5252551e66f499e4934efb611812f3820e990bb"
   integrity sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==
 
-"@esbuild/linux-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz#70ac6fa14f5cb7e1f7f887bcffb680ad09922b5b"
-  integrity sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==
+"@esbuild/linux-arm64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz#e1066bce58394f1b1141deec8557a5f0a22f5977"
+  integrity sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==
 
 "@esbuild/linux-arm64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz#dc4acf235531cd6984f5d6c3b13dbfb7ddb303cb"
   integrity sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==
 
-"@esbuild/linux-arm@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz#fc6fd11a8aca56c1f6f3894f2bea0479f8f626b9"
-  integrity sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==
+"@esbuild/linux-arm@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz#452cd66b20932d08bdc53a8b61c0e30baf4348b9"
+  integrity sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==
 
 "@esbuild/linux-arm@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz#56a900e39240d7d5d1d273bc053daa295c92e322"
   integrity sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==
 
-"@esbuild/linux-ia32@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz#3271f53b3f93e3d093d518d1649d6d68d346ede2"
-  integrity sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==
+"@esbuild/linux-ia32@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz#b24f8acc45bcf54192c7f2f3be1b53e6551eafe0"
+  integrity sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==
 
 "@esbuild/linux-ia32@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz#d4a36d473360f6870efcd19d52bbfff59a2ed1cc"
   integrity sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==
 
-"@esbuild/linux-loong64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz#ed62e04238c57026aea831c5a130b73c0f9f26df"
-  integrity sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==
+"@esbuild/linux-loong64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz#f9cfffa7fc8322571fbc4c8b3268caf15bd81ad0"
+  integrity sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==
 
 "@esbuild/linux-loong64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz#fcf0ab8c3eaaf45891d0195d4961cb18b579716a"
   integrity sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==
 
-"@esbuild/linux-mips64el@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz#e79b8eb48bf3b106fadec1ac8240fb97b4e64cbe"
-  integrity sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==
+"@esbuild/linux-mips64el@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz#575a14bd74644ffab891adc7d7e60d275296f2cd"
+  integrity sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==
 
 "@esbuild/linux-mips64el@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz#598b67d34048bb7ee1901cb12e2a0a434c381c10"
   integrity sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==
 
-"@esbuild/linux-ppc64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz#5f2203860a143b9919d383ef7573521fb154c3e4"
-  integrity sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==
+"@esbuild/linux-ppc64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz#75b99c70a95fbd5f7739d7692befe60601591869"
+  integrity sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==
 
 "@esbuild/linux-ppc64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz#3846c5df6b2016dab9bc95dde26c40f11e43b4c0"
   integrity sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==
 
-"@esbuild/linux-riscv64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz#07bcafd99322d5af62f618cb9e6a9b7f4bb825dc"
-  integrity sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==
+"@esbuild/linux-riscv64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz#2e3259440321a44e79ddf7535c325057da875cd6"
+  integrity sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==
 
 "@esbuild/linux-riscv64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz#173d4475b37c8d2c3e1707e068c174bb3f53d07d"
   integrity sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==
 
-"@esbuild/linux-s390x@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz#b7ccf686751d6a3e44b8627ababc8be3ef62d8de"
-  integrity sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==
+"@esbuild/linux-s390x@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz#17676cabbfe5928da5b2a0d6df5d58cd08db2663"
+  integrity sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==
 
 "@esbuild/linux-s390x@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz#f7a4790105edcab8a5a31df26fbfac1aa3dacfab"
   integrity sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==
 
-"@esbuild/linux-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz#6d8f0c768e070e64309af8004bb94e68ab2bb3b0"
-  integrity sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==
+"@esbuild/linux-x64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz#0583775685ca82066d04c3507f09524d3cd7a306"
+  integrity sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==
 
 "@esbuild/linux-x64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz#2ecc1284b1904aeb41e54c9ddc7fcd349b18f650"
   integrity sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==
 
+"@esbuild/netbsd-arm64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz#f04c4049cb2e252fe96b16fed90f70746b13f4a4"
+  integrity sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==
+
 "@esbuild/netbsd-arm64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz#e2863c2cd1501845995cb11adf26f7fe4be527b0"
   integrity sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==
 
-"@esbuild/netbsd-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz#bbe430f60d378ecb88decb219c602667387a6047"
-  integrity sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==
+"@esbuild/netbsd-x64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz#77da0d0a0d826d7c921eea3d40292548b258a076"
+  integrity sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==
 
 "@esbuild/netbsd-x64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz#93f7609e2885d1c0b5a1417885fba8d1fcc41272"
   integrity sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==
 
+"@esbuild/openbsd-arm64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz#6296f5867aedef28a81b22ab2009c786a952dccd"
+  integrity sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==
+
 "@esbuild/openbsd-arm64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz#a1985604a203cdc325fd47542e106fafd698f02e"
   integrity sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==
 
-"@esbuild/openbsd-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz#99d1cf2937279560d2104821f5ccce220cb2af70"
-  integrity sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==
+"@esbuild/openbsd-x64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz#f8d23303360e27b16cf065b23bbff43c14142679"
+  integrity sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==
 
 "@esbuild/openbsd-x64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz#8209e46c42f1ffbe6e4ef77a32e1f47d404ad42a"
   integrity sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==
 
+"@esbuild/openharmony-arm64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz#49e0b768744a3924be0d7fd97dd6ce9b2923d88d"
+  integrity sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==
+
 "@esbuild/openharmony-arm64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz#8fade4441893d9cc44cbd7dcf3776f508ab6fb2f"
   integrity sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==
 
-"@esbuild/sunos-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz#08741512c10d529566baba837b4fe052c8f3487b"
-  integrity sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==
+"@esbuild/sunos-x64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz#a6ed7d6778d67e528c81fb165b23f4911b9b13d6"
+  integrity sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==
 
 "@esbuild/sunos-x64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz#980d4b9703a16f0f07016632424fc6d9a789dfc2"
   integrity sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==
 
-"@esbuild/win32-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz#675b7385398411240735016144ab2e99a60fc75d"
-  integrity sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==
+"@esbuild/win32-arm64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz#9ac14c378e1b653af17d08e7d3ce34caef587323"
+  integrity sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==
 
 "@esbuild/win32-arm64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz#1c09a3633c949ead3d808ba37276883e71f6111a"
   integrity sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==
 
-"@esbuild/win32-ia32@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz#1bfc3ce98aa6ca9a0969e4d2af72144c59c1193b"
-  integrity sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==
+"@esbuild/win32-ia32@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz#918942dcbbb35cc14fca39afb91b5e6a3d127267"
+  integrity sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==
 
 "@esbuild/win32-ia32@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz#1b1e3a63ad4bef82200fef4e369e0fff7009eee5"
   integrity sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==
 
-"@esbuild/win32-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz#acad351d582d157bb145535db2a6ff53dd514b5c"
-  integrity sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==
+"@esbuild/win32-x64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz#9bdad8176be7811ad148d1f8772359041f46c6c5"
+  integrity sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==
 
 "@esbuild/win32-x64@0.27.2":
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz#9e585ab6086bef994c6e8a5b3a0481219ada862b"
   integrity sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==
-
-"@jest/schemas@^29.6.3":
-  version "29.6.3"
-  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
-  integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
-  dependencies:
-    "@sinclair/typebox" "^0.27.8"
 
 "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.13"
@@ -405,10 +413,18 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz#cc6f094a3ffe5556bb4a831ee6fb572b8cd81a75"
   integrity sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==
 
-"@sinclair/typebox@^0.27.8":
-  version "0.27.8"
-  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
-  integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
+"@types/chai@^5.2.2":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.3.tgz#8e9cd9e1c3581fa6b341a5aed5588eb285be0b4a"
+  integrity sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==
+  dependencies:
+    "@types/deep-eql" "*"
+    assertion-error "^2.0.1"
+
+"@types/deep-eql@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
+  integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
 "@types/estree@1.0.8", "@types/estree@^1.0.0":
   version "1.0.8"
@@ -422,76 +438,81 @@
   dependencies:
     undici-types "~6.21.0"
 
-"@vitest/expect@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-1.6.1.tgz#b90c213f587514a99ac0bf84f88cff9042b0f14d"
-  integrity sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==
+"@vitest/expect@3.2.7":
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.2.7.tgz#70a34158383d008c3bf5d802e2643317f09df6d8"
+  integrity sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==
   dependencies:
-    "@vitest/spy" "1.6.1"
-    "@vitest/utils" "1.6.1"
-    chai "^4.3.10"
+    "@types/chai" "^5.2.2"
+    "@vitest/spy" "3.2.7"
+    "@vitest/utils" "3.2.7"
+    chai "^5.2.0"
+    tinyrainbow "^2.0.0"
 
-"@vitest/runner@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-1.6.1.tgz#10f5857c3e376218d58c2bfacfea1161e27e117f"
-  integrity sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==
+"@vitest/mocker@3.2.7":
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.2.7.tgz#331be944cb783c642dd42bd743411aca24ea0466"
+  integrity sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==
   dependencies:
-    "@vitest/utils" "1.6.1"
-    p-limit "^5.0.0"
-    pathe "^1.1.1"
-
-"@vitest/snapshot@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-1.6.1.tgz#90414451a634bb36cd539ccb29ae0d048a8c0479"
-  integrity sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==
-  dependencies:
-    magic-string "^0.30.5"
-    pathe "^1.1.1"
-    pretty-format "^29.7.0"
-
-"@vitest/spy@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-1.6.1.tgz#33376be38a5ed1ecd829eb986edaecc3e798c95d"
-  integrity sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==
-  dependencies:
-    tinyspy "^2.2.0"
-
-"@vitest/utils@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-1.6.1.tgz#6d2f36cb6d866f2bbf59da854a324d6bf8040f17"
-  integrity sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==
-  dependencies:
-    diff-sequences "^29.6.3"
+    "@vitest/spy" "3.2.7"
     estree-walker "^3.0.3"
-    loupe "^2.3.7"
-    pretty-format "^29.7.0"
+    magic-string "^0.30.17"
 
-acorn-walk@^8.3.2:
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.4.tgz#794dd169c3977edf4ba4ea47583587c5866236b7"
-  integrity sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==
+"@vitest/pretty-format@3.2.7", "@vitest/pretty-format@^3.2.7":
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.2.7.tgz#2a7b593f8e007e9d8ef7e7343aa30ec73fdeaf29"
+  integrity sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==
   dependencies:
-    acorn "^8.11.0"
+    tinyrainbow "^2.0.0"
 
-acorn@^8.11.0, acorn@^8.15.0:
+"@vitest/runner@3.2.7":
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-3.2.7.tgz#c0c080228189f1fa6cda40f59be09d746b0aca51"
+  integrity sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==
+  dependencies:
+    "@vitest/utils" "3.2.7"
+    pathe "^2.0.3"
+    strip-literal "^3.0.0"
+
+"@vitest/snapshot@3.2.7":
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-3.2.7.tgz#a3a7e1950ce99ec4cf02395e20ddca403b6c818e"
+  integrity sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==
+  dependencies:
+    "@vitest/pretty-format" "3.2.7"
+    magic-string "^0.30.17"
+    pathe "^2.0.3"
+
+"@vitest/spy@3.2.7":
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-3.2.7.tgz#ca7fbee44019523ca450395d9a2284ce9ece1f31"
+  integrity sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==
+  dependencies:
+    tinyspy "^4.0.3"
+
+"@vitest/utils@3.2.7":
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-3.2.7.tgz#302c8126211ac4dfea87b3b5085c098d6d22e89e"
+  integrity sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==
+  dependencies:
+    "@vitest/pretty-format" "3.2.7"
+    loupe "^3.1.4"
+    tinyrainbow "^2.0.0"
+
+acorn@^8.15.0:
   version "8.15.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
-
-ansi-styles@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
-  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 any-promise@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
   integrity sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==
 
-assertion-error@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
-  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
 
 bundle-require@^5.1.0:
   version "5.1.0"
@@ -505,25 +526,21 @@ cac@^6.7.14:
   resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
   integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
 
-chai@^4.3.10:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-4.5.0.tgz#707e49923afdd9b13a8b0b47d33d732d13812fd8"
-  integrity sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==
+chai@^5.2.0:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.3.3.tgz#dd3da955e270916a4bd3f625f4b919996ada7e06"
+  integrity sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==
   dependencies:
-    assertion-error "^1.1.0"
-    check-error "^1.0.3"
-    deep-eql "^4.1.3"
-    get-func-name "^2.0.2"
-    loupe "^2.3.6"
-    pathval "^1.1.1"
-    type-detect "^4.1.0"
+    assertion-error "^2.0.1"
+    check-error "^2.1.1"
+    deep-eql "^5.0.1"
+    loupe "^3.1.0"
+    pathval "^2.0.0"
 
-check-error@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.3.tgz#a6502e4312a7ee969f646e83bb3ddd56281bd694"
-  integrity sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==
-  dependencies:
-    get-func-name "^2.0.2"
+check-error@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.3.tgz#2427361117b70cca8dc89680ead32b157019caf5"
+  integrity sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==
 
 chokidar@^4.0.3:
   version "4.0.3"
@@ -547,62 +564,54 @@ consola@^3.4.0:
   resolved "https://registry.yarnpkg.com/consola/-/consola-3.4.2.tgz#5af110145397bb67afdab77013fdc34cae590ea7"
   integrity sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==
 
-cross-spawn@^7.0.3:
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
-  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
-  dependencies:
-    path-key "^3.1.0"
-    shebang-command "^2.0.0"
-    which "^2.0.1"
-
-debug@^4.3.4, debug@^4.4.0:
+debug@^4.4.0, debug@^4.4.1:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
 
-deep-eql@^4.1.3:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.4.tgz#d0d3912865911bb8fac5afb4e3acfa6a28dc72b7"
-  integrity sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==
-  dependencies:
-    type-detect "^4.0.0"
+deep-eql@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
+  integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
 
-diff-sequences@^29.6.3:
-  version "29.6.3"
-  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
-  integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
+es-module-lexer@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
 
-esbuild@^0.21.3:
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.21.5.tgz#9ca301b120922959b766360d8ac830da0d02997d"
-  integrity sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==
+esbuild@^0.25.0:
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.25.12.tgz#97a1d041f4ab00c2fce2f838d2b9969a2d2a97a5"
+  integrity sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==
   optionalDependencies:
-    "@esbuild/aix-ppc64" "0.21.5"
-    "@esbuild/android-arm" "0.21.5"
-    "@esbuild/android-arm64" "0.21.5"
-    "@esbuild/android-x64" "0.21.5"
-    "@esbuild/darwin-arm64" "0.21.5"
-    "@esbuild/darwin-x64" "0.21.5"
-    "@esbuild/freebsd-arm64" "0.21.5"
-    "@esbuild/freebsd-x64" "0.21.5"
-    "@esbuild/linux-arm" "0.21.5"
-    "@esbuild/linux-arm64" "0.21.5"
-    "@esbuild/linux-ia32" "0.21.5"
-    "@esbuild/linux-loong64" "0.21.5"
-    "@esbuild/linux-mips64el" "0.21.5"
-    "@esbuild/linux-ppc64" "0.21.5"
-    "@esbuild/linux-riscv64" "0.21.5"
-    "@esbuild/linux-s390x" "0.21.5"
-    "@esbuild/linux-x64" "0.21.5"
-    "@esbuild/netbsd-x64" "0.21.5"
-    "@esbuild/openbsd-x64" "0.21.5"
-    "@esbuild/sunos-x64" "0.21.5"
-    "@esbuild/win32-arm64" "0.21.5"
-    "@esbuild/win32-ia32" "0.21.5"
-    "@esbuild/win32-x64" "0.21.5"
+    "@esbuild/aix-ppc64" "0.25.12"
+    "@esbuild/android-arm" "0.25.12"
+    "@esbuild/android-arm64" "0.25.12"
+    "@esbuild/android-x64" "0.25.12"
+    "@esbuild/darwin-arm64" "0.25.12"
+    "@esbuild/darwin-x64" "0.25.12"
+    "@esbuild/freebsd-arm64" "0.25.12"
+    "@esbuild/freebsd-x64" "0.25.12"
+    "@esbuild/linux-arm" "0.25.12"
+    "@esbuild/linux-arm64" "0.25.12"
+    "@esbuild/linux-ia32" "0.25.12"
+    "@esbuild/linux-loong64" "0.25.12"
+    "@esbuild/linux-mips64el" "0.25.12"
+    "@esbuild/linux-ppc64" "0.25.12"
+    "@esbuild/linux-riscv64" "0.25.12"
+    "@esbuild/linux-s390x" "0.25.12"
+    "@esbuild/linux-x64" "0.25.12"
+    "@esbuild/netbsd-arm64" "0.25.12"
+    "@esbuild/netbsd-x64" "0.25.12"
+    "@esbuild/openbsd-arm64" "0.25.12"
+    "@esbuild/openbsd-x64" "0.25.12"
+    "@esbuild/openharmony-arm64" "0.25.12"
+    "@esbuild/sunos-x64" "0.25.12"
+    "@esbuild/win32-arm64" "0.25.12"
+    "@esbuild/win32-ia32" "0.25.12"
+    "@esbuild/win32-x64" "0.25.12"
 
 esbuild@^0.27.0:
   version "0.27.2"
@@ -643,22 +652,12 @@ estree-walker@^3.0.3:
   dependencies:
     "@types/estree" "^1.0.0"
 
-execa@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-8.0.1.tgz#51f6a5943b580f963c3ca9c6321796db8cc39b8c"
-  integrity sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==
-  dependencies:
-    cross-spawn "^7.0.3"
-    get-stream "^8.0.1"
-    human-signals "^5.0.0"
-    is-stream "^3.0.0"
-    merge-stream "^2.0.0"
-    npm-run-path "^5.1.0"
-    onetime "^6.0.0"
-    signal-exit "^4.1.0"
-    strip-final-newline "^3.0.0"
+expect-type@^1.2.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.4.0.tgz#24edf7f0cc69a44d008567ba4594ab96f3c3a3d6"
+  integrity sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==
 
-fdir@^6.5.0:
+fdir@^6.4.4, fdir@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
@@ -676,31 +675,6 @@ fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
-get-func-name@^2.0.1, get-func-name@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.2.tgz#0d7cf20cd13fda808669ffa88f4ffc7a3943fc41"
-  integrity sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==
-
-get-stream@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-8.0.1.tgz#def9dfd71742cd7754a7761ed43749a27d02eca2"
-  integrity sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==
-
-human-signals@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
-  integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
-
-is-stream@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
-  integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
-
-isexe@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
-  integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
 joycon@^3.1.1:
   version "3.1.1"
@@ -727,39 +701,19 @@ load-tsconfig@^0.2.3:
   resolved "https://registry.yarnpkg.com/load-tsconfig/-/load-tsconfig-0.2.5.tgz#453b8cd8961bfb912dea77eb6c168fe8cca3d3a1"
   integrity sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==
 
-local-pkg@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.5.1.tgz#69658638d2a95287534d4c2fff757980100dbb6d"
-  integrity sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==
-  dependencies:
-    mlly "^1.7.3"
-    pkg-types "^1.2.1"
+loupe@^3.1.0, loupe@^3.1.4:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.2.1.tgz#0095cf56dc5b7a9a7c08ff5b1a8796ec8ad17e76"
+  integrity sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==
 
-loupe@^2.3.6, loupe@^2.3.7:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.7.tgz#6e69b7d4db7d3ab436328013d37d1c8c3540c697"
-  integrity sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==
-  dependencies:
-    get-func-name "^2.0.1"
-
-magic-string@^0.30.17, magic-string@^0.30.5:
+magic-string@^0.30.17:
   version "0.30.21"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
   integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.5"
 
-merge-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
-  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
-
-mimic-fn@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
-  integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
-
-mlly@^1.7.3, mlly@^1.7.4:
+mlly@^1.7.4:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/mlly/-/mlly-1.8.0.tgz#e074612b938af8eba1eaf43299cbc89cb72d824e"
   integrity sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==
@@ -783,68 +737,32 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nanoid@^3.3.11:
-  version "3.3.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
-  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
-
-npm-run-path@^5.1.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-5.3.0.tgz#e23353d0ebb9317f174e93417e4a4d82d0249e9f"
-  integrity sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==
-  dependencies:
-    path-key "^4.0.0"
+nanoid@^3.3.17, nanoid@^3.3.18:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
-onetime@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-6.0.0.tgz#7c24c18ed1fd2e9bca4bd26806a33613c77d34b4"
-  integrity sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==
-  dependencies:
-    mimic-fn "^4.0.0"
-
-p-limit@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-5.0.0.tgz#6946d5b7140b649b7a33a027d89b4c625b3a5985"
-  integrity sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==
-  dependencies:
-    yocto-queue "^1.0.0"
-
-path-key@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
-  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
-
-path-key@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
-  integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
-
-pathe@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
-  integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
-
 pathe@^2.0.1, pathe@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
 
-pathval@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
-  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
+pathval@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.1.tgz#8855c5a2899af072d6ac05d11e46045ad0dc605d"
+  integrity sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==
 
-picocolors@^1.0.0, picocolors@^1.1.1:
+picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^4.0.3, picomatch@^4.0.4:
+picomatch@^4.0.2, picomatch@^4.0.3, picomatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
@@ -854,7 +772,7 @@ pirates@^4.0.1:
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.7.tgz#643b4a18c4257c8a65104b73f3049ce9a0a15e22"
   integrity sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==
 
-pkg-types@^1.2.1, pkg-types@^1.3.1:
+pkg-types@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/pkg-types/-/pkg-types-1.3.1.tgz#bd7cc70881192777eef5326c19deb46e890917df"
   integrity sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==
@@ -870,28 +788,14 @@ postcss-load-config@^6.0.1:
   dependencies:
     lilconfig "^3.1.1"
 
-postcss@^8.4.43:
-  version "8.5.6"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.6.tgz#2825006615a619b4f62a9e7426cc120b349a8f3c"
-  integrity sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==
+postcss@^8.5.18, postcss@^8.5.3:
+  version "8.5.26"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.26.tgz#6e75135780c7e10df3433bf2266c552d35c8c620"
+  integrity sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==
   dependencies:
-    nanoid "^3.3.11"
+    nanoid "^3.3.17"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
-
-pretty-format@^29.7.0:
-  version "29.7.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
-  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
-  dependencies:
-    "@jest/schemas" "^29.6.3"
-    ansi-styles "^5.0.0"
-    react-is "^18.0.0"
-
-react-is@^18.0.0:
-  version "18.3.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
-  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 readdirp@^4.0.1:
   version "4.1.2"
@@ -903,7 +807,7 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-rollup@^4.20.0, rollup@^4.34.8, rollup@^4.59.0:
+rollup@^4.34.8, rollup@^4.34.9, rollup@^4.59.0:
   version "4.60.3"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.60.3.tgz#789258d41d090687d0ca7e80e8583d733711ddd3"
   integrity sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==
@@ -937,27 +841,10 @@ rollup@^4.20.0, rollup@^4.34.8, rollup@^4.59.0:
     "@rollup/rollup-win32-x64-msvc" "4.60.3"
     fsevents "~2.3.2"
 
-shebang-command@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
-  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
-  dependencies:
-    shebang-regex "^3.0.0"
-
-shebang-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
-  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
-
 siginfo@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
   integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
-
-signal-exit@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
-  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
 source-map-js@^1.2.1:
   version "1.2.1"
@@ -974,20 +861,15 @@ stackback@0.0.2:
   resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
   integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
 
-std-env@^3.5.0:
+std-env@^3.9.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.10.0.tgz#d810b27e3a073047b2b5e40034881f5ea6f9c83b"
   integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
 
-strip-final-newline@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
-  integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
-
-strip-literal@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-2.1.1.tgz#26906e65f606d49f748454a08084e94190c2e5ad"
-  integrity sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==
+strip-literal@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-3.1.0.tgz#222b243dd2d49c0bcd0de8906adbd84177196032"
+  integrity sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==
   dependencies:
     js-tokens "^9.0.1"
 
@@ -1018,7 +900,7 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-tinybench@^2.5.1:
+tinybench@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
   integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
@@ -1036,15 +918,28 @@ tinyglobby@^0.2.11:
     fdir "^6.5.0"
     picomatch "^4.0.3"
 
-tinypool@^0.8.3:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.8.4.tgz#e217fe1270d941b39e98c625dcecebb1408c9aa8"
-  integrity sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==
+tinyglobby@^0.2.13, tinyglobby@^0.2.14:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
+  integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
 
-tinyspy@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-2.2.1.tgz#117b2342f1f38a0dbdcc73a50a454883adf861d1"
-  integrity sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==
+tinypool@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.1.1.tgz#059f2d042bd37567fbc017d3d426bdd2a2612591"
+  integrity sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==
+
+tinyrainbow@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-2.0.0.tgz#9509b2162436315e80e3eee0fcce4474d2444294"
+  integrity sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==
+
+tinyspy@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-4.0.4.tgz#d77a002fb53a88aa1429b419c1c92492e0c81f78"
+  integrity sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==
 
 tree-kill@^1.2.2:
   version "1.2.2"
@@ -1079,11 +974,6 @@ tsup@^8.0.0:
     tinyglobby "^0.2.11"
     tree-kill "^1.2.2"
 
-type-detect@^4.0.0, type-detect@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.1.0.tgz#deb2453e8f08dcae7ae98c626b13dddb0155906c"
-  integrity sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==
-
 typescript@^5.3.0:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
@@ -1099,70 +989,64 @@ undici-types@~6.21.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
-vite-node@1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-1.6.1.tgz#fff3ef309296ea03ceaa6ca4bb660922f5416c57"
-  integrity sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==
+vite-node@3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-3.2.4.tgz#f3676d94c4af1e76898c162c92728bca65f7bb07"
+  integrity sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==
   dependencies:
     cac "^6.7.14"
-    debug "^4.3.4"
-    pathe "^1.1.1"
-    picocolors "^1.0.0"
-    vite "^5.0.0"
+    debug "^4.4.1"
+    es-module-lexer "^1.7.0"
+    pathe "^2.0.3"
+    vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
 
-vite@^5.0.0:
-  version "5.4.21"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.21.tgz#84a4f7c5d860b071676d39ba513c0d598fdc7027"
-  integrity sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==
+"vite@^5.0.0 || ^6.0.0 || ^7.0.0-0", vite@^6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-6.4.3.tgz#85a164db7ce706f2a776812efa2b340f1721858e"
+  integrity sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==
   dependencies:
-    esbuild "^0.21.3"
-    postcss "^8.4.43"
-    rollup "^4.20.0"
+    esbuild "^0.25.0"
+    fdir "^6.4.4"
+    picomatch "^4.0.2"
+    postcss "^8.5.3"
+    rollup "^4.34.9"
+    tinyglobby "^0.2.13"
   optionalDependencies:
     fsevents "~2.3.3"
 
-vitest@^1.0.0:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-1.6.1.tgz#b4a3097adf8f79ac18bc2e2e0024c534a7a78d2f"
-  integrity sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==
+vitest@^3.2.6:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.2.7.tgz#1944b6ed013a25fd26a73d18e1af92c10a57af6c"
+  integrity sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==
   dependencies:
-    "@vitest/expect" "1.6.1"
-    "@vitest/runner" "1.6.1"
-    "@vitest/snapshot" "1.6.1"
-    "@vitest/spy" "1.6.1"
-    "@vitest/utils" "1.6.1"
-    acorn-walk "^8.3.2"
-    chai "^4.3.10"
-    debug "^4.3.4"
-    execa "^8.0.1"
-    local-pkg "^0.5.0"
-    magic-string "^0.30.5"
-    pathe "^1.1.1"
-    picocolors "^1.0.0"
-    std-env "^3.5.0"
-    strip-literal "^2.0.0"
-    tinybench "^2.5.1"
-    tinypool "^0.8.3"
-    vite "^5.0.0"
-    vite-node "1.6.1"
-    why-is-node-running "^2.2.2"
+    "@types/chai" "^5.2.2"
+    "@vitest/expect" "3.2.7"
+    "@vitest/mocker" "3.2.7"
+    "@vitest/pretty-format" "^3.2.7"
+    "@vitest/runner" "3.2.7"
+    "@vitest/snapshot" "3.2.7"
+    "@vitest/spy" "3.2.7"
+    "@vitest/utils" "3.2.7"
+    chai "^5.2.0"
+    debug "^4.4.1"
+    expect-type "^1.2.1"
+    magic-string "^0.30.17"
+    pathe "^2.0.3"
+    picomatch "^4.0.2"
+    std-env "^3.9.0"
+    tinybench "^2.9.0"
+    tinyexec "^0.3.2"
+    tinyglobby "^0.2.14"
+    tinypool "^1.1.1"
+    tinyrainbow "^2.0.0"
+    vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+    vite-node "3.2.4"
+    why-is-node-running "^2.3.0"
 
-which@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
-  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
-  dependencies:
-    isexe "^2.0.0"
-
-why-is-node-running@^2.2.2:
+why-is-node-running@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
   integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
   dependencies:
     siginfo "^2.0.0"
     stackback "0.0.2"
-
-yocto-queue@^1.0.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.2.tgz#3e09c95d3f1aa89a58c114c99223edf639152c00"
-  integrity sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==

--- a/sdk/react/README.md
+++ b/sdk/react/README.md
@@ -1,23 +1,23 @@
-# @alexanderwanyoike/the0-react
+# the0-react
 
 React SDK for building custom bot dashboards on the0 platform.
 
 ## Installation
 
 ```bash
-npm install @alexanderwanyoike/the0-react
+npm install the0-react
 # or
-yarn add @alexanderwanyoike/the0-react
+yarn add the0-react
 ```
 
-> Migrating from GitHub Packages? This package now lives on the public npm
-> registry. Remove the `@alexanderwanyoike:registry` line from your `.npmrc`
-> (project or `~/.npmrc`) to pick up new versions.
+> Migrating from GitHub Packages? This package was previously published there
+> as `@alexanderwanyoike/the0-react`. Update your dependency to `the0-react` and remove the
+> `@alexanderwanyoike:registry` line from your `.npmrc` (project or `~/.npmrc`).
 
 ## Usage
 
 ```tsx
-import { useThe0Events } from '@alexanderwanyoike/the0-react';
+import { useThe0Events } from 'the0-react';
 
 export default function Dashboard() {
   const { events, utils, loading, error } = useThe0Events();
@@ -119,8 +119,7 @@ This package is published to the public npm registry.
 
 ### Prerequisites
 
-Authenticate with npm as a user with publish rights to the
-`@alexanderwanyoike` scope:
+Authenticate with npm as a maintainer of the package:
 
 ```bash
 npm login

--- a/sdk/react/README.md
+++ b/sdk/react/README.md
@@ -4,20 +4,15 @@ React SDK for building custom bot dashboards on the0 platform.
 
 ## Installation
 
-This package is published to GitHub Packages. First, configure npm to use GitHub Packages for the `@alexanderwanyoike` scope:
-
-```bash
-# Create or edit ~/.npmrc
-echo "@alexanderwanyoike:registry=https://npm.pkg.github.com" >> ~/.npmrc
-```
-
-Then install:
-
 ```bash
 npm install @alexanderwanyoike/the0-react
 # or
 yarn add @alexanderwanyoike/the0-react
 ```
+
+> Migrating from GitHub Packages? This package now lives on the public npm
+> registry. Remove the `@alexanderwanyoike:registry` line from your `.npmrc`
+> (project or `~/.npmrc`) to pick up new versions.
 
 ## Usage
 
@@ -120,19 +115,16 @@ esbuild frontend/index.tsx \
 
 ## Publishing (Maintainers)
 
-This package is published to GitHub Packages.
+This package is published to the public npm registry.
 
 ### Prerequisites
 
-1. Create a GitHub Personal Access Token with `write:packages` scope:
-   https://github.com/settings/tokens/new?scopes=write:packages,read:packages
+Authenticate with npm as a user with publish rights to the
+`@alexanderwanyoike` scope:
 
-2. Authenticate with GitHub Packages:
-   ```bash
-   npm login --registry=https://npm.pkg.github.com
-   # Username: your-github-username
-   # Password: your-personal-access-token
-   ```
+```bash
+npm login
+```
 
 ### Publish
 
@@ -140,7 +132,7 @@ This package is published to GitHub Packages.
 # Build the package
 yarn build
 
-# Publish to GitHub Packages
+# Publish to npm
 npm publish
 ```
 

--- a/sdk/react/package.json
+++ b/sdk/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@alexanderwanyoike/the0-react",
+  "name": "the0-react",
   "version": "0.2.0",
   "description": "React SDK for the0 bot custom frontends",
   "repository": {

--- a/sdk/react/package.json
+++ b/sdk/react/package.json
@@ -8,7 +8,7 @@
     "directory": "sdk/react"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com",
+    "registry": "https://registry.npmjs.org",
     "access": "public"
   },
   "main": "dist/index.js",

--- a/sdk/react/src/__tests__/index.test.tsx
+++ b/sdk/react/src/__tests__/index.test.tsx
@@ -10,7 +10,7 @@ import {
   The0EventsContextValue,
 } from "../index";
 
-describe("@the0/react SDK", () => {
+describe("the0-react SDK", () => {
   // Create mock utils
   const createMockUtils = (events: BotEvent[]): BotEventUtils => ({
     since: jest.fn(() => events),

--- a/sdk/react/src/__tests__/setup.ts
+++ b/sdk/react/src/__tests__/setup.ts
@@ -1,4 +1,4 @@
-// Jest setup for @the0/react SDK
+// Jest setup for the0-react SDK
 import "@testing-library/react";
 
 // Suppress console errors during tests unless debugging

--- a/sdk/react/src/build.ts
+++ b/sdk/react/src/build.ts
@@ -23,7 +23,7 @@ export interface BuildOptions {
  *
  * @example
  * ```js
- * import { build } from "@alexanderwanyoike/the0-react/build";
+ * import { build } from "the0-react/build";
  *
  * // Simple usage with defaults
  * await build();

--- a/sdk/react/src/esbuild.ts
+++ b/sdk/react/src/esbuild.ts
@@ -14,7 +14,7 @@ import type { Plugin } from "esbuild";
  * @example
  * ```js
  * import * as esbuild from "esbuild";
- * import { reactGlobalPlugin } from "@alexanderwanyoike/the0-react/esbuild";
+ * import { reactGlobalPlugin } from "the0-react/esbuild";
  *
  * await esbuild.build({
  *   entryPoints: ["index.tsx"],

--- a/sdk/react/src/index.ts
+++ b/sdk/react/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @the0/react - React SDK for bot custom frontends
+ * the0-react - React SDK for bot custom frontends
  *
  * This SDK provides hooks and utilities for building custom dashboards
  * that visualize bot metrics and events.
@@ -104,7 +104,7 @@ export const The0EventsContext = getSharedContext();
  *
  * @example
  * ```tsx
- * import { useThe0Events } from '@the0/react';
+ * import { useThe0Events } from 'the0-react';
  *
  * export default function Dashboard() {
  *   const { events, utils, loading } = useThe0Events();


### PR DESCRIPTION
## Summary

- **CLI**: bot bundle zips use forward slashes in entry names (ZIP spec), fixing deploys from Windows where every bot with dependencies previously failed at runtime with `ModuleNotFoundError` (#322, thanks @jrodriguez300)
- **Runtime**: the gc service creates its `bot-logs` and `bot-state` buckets at the start of each sweep instead of crash-looping on a fresh stack, and tolerates losing the bucket-creation race to another service (#324)
- **SDKs**: `@alexanderwanyoike/the0-node` and `@alexanderwanyoike/the0-react` moved from GitHub Packages to the public npm registry as **`the0-node`** and **`the0-react`**; installs need no registry configuration or authentication, and all example bots and docs are updated (#325)
- **CI**: SDK npm releases publish via GitHub Actions using npm trusted publishing (OIDC) with provenance attestations; no npm tokens exist anywhere (#326)
- Helm chart bumped to 0.9.7 / appVersion 1.14.6

## Test plan

- [x] CLI: full `go test ./...` including the new zip entry regression test
- [x] Runtime: full `go test ./...` including new gc bucket-creation and race tests (written red-first)
- [x] SDKs: `yarn build` and `yarn test` pass for the0-node and the0-react after the rename
- [x] `the0-node@0.3.1` and `the0-react@0.2.0` are live on npmjs with trusted publishers configured
- [ ] Security policy gate on this PR (HIGH/CRITICAL advisories can land between dev and release; any findings go to a separate PR)

https://claude.ai/code/session_01JN2kbt5Ui3tztGeuQJsvBz