### PR TITLE
fix(api): unpin libexpat so the image builds against current Alpine repos

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,13 +6,17 @@ WORKDIR /app
 
 # Install dependencies for building (needed for some native modules)
 FROM base AS deps
-RUN apk add --no-cache libc6-compat python3 make g++
+# libexpat is listed explicitly to overwrite the base image's pinned world
+# entry: the DHI image pins libexpat at a checksum while Alpine's repo has
+# moved python3 to require libexpat >= 2.8.0, and without the overwrite apk
+# cannot resolve and the build fails.
+RUN apk add --no-cache libexpat libc6-compat python3 make g++
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 
 # Install only runtime dependencies for the production image
 FROM base AS prod-deps
-RUN apk add --no-cache libc6-compat python3 make g++
+RUN apk add --no-cache libexpat libc6-compat python3 make g++
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile --production=true \
   && yarn cache clean


### PR DESCRIPTION
## Description

Both v1.14.6 tag builds of the api image failed at `apk add ... python3` with `unable to select packages`. Root cause: the `dhi.io/node:20-alpine3.22-dev` hardened base pins `libexpat` at a checksum in `/etc/apk/world`, while Alpine 3.22's live repository has moved `python3` to require `libexpat >= 2.8.0`. The two constraints are unsatisfiable together, so every api image build fails until either Docker refreshes the DHI base or we override the pin.

This adds `libexpat` to both `apk add` lines, which overwrites the pinned world entry with an unpinned one and lets apk resolve libexpat 2.8.x.

Verified against a fresh pull of the base image: the failure reproduces exactly without the change, and with it apk resolves, python3 3.12.14 installs and runs, and the world entry shows unpinned `libexpat`.

Note `api:1.14.6` in GHCR was published by retagging the bit-identical `1.14.5` manifest (api/ had zero changes in that release), so prod is unaffected; this fix is required for any future api image build.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Component(s) Affected

- [x] API Service (Dockerfile only, no code changes)

## Testing

- [x] Manual verification in the pulled base image (repro + fix, output above)
- PR CI does not exercise Docker builds; the next tag build is the end-to-end proof

https://claude.ai/code/session_01JN2kbt5Ui3tztGeuQJsvBz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container build reliability by ensuring the required system library is installed explicitly.
  * Resolved package compatibility issues caused by updated Python runtime requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->